### PR TITLE
feat(#231): add defensive event subscriber decorator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -205,7 +205,7 @@ deptrac-debug: ## Find files unassigned for Deptrac
 	$(EXEC_ENV) $(DEPTRAC) debug:unassigned --config-file=deptrac.yaml
 
 behat: setup-test-db clear-test-expression-language-caches ## A php framework for autotesting business expectations
-	APP_ENV=test APP_DEBUG=0 $(DOCKER_COMPOSE) up --detach --wait php
+	APP_ENV=test APP_DEBUG=0 $(DOCKER_COMPOSE) up --detach --wait php database redis mailer localstack
 	$(EXEC_ENV) $(BEHAT_ENV) $(BEHAT)
 
 integration-tests: setup-test-db ## Run integration tests

--- a/config/packages/test/cache.yaml
+++ b/config/packages/test/cache.yaml
@@ -2,6 +2,7 @@ framework:
   cache:
     prefix_seed: '_/srv/app.App_Shared_KernelDevDebugContainer'
     app: cache.adapter.redis
+    system: cache.adapter.array
     default_redis_provider: '%env(resolve:REDIS_URL)%'
 
     pools:
@@ -14,15 +15,3 @@ framework:
         adapter: cache.adapter.array
         provider: null
         tags: true
-
-      cache.validator_expression_language:
-        adapter: cache.adapter.filesystem
-
-      cache.security_expression_language:
-        adapter: cache.adapter.filesystem
-
-      cache.security_is_granted_attribute_expression_language:
-        adapter: cache.adapter.filesystem
-
-      cache.security_is_csrf_token_valid_attribute_expression_language:
-        adapter: cache.adapter.filesystem

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -19,6 +19,7 @@ services:
     exclude:
       - '../src/Shared/Kernel.php'
       - '../src/OAuth/Infrastructure/Provider/DeterministicOAuthProvider.php'
+      - '../src/Shared/Infrastructure/Bus/Event/DefensiveEventSubscriberDecorator.php'
 
   # add more service definitions when explicit configuration is needed
   # please note that last definitions always *replace* previous ones
@@ -215,6 +216,9 @@ services:
 
   App\Shared\Application\Observability\Emitter\BusinessMetricsEmitterInterface:
     alias: App\Shared\Infrastructure\Observability\Emitter\AwsEmfBusinessMetricsEmitter
+
+  App\Shared\Application\Observability\Factory\EventSubscriberFailureMetricFactoryInterface:
+    alias: App\Shared\Infrastructure\Observability\Factory\EventSubscriberFailureMetricFactory
 
   App\Shared\Application\Observability\Factory\MetricDimensionsFactoryInterface:
     alias: App\Shared\Infrastructure\Observability\Factory\MetricDimensionsFactory

--- a/docs/design-and-architecture.md
+++ b/docs/design-and-architecture.md
@@ -88,14 +88,14 @@ This is the list of currently available Domain Events, which can be found in `Us
 7. **UserConfirmedEvent**: Published after the user is confirmed.
 8. **UserRegisteredEvent**: Published after the user is registered.
 
-Also, you can find Subscribers for these events in `src/User/Application/EventSubscriber`, and a Message Bus for them in `Shared/Infrastructure/Bus/Event`.
+Also, you can find Subscribers for these events in `src/User/Application/EventSubscriber`, and a Message Bus for them in `Shared/Infrastructure/Bus/Event`. The in-memory event bus wraps domain event subscribers with a defensive decorator so one subscriber failure is logged and measured without preventing remaining subscribers from handling the same event.
 
 ## Observability
 
 - Business metrics are emitted in AWS Embedded Metric Format (EMF) via `App\Shared\Application\Observability` value objects and the `AwsEmfBusinessMetricsEmitter` logger. Set the namespace with `AWS_EMF_NAMESPACE` (default `UserService/BusinessMetrics`).
 - HTTP responses publish endpoint-level metrics through `ApiEndpointBusinessMetricsSubscriber`, which records `EndpointInvocations` with `Endpoint` and `Operation` dimensions.
 - User domain events emit User-specific metrics: `UsersRegistered` (registration), `UsersUpdated` (email/password changes), and `PasswordResetRequests` (reset flow entry). Metrics live in `User/Application/Metric/*` with dedicated subscribers under `User/Application/EventSubscriber/*MetricsSubscriber`.
-- Domain-event infrastructure now includes resilient async components (envelope, dispatcher, handler) and failure metrics for queue/subscriber issues; the default bus remains in-memory, keeping metrics best-effort and non-blocking.
+- Domain-event infrastructure includes resilient async components (envelope, dispatcher, handler) and a defensive in-memory subscriber decorator. Subscriber failures are logged and emitted as `EventSubscriberFailures` metrics while event processing continues for remaining subscribers.
 
 ## Architecture Diagram
 

--- a/specs/issue-231-event-subscriber-defensive-decorator/tech-spec.md
+++ b/specs/issue-231-event-subscriber-defensive-decorator/tech-spec.md
@@ -1,0 +1,78 @@
+# Issue #231: Defensive Domain Event Subscriber Decorator
+
+## Problem
+
+Domain event subscribers are isolated in async worker processing, but the
+synchronous `InMemorySymfonyEventBus` still delegates directly to subscribers
+through Symfony Messenger. A subscriber exception can therefore bubble through
+the synchronous event chain and prevent later subscribers from handling the same
+domain event.
+
+Issue #231 asks for a try-catch decorator that catches subscriber failures,
+logs them, and prevents one subscriber failure from breaking the whole chain.
+Issue #228 describes the same defensive-programming requirement for all event
+subscribers, so this implementation should satisfy both requirements once it
+is merged.
+
+## Goals
+
+- Add a reusable defensive decorator for `DomainEventSubscriberInterface`
+  implementations.
+- Apply the decorator to every subscriber used by `InMemorySymfonyEventBus`.
+- Preserve existing subscriber routing through `subscribedTo()`.
+- Log subscriber failures without logging event payloads.
+- Emit `EventSubscriberFailures` metrics for synchronous subscriber failures.
+- Keep command handlers and non-subscriber message handlers unchanged.
+
+## Non-Goals
+
+- Do not change individual user event subscriber business logic.
+- Do not alter async queue behavior; `DomainEventMessageHandler` already has
+  equivalent resilience.
+- Do not change domain event contracts or event payload serialization.
+- Do not add new API behavior, persistence schema, or load-test scenarios.
+
+## Proposed Design
+
+Add `App\Shared\Infrastructure\Bus\Event\DefensiveEventSubscriberDecorator`
+that implements `DomainEventSubscriberInterface` and wraps one inner domain
+event subscriber.
+
+The decorator delegates `subscribedTo()` directly to the inner subscriber.
+Its `__invoke()` method calls the inner subscriber inside a try-catch block.
+On failure, it logs contextual metadata and emits an
+`EventSubscriberFailureMetric`; metric emission failure is also caught and
+logged as a warning.
+
+Update `InMemorySymfonyEventBus` so it decorates the tagged
+`app.event_subscriber` iterator before building the Messenger bus. This keeps
+existing `MessageBusFactory` routing intact because subscriber routing remains
+based on `subscribedTo()`.
+
+## Acceptance Mapping
+
+- All subscribers use defensive programming:
+  `InMemorySymfonyEventBus` wraps all tagged domain event subscribers before
+  routing them.
+- No unhandled exceptions bubble up from subscribers:
+  the decorator catches `Throwable` from inner subscriber invocation.
+- Adequate logging/reporting:
+  failures are logged with subscriber class, event id, event type, event name,
+  error message, and exception class; failure metrics are emitted.
+- Tests pass:
+  add focused unit coverage for the decorator and the synchronous event bus
+  continuing after one subscriber fails.
+
+## Validation Plan
+
+- `make unit-tests`
+- `make ci`
+- `make ai-review-loop`
+
+## Performance Impact
+
+Runtime impact is minimal: synchronous event publishing adds one lightweight
+decorator object per subscriber at bus construction time and one try-catch
+boundary per subscriber invocation. No extra I/O occurs on successful
+subscriber execution. On failures, logging and metric emission add the intended
+observability work.

--- a/src/Shared/Infrastructure/Bus/Event/DefensiveEventSubscriberDecorator.php
+++ b/src/Shared/Infrastructure/Bus/Event/DefensiveEventSubscriberDecorator.php
@@ -80,8 +80,8 @@ final readonly class DefensiveEventSubscriberDecorator implements
             'event_id' => $event->eventId(),
             'event_type' => $event::class,
             'event_name' => $event::eventName(),
-            'error' => $exception->getMessage(),
             'exception_class' => $exception::class,
+            'exception_code' => (string) $exception->getCode(),
         ];
     }
 }

--- a/src/Shared/Infrastructure/Bus/Event/DefensiveEventSubscriberDecorator.php
+++ b/src/Shared/Infrastructure/Bus/Event/DefensiveEventSubscriberDecorator.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Infrastructure\Bus\Event;
+
+use App\Shared\Application\Observability\Emitter\BusinessMetricsEmitterInterface;
+use App\Shared\Application\Observability\Factory\EventSubscriberFailureMetricFactoryInterface;
+use App\Shared\Domain\Bus\Event\DomainEvent;
+use App\Shared\Domain\Bus\Event\DomainEventSubscriberInterface;
+use Psr\Log\LoggerInterface;
+
+final readonly class DefensiveEventSubscriberDecorator implements
+    DomainEventSubscriberInterface
+{
+    public function __construct(
+        private DomainEventSubscriberInterface $inner,
+        private LoggerInterface $logger,
+        private BusinessMetricsEmitterInterface $metricsEmitter,
+        private EventSubscriberFailureMetricFactoryInterface $metricFactory
+    ) {
+    }
+
+    public function __invoke(DomainEvent $event): void
+    {
+        try {
+            ($this->inner)($event);
+        } catch (\Throwable $exception) {
+            $this->handleSubscriberFailure($event, $exception);
+        }
+    }
+
+    /**
+     * @return array<class-string<DomainEvent>>
+     */
+    #[\Override]
+    public function subscribedTo(): array
+    {
+        return $this->inner->subscribedTo();
+    }
+
+    private function handleSubscriberFailure(
+        DomainEvent $event,
+        \Throwable $exception
+    ): void {
+        $this->logger->error(
+            'Domain event subscriber execution failed',
+            $this->failureContext($event, $exception)
+        );
+
+        try {
+            $this->emitFailureMetric($event);
+        } catch (\Throwable $metricException) {
+            $this->logger->warning(
+                'Failed to emit subscriber failure metric',
+                $this->failureContext($event, $metricException)
+            );
+        }
+    }
+
+    private function emitFailureMetric(DomainEvent $event): void
+    {
+        $metric = $this->metricFactory->create(
+            $this->inner::class,
+            $event::class
+        );
+
+        $this->metricsEmitter->emit($metric);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function failureContext(
+        DomainEvent $event,
+        \Throwable $exception
+    ): array {
+        return [
+            'subscriber' => $this->inner::class,
+            'event_id' => $event->eventId(),
+            'event_type' => $event::class,
+            'event_name' => $event::eventName(),
+            'error' => $exception->getMessage(),
+            'exception_class' => $exception::class,
+        ];
+    }
+}

--- a/src/Shared/Infrastructure/Bus/Event/InMemorySymfonyEventBus.php
+++ b/src/Shared/Infrastructure/Bus/Event/InMemorySymfonyEventBus.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace App\Shared\Infrastructure\Bus\Event;
 
+use App\Shared\Application\Observability\Emitter\BusinessMetricsEmitterInterface;
+use App\Shared\Application\Observability\Factory\EventSubscriberFailureMetricFactoryInterface;
 use App\Shared\Domain\Bus\Event\DomainEvent;
 use App\Shared\Domain\Bus\Event\DomainEventSubscriberInterface;
 use App\Shared\Domain\Bus\Event\EventBusInterface;
 use App\Shared\Infrastructure\Bus\MessageBusFactory;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Messenger\Exception\HandlerFailedException;
 use Symfony\Component\Messenger\Exception\NoHandlerForMessageException;
 use Symfony\Component\Messenger\MessageBusInterface;
@@ -21,9 +24,19 @@ class InMemorySymfonyEventBus implements EventBusInterface
      */
     public function __construct(
         MessageBusFactory $busFactory,
-        iterable $subscribers
+        iterable $subscribers,
+        LoggerInterface $logger,
+        BusinessMetricsEmitterInterface $metricsEmitter,
+        EventSubscriberFailureMetricFactoryInterface $metricFactory
     ) {
-        $this->bus = $busFactory->create($subscribers);
+        $this->bus = $busFactory->create(
+            $this->decorateSubscribers(
+                $subscribers,
+                $logger,
+                $metricsEmitter,
+                $metricFactory
+            )
+        );
     }
 
     #[\Override]
@@ -41,5 +54,30 @@ class InMemorySymfonyEventBus implements EventBusInterface
         } catch (HandlerFailedException $exception) {
             throw $exception->getPrevious() ?? $exception;
         }
+    }
+
+    /**
+     * @param iterable<DomainEventSubscriberInterface> $subscribers
+     *
+     * @return list<DefensiveEventSubscriberDecorator>
+     */
+    private function decorateSubscribers(
+        iterable $subscribers,
+        LoggerInterface $logger,
+        BusinessMetricsEmitterInterface $metricsEmitter,
+        EventSubscriberFailureMetricFactoryInterface $metricFactory
+    ): array {
+        $decoratedSubscribers = [];
+
+        foreach ($subscribers as $subscriber) {
+            $decoratedSubscribers[] = new DefensiveEventSubscriberDecorator(
+                $subscriber,
+                $logger,
+                $metricsEmitter,
+                $metricFactory
+            );
+        }
+
+        return $decoratedSubscribers;
     }
 }

--- a/src/Shared/Infrastructure/Bus/MessageBusFactory.php
+++ b/src/Shared/Infrastructure/Bus/MessageBusFactory.php
@@ -6,6 +6,7 @@ namespace App\Shared\Infrastructure\Bus;
 
 use App\Shared\Domain\Bus\Event\DomainEventSubscriberInterface;
 use App\Shared\Infrastructure\Bus\Extractor\CallableFirstParameterExtractor;
+use Symfony\Component\Messenger\Handler\HandlerDescriptor;
 use Symfony\Component\Messenger\Handler\HandlersLocator;
 use Symfony\Component\Messenger\MessageBus;
 use Symfony\Component\Messenger\Middleware\HandleMessageMiddleware;
@@ -40,18 +41,15 @@ final readonly class MessageBusFactory
     /**
      * @param iterable<object> $callables
      *
-     * @return array<array<DomainEventSubscriberInterface>>
+     * @return array<array<object|HandlerDescriptor>>
      *
-     * @psalm-return array<int|string, array<DomainEventSubscriberInterface>>
+     * @psalm-return array<int|string, array<object|HandlerDescriptor>>
      */
     private function buildHandlersMap(iterable $callables): array
     {
         $callableArray = iterator_to_array($callables);
 
-        $subscribers = array_filter(
-            $callableArray,
-            static fn (object $handler): bool => $handler instanceof DomainEventSubscriberInterface
-        );
+        $subscribers = $this->filterSubscribers($callableArray);
 
         $regularHandlers = array_filter(
             $callableArray,
@@ -59,7 +57,7 @@ final readonly class MessageBusFactory
         );
 
         // DomainEventSubscribers use subscribedTo() for routing
-        $subscriberMap = $this->extractor->forPipedCallables($subscribers);
+        $subscriberMap = $this->createSubscriberHandlerMap($subscribers);
 
         // Regular handlers use __invoke parameter type for routing
         // Note: Unmappable handlers get null keys, but Symfony's HandlersLocator
@@ -67,5 +65,52 @@ final readonly class MessageBusFactory
         $handlerMap = $this->extractor->forCallables($regularHandlers);
 
         return array_merge_recursive($subscriberMap, $handlerMap);
+    }
+
+    /**
+     * @param array<object> $callables
+     *
+     * @return list<DomainEventSubscriberInterface>
+     */
+    private function filterSubscribers(array $callables): array
+    {
+        $subscribers = [];
+
+        foreach ($callables as $callable) {
+            if ($callable instanceof DomainEventSubscriberInterface) {
+                $subscribers[] = $callable;
+            }
+        }
+
+        return $subscribers;
+    }
+
+    /**
+     * @param list<DomainEventSubscriberInterface> $subscribers
+     *
+     * @return array<string, list<HandlerDescriptor>>
+     */
+    private function createSubscriberHandlerMap(array $subscribers): array
+    {
+        $handlersMap = [];
+
+        foreach ($this->extractor->forPipedCallables($subscribers) as $event => $eventSubscribers) {
+            $handlersMap[$event] = array_map(
+                fn (
+                    DomainEventSubscriberInterface $subscriber
+                ): HandlerDescriptor => $this->createSubscriberHandlerDescriptor($subscriber),
+                $eventSubscribers
+            );
+        }
+
+        return $handlersMap;
+    }
+
+    private function createSubscriberHandlerDescriptor(
+        DomainEventSubscriberInterface $subscriber
+    ): HandlerDescriptor {
+        return new HandlerDescriptor($subscriber, [
+            'alias' => \sprintf('%s#%d', $subscriber::class, \spl_object_id($subscriber)),
+        ]);
     }
 }

--- a/tests/Unit/Shared/Infrastructure/Bus/Event/DefensiveEventSubscriberDecoratorTest.php
+++ b/tests/Unit/Shared/Infrastructure/Bus/Event/DefensiveEventSubscriberDecoratorTest.php
@@ -1,0 +1,185 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Shared\Infrastructure\Bus\Event;
+
+use App\Shared\Domain\Bus\Event\DomainEventSubscriberInterface;
+use App\Shared\Infrastructure\Bus\Event\DefensiveEventSubscriberDecorator;
+use App\Shared\Infrastructure\Observability\Factory\EventSubscriberFailureMetricFactory;
+use App\Tests\Unit\Shared\Infrastructure\Bus\Event\Stub\FailingTestDomainEventSubscriber;
+use App\Tests\Unit\Shared\Infrastructure\Bus\Event\Stub\RecordingTestDomainEventSubscriber;
+use App\Tests\Unit\Shared\Infrastructure\Bus\Event\Stub\TestDomainEvent;
+use App\Tests\Unit\Shared\Infrastructure\Bus\Event\Stub\TestSubscriberFailureException;
+use App\Tests\Unit\Shared\Infrastructure\Observability\BusinessMetricsEmitterSpy;
+use App\Tests\Unit\UnitTestCase;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+
+final class DefensiveEventSubscriberDecoratorTest extends UnitTestCase
+{
+    private BusinessMetricsEmitterSpy $metricsEmitter;
+    private EventSubscriberFailureMetricFactory $metricFactory;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->metricsEmitter = new BusinessMetricsEmitterSpy();
+        $this->metricFactory = new EventSubscriberFailureMetricFactory();
+    }
+
+    public function testDelegatesSubscribedEventsToInnerSubscriber(): void
+    {
+        $subscriber = new RecordingTestDomainEventSubscriber();
+        $decorator = $this->createDecorator($subscriber, new NullLogger());
+
+        self::assertSame([TestDomainEvent::class], $decorator->subscribedTo());
+    }
+
+    public function testDelegatesEventHandlingToInnerSubscriber(): void
+    {
+        $subscriber = new RecordingTestDomainEventSubscriber();
+        $decorator = $this->createDecorator($subscriber, new NullLogger());
+        $event = $this->createTestEvent();
+
+        $decorator($event);
+
+        self::assertSame($event, $subscriber->handledEvent());
+    }
+
+    public function testCatchesSubscriberFailureAndEmitsMetric(): void
+    {
+        $capturedContext = [];
+        $logger = $this->createErrorLogger($capturedContext);
+        $subscriber = new FailingTestDomainEventSubscriber();
+        $decorator = $this->createDecorator($subscriber, $logger);
+        $eventId = $this->faker->uuid();
+        $event = $this->createTestEvent($eventId);
+
+        $decorator($event);
+
+        $this->assertFailureContext(
+            $capturedContext,
+            $subscriber::class,
+            $eventId,
+            'Subscriber failed',
+            TestSubscriberFailureException::class,
+        );
+        self::assertSame(1, $this->metricsEmitter->count());
+    }
+
+    public function testCatchesMetricEmissionFailure(): void
+    {
+        $capturedContext = [];
+        $logger = $this->createWarningLogger($capturedContext);
+        $subscriber = new FailingTestDomainEventSubscriber();
+        $decorator = $this->createDecorator($subscriber, $logger);
+        $event = $this->createTestEvent();
+
+        $this->metricsEmitter->failOnNextCall();
+
+        $decorator($event);
+
+        $this->assertFailureContext(
+            $capturedContext,
+            $subscriber::class,
+            $event->eventId(),
+            'Metric emission failed',
+            \RuntimeException::class
+        );
+    }
+
+    private function createDecorator(
+        DomainEventSubscriberInterface $subscriber,
+        LoggerInterface $logger
+    ): DefensiveEventSubscriberDecorator {
+        return new DefensiveEventSubscriberDecorator(
+            $subscriber,
+            $logger,
+            $this->metricsEmitter,
+            $this->metricFactory
+        );
+    }
+
+    private function createTestEvent(?string $eventId = null): TestDomainEvent
+    {
+        return new TestDomainEvent(
+            $this->faker->uuid(),
+            $this->faker->word(),
+            $eventId
+        );
+    }
+
+    /**
+     * @param array<string, string> $capturedContext
+     */
+    private function assertFailureContext(
+        array $capturedContext,
+        string $subscriberClass,
+        string $eventId,
+        string $error,
+        string $exceptionClass
+    ): void {
+        self::assertSame($subscriberClass, $capturedContext['subscriber']);
+        self::assertSame($eventId, $capturedContext['event_id']);
+        self::assertSame(TestDomainEvent::class, $capturedContext['event_type']);
+        self::assertSame(TestDomainEvent::eventName(), $capturedContext['event_name']);
+        self::assertSame($error, $capturedContext['error']);
+        self::assertSame($exceptionClass, $capturedContext['exception_class']);
+    }
+
+    /**
+     * @param array<string, string> &$capturedContext
+     */
+    private function createErrorLogger(
+        array &$capturedContext
+    ): \PHPUnit\Framework\MockObject\MockObject&LoggerInterface {
+        return $this->createContextCapturingLogger(
+            'error',
+            'Domain event subscriber execution failed',
+            $capturedContext
+        );
+    }
+
+    /**
+     * @param array<string, string> &$capturedContext
+     */
+    private function createWarningLogger(
+        array &$capturedContext
+    ): \PHPUnit\Framework\MockObject\MockObject&LoggerInterface {
+        return $this->createContextCapturingLogger(
+            'warning',
+            'Failed to emit subscriber failure metric',
+            $capturedContext
+        );
+    }
+
+    /**
+     * @param array<string, string> &$capturedContext
+     */
+    private function createContextCapturingLogger(
+        string $method,
+        string $expectedMessage,
+        array &$capturedContext
+    ): \PHPUnit\Framework\MockObject\MockObject&LoggerInterface {
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->method($method)
+            ->willReturnCallback(
+                static function (
+                    string $message,
+                    array $context
+                ) use (
+                    &$capturedContext,
+                    $expectedMessage
+                ): void {
+                    if ($message === $expectedMessage) {
+                        $capturedContext = $context;
+                    }
+                }
+            );
+
+        return $logger;
+    }
+}

--- a/tests/Unit/Shared/Infrastructure/Bus/Event/DefensiveEventSubscriberDecoratorTest.php
+++ b/tests/Unit/Shared/Infrastructure/Bus/Event/DefensiveEventSubscriberDecoratorTest.php
@@ -64,8 +64,8 @@ final class DefensiveEventSubscriberDecoratorTest extends UnitTestCase
             $capturedContext,
             $subscriber::class,
             $eventId,
-            'Subscriber failed',
             TestSubscriberFailureException::class,
+            '0',
         );
         self::assertSame(1, $this->metricsEmitter->count());
     }
@@ -86,8 +86,8 @@ final class DefensiveEventSubscriberDecoratorTest extends UnitTestCase
             $capturedContext,
             $subscriber::class,
             $event->eventId(),
-            'Metric emission failed',
-            \RuntimeException::class
+            \RuntimeException::class,
+            '0',
         );
     }
 
@@ -119,15 +119,16 @@ final class DefensiveEventSubscriberDecoratorTest extends UnitTestCase
         array $capturedContext,
         string $subscriberClass,
         string $eventId,
-        string $error,
-        string $exceptionClass
+        string $exceptionClass,
+        string $exceptionCode
     ): void {
         self::assertSame($subscriberClass, $capturedContext['subscriber']);
         self::assertSame($eventId, $capturedContext['event_id']);
         self::assertSame(TestDomainEvent::class, $capturedContext['event_type']);
         self::assertSame(TestDomainEvent::eventName(), $capturedContext['event_name']);
-        self::assertSame($error, $capturedContext['error']);
+        self::assertArrayNotHasKey('error', $capturedContext);
         self::assertSame($exceptionClass, $capturedContext['exception_class']);
+        self::assertSame($exceptionCode, $capturedContext['exception_code']);
     }
 
     /**

--- a/tests/Unit/Shared/Infrastructure/Bus/Event/InMemorySymfonyEventBusTest.php
+++ b/tests/Unit/Shared/Infrastructure/Bus/Event/InMemorySymfonyEventBusTest.php
@@ -5,10 +5,19 @@ declare(strict_types=1);
 namespace App\Tests\Unit\Shared\Infrastructure\Bus\Event;
 
 use App\Shared\Domain\Bus\Event\DomainEvent;
+use App\Shared\Domain\Bus\Event\DomainEventSubscriberInterface;
 use App\Shared\Infrastructure\Bus\Event\EventNotRegisteredException;
 use App\Shared\Infrastructure\Bus\Event\InMemorySymfonyEventBus;
+use App\Shared\Infrastructure\Bus\Extractor\CallableFirstParameterExtractor;
+use App\Shared\Infrastructure\Bus\InvokeParameterExtractor;
 use App\Shared\Infrastructure\Bus\MessageBusFactory;
+use App\Shared\Infrastructure\Observability\Factory\EventSubscriberFailureMetricFactory;
+use App\Tests\Unit\Shared\Infrastructure\Bus\Event\Stub\FailingTestDomainEventSubscriber;
+use App\Tests\Unit\Shared\Infrastructure\Bus\Event\Stub\RecordingTestDomainEventSubscriber;
+use App\Tests\Unit\Shared\Infrastructure\Bus\Event\Stub\TestDomainEvent;
+use App\Tests\Unit\Shared\Infrastructure\Observability\BusinessMetricsEmitterSpy;
 use App\Tests\Unit\UnitTestCase;
+use Psr\Log\NullLogger;
 use Symfony\Component\Messenger\Exception\HandlerFailedException;
 use Symfony\Component\Messenger\Exception\NoHandlerForMessageException;
 use Symfony\Component\Messenger\MessageBus;
@@ -18,7 +27,7 @@ final class InMemorySymfonyEventBusTest extends UnitTestCase
     private MessageBusFactory $messageBusFactory;
 
     /**
-     * @var array<DomainEvent>
+     * @var array<DomainEventSubscriberInterface>
      */
     private array $eventSubscribers;
 
@@ -29,7 +38,7 @@ final class InMemorySymfonyEventBusTest extends UnitTestCase
         $this->messageBusFactory =
             $this->createMock(MessageBusFactory::class);
         $this->eventSubscribers =
-            [$this->createMock(DomainEvent::class)];
+            [$this->createMock(DomainEventSubscriberInterface::class)];
     }
 
     public function testDispatchWithNoHandlerForMessageException(): void
@@ -39,12 +48,7 @@ final class InMemorySymfonyEventBusTest extends UnitTestCase
         $messageBus->expects($this->once())
             ->method('dispatch')
             ->willThrowException(new NoHandlerForMessageException());
-        $this->messageBusFactory->method('create')
-            ->willReturn($messageBus);
-        $eventBus = new InMemorySymfonyEventBus(
-            $this->messageBusFactory,
-            $this->eventSubscribers
-        );
+        $eventBus = $this->createEventBus($messageBus);
 
         $this->expectException(EventNotRegisteredException::class);
 
@@ -60,12 +64,7 @@ final class InMemorySymfonyEventBusTest extends UnitTestCase
             ->willThrowException(
                 $this->createMock(HandlerFailedException::class)
             );
-        $this->messageBusFactory->method('create')
-            ->willReturn($messageBus);
-        $eventBus = new InMemorySymfonyEventBus(
-            $this->messageBusFactory,
-            $this->eventSubscribers
-        );
+        $eventBus = $this->createEventBus($messageBus);
 
         $this->expectException(HandlerFailedException::class);
 
@@ -79,15 +78,50 @@ final class InMemorySymfonyEventBusTest extends UnitTestCase
         $messageBus->expects($this->once())
             ->method('dispatch')
             ->willThrowException(new \RuntimeException());
-        $this->messageBusFactory->method('create')
-            ->willReturn($messageBus);
-        $eventBus = new InMemorySymfonyEventBus(
-            $this->messageBusFactory,
-            $this->eventSubscribers
-        );
+        $eventBus = $this->createEventBus($messageBus);
 
         $this->expectException(\RuntimeException::class);
 
         $eventBus->publish($event);
+    }
+
+    public function testSubscriberFailureDoesNotStopRemainingSubscribers(): void
+    {
+        $successSubscriber = new RecordingTestDomainEventSubscriber();
+        $metricsEmitter = new BusinessMetricsEmitterSpy();
+        $eventBus = new InMemorySymfonyEventBus(
+            new MessageBusFactory(
+                new CallableFirstParameterExtractor(new InvokeParameterExtractor())
+            ),
+            [
+                new FailingTestDomainEventSubscriber(),
+                $successSubscriber,
+            ],
+            new NullLogger(),
+            $metricsEmitter,
+            new EventSubscriberFailureMetricFactory()
+        );
+
+        $eventBus->publish(new TestDomainEvent(
+            $this->faker->uuid(),
+            $this->faker->word()
+        ));
+
+        self::assertTrue($successSubscriber->wasCalled());
+        self::assertSame(1, $metricsEmitter->count());
+    }
+
+    private function createEventBus(MessageBus $messageBus): InMemorySymfonyEventBus
+    {
+        $this->messageBusFactory->method('create')
+            ->willReturn($messageBus);
+
+        return new InMemorySymfonyEventBus(
+            $this->messageBusFactory,
+            $this->eventSubscribers,
+            new NullLogger(),
+            new BusinessMetricsEmitterSpy(),
+            new EventSubscriberFailureMetricFactory()
+        );
     }
 }

--- a/tests/Unit/Shared/Infrastructure/Bus/Event/Stub/FailingTestDomainEventSubscriber.php
+++ b/tests/Unit/Shared/Infrastructure/Bus/Event/Stub/FailingTestDomainEventSubscriber.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Shared\Infrastructure\Bus\Event\Stub;
+
+use App\Shared\Domain\Bus\Event\DomainEventSubscriberInterface;
+
+final class FailingTestDomainEventSubscriber implements DomainEventSubscriberInterface
+{
+    public function __invoke(TestDomainEvent $_event): void
+    {
+        throw new TestSubscriberFailureException('Subscriber failed');
+    }
+
+    /**
+     * @return array<class-string<TestDomainEvent>>
+     */
+    #[\Override]
+    public function subscribedTo(): array
+    {
+        return [TestDomainEvent::class];
+    }
+}

--- a/tests/Unit/Shared/Infrastructure/Bus/Event/Stub/RecordingTestDomainEventSubscriber.php
+++ b/tests/Unit/Shared/Infrastructure/Bus/Event/Stub/RecordingTestDomainEventSubscriber.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Shared\Infrastructure\Bus\Event\Stub;
+
+use App\Shared\Domain\Bus\Event\DomainEventSubscriberInterface;
+
+final class RecordingTestDomainEventSubscriber implements DomainEventSubscriberInterface
+{
+    private ?TestDomainEvent $handledEvent = null;
+
+    public function __invoke(TestDomainEvent $event): void
+    {
+        $this->handledEvent = $event;
+    }
+
+    /**
+     * @return array<class-string<TestDomainEvent>>
+     */
+    #[\Override]
+    public function subscribedTo(): array
+    {
+        return [TestDomainEvent::class];
+    }
+
+    public function handledEvent(): ?TestDomainEvent
+    {
+        return $this->handledEvent;
+    }
+
+    public function wasCalled(): bool
+    {
+        return $this->handledEvent !== null;
+    }
+}

--- a/tests/Unit/Shared/Infrastructure/Bus/Event/Stub/TestSubscriberFailureException.php
+++ b/tests/Unit/Shared/Infrastructure/Bus/Event/Stub/TestSubscriberFailureException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Shared\Infrastructure\Bus\Event\Stub;
+
+final class TestSubscriberFailureException extends \RuntimeException
+{
+}

--- a/tests/Unit/Shared/Infrastructure/Bus/MessageBusFactoryTest.php
+++ b/tests/Unit/Shared/Infrastructure/Bus/MessageBusFactoryTest.php
@@ -14,6 +14,7 @@ use App\Tests\Unit\Shared\Infrastructure\Bus\Stub\SecondTestEventSubscriber;
 use App\Tests\Unit\Shared\Infrastructure\Bus\Stub\TestCommand;
 use App\Tests\Unit\Shared\Infrastructure\Bus\Stub\TestEvent;
 use App\Tests\Unit\UnitTestCase;
+use Symfony\Component\Messenger\Handler\HandlerDescriptor;
 use Symfony\Component\Messenger\MessageBus;
 
 final class MessageBusFactoryTest extends UnitTestCase
@@ -48,7 +49,10 @@ final class MessageBusFactoryTest extends UnitTestCase
         $messageBus->dispatch(new TestCommand());
         self::assertTrue($regularHandlerCalled, 'Regular handler should be called');
 
-        $messageBus->dispatch(new TestEvent('event-id', '2024-01-01 00:00:00'));
+        $messageBus->dispatch(new TestEvent(
+            $this->faker->uuid(),
+            $this->faker->dateTime()->format('Y-m-d H:i:s')
+        ));
         self::assertTrue($subscriberCalled, 'Subscriber should be called');
     }
 
@@ -137,12 +141,34 @@ final class MessageBusFactoryTest extends UnitTestCase
         $reflection = new \ReflectionMethod(MessageBusFactory::class, 'buildHandlersMap');
         $this->makeAccessible($reflection);
 
-        /** @var array<string, array<DomainEventSubscriberInterface>> $handlersMap */
+        /** @var array<string, array<HandlerDescriptor>> $handlersMap */
         $handlersMap = $reflection->invoke($factory, [$subscriber]);
 
         self::assertArrayHasKey(TestEvent::class, $handlersMap);
         self::assertCount(1, $handlersMap[TestEvent::class]);
-        self::assertSame($subscriber, $handlersMap[TestEvent::class][0]);
+        self::assertInstanceOf(HandlerDescriptor::class, $handlersMap[TestEvent::class][0]);
+    }
+
+    public function testSubscribersUsingSameDecoratorClassAreNotDeduplicated(): void
+    {
+        $firstSubscriberCalled = false;
+        $secondSubscriberCalled = false;
+
+        $factory = new MessageBusFactory(
+            new CallableFirstParameterExtractor(new InvokeParameterExtractor())
+        );
+        $messageBus = $factory->create([
+            $this->createEventSubscriber($firstSubscriberCalled),
+            $this->createEventSubscriber($secondSubscriberCalled),
+        ]);
+
+        $messageBus->dispatch(new TestEvent(
+            $this->faker->uuid(),
+            $this->faker->dateTime()->format('Y-m-d H:i:s')
+        ));
+
+        self::assertTrue($firstSubscriberCalled);
+        self::assertTrue($secondSubscriberCalled);
     }
 
     private function createRegularHandler(bool &$called): object


### PR DESCRIPTION
## Description

Adds a defensive `DomainEventSubscriberInterface` decorator for the in-memory domain event bus. Subscriber failures are now caught, logged with safe context, and reported through `EventSubscriberFailures` metrics so later subscribers still receive the same event.

Also updates `MessageBusFactory` to give decorated subscribers unique `HandlerDescriptor` aliases; without this, Symfony Messenger can treat multiple decorators of the same class as already handled and skip later subscribers.

Performance changes:
- Success path adds one lightweight `try/catch` boundary per subscriber invocation.
- Bus construction creates one decorator object per subscriber.
- `HandlerDescriptor` aliasing is a build-time routing-map change and adds no runtime I/O.
- Successful subscriber execution does no extra logging or metric emission.
- Failure path intentionally logs once and emits one failure metric.
- Behat service startup and test cache changes are test/CI-only and have no production runtime impact.

## Related Issue

Closes #231
Duplicate: #228 (closed as duplicate of #231)

## Motivation and Context

A failure in one synchronous domain-event subscriber could previously bubble through the in-memory event chain and prevent remaining subscribers from running. The async event path already has equivalent resilience; this brings the synchronous path in line with that behavior.

## How Has This Been Tested?

- `make unit-tests` passed: `OK (2251 tests, 6138 assertions)`, `Lines: 100.00%`.
- `HTTP_PORT=59081 HTTPS_PORT=59445 HTTP3_PORT=59446 INFECTION_THREADS=4 make ci` passed end-to-end.
- Behat passed: `644 scenarios (644 passed)`, `3622 steps (3622 passed)`.
- Integration tests passed: `OK (120 tests, 721 assertions)`.
- OpenAPI generation/diff/validation passed; diff reported equivalent specs.
- Schemathesis passed all configured checks.
- Infection passed with `MSI 100%`, `Mutation Code Coverage 100%`, `Covered Code MSI 100%`.
- `make ai-review-loop` passed via writable `AI_REVIEW_LOG_DIR=/tmp/user-service-ai-review-231`: `STATUS: PASS`, `0 issues`.
- `git diff --check` passed.
- `npx --yes prettier@3.5.3 --check docs/design-and-architecture.md specs/issue-231-event-subscriber-defensive-decorator/tech-spec.md` passed.

## Screenshots (if appropriate):

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING.md**](https://github.com/VilnaCRM-Org/user-service/blob/main/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] You have only one commit (if not, squash them into one commit).
- [x] Structurizr documentation has been updated to reflect any architectural changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a defensive event subscriber decorator so one subscriber failure is caught, logged, and measured without stopping other subscribers. Implements #231 and aligns the sync event path with the async path.

- **New Features**
  - Wrap all `DomainEventSubscriberInterface` instances in `InMemorySymfonyEventBus` with `DefensiveEventSubscriberDecorator`.
  - On failure: catch exceptions, log safe context (subscriber class, event id/type/name, exception class/code), and emit `EventSubscriberFailures`; success path unchanged.

- **Bug Fixes**
  - In `MessageBusFactory`, register subscribers as `HandlerDescriptor` with a per-instance `alias` to prevent Symfony Messenger from deduplicating decorated handlers and skipping later subscribers.
  - Do not log exception messages in failure context to avoid leaking sensitive data.

<sup>Written for commit aaee52f34521cc3df0e8369144571f78dd0b3902. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Event subscriber failures are now caught and logged without interrupting the event processing chain, and failure metrics are emitted for improved resilience and observability.

* **Documentation**
  * Architecture docs updated to describe the defensive subscriber behavior and observability changes.

* **Tests**
  * Added unit tests verifying subscriber resilience, logging, and failure-metric emission.

* **Chores**
  * Test/runtime configuration updated to bring up additional services during test runs.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/VilnaCRM-Org/user-service/pull/281)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## BMAD Planning Evidence

- BMAD planning artifact: `specs/issue-231-event-subscriber-defensive-decorator/tech-spec.md`
- Duplicate issue #228 is closed as a duplicate of #231; this PR now closes #231 only.
- The planning artifact maps the defensive subscriber decorator scope, acceptance criteria, and verification strategy.