### PR TITLE
refactor(#230): return command responses from handlers

### DIFF
--- a/deptrac.yaml
+++ b/deptrac.yaml
@@ -9,7 +9,7 @@ parameters:
     - name: Application
       collectors:
         - type: className
-          regex: '.*App\\User\\Application\\(Transformer|Command|CommandHandler|DTO|EventListener|EventSubscriber|Factory|MutationInput|Processor|Resolver|ExceptionMessageHandler|Message|Query|Controller|Validator|Metric|Provider).*'
+          regex: '.*App\\User\\Application\\(Transformer|Command|CommandHandler|DTO|EventListener|EventSubscriber|Factory|MutationInput|Processor|Resolver|ExceptionMessageHandler|Message|Query|Controller|Validator|Metric|Provider|Service).*'
         - type: className
           regex: '.*App\\Shared\\Application\\(Validator|Transformer|Provider|Converter|DTO|EventListener|Normalizer|QueryParameter|Resolver|Factory|Observability|Bus|Matcher).*'
         - type: className

--- a/specs/issue-230-command-response-refactor/tech-spec.md
+++ b/specs/issue-230-command-response-refactor/tech-spec.md
@@ -1,0 +1,61 @@
+# Issue 230 Command Response Refactor Tech Spec
+
+## BMAD Planning Trace
+
+- Issue: #230 Refactor command handlers to return response instead of setting on command object
+- Planning method: BMAD planning-first workflow via BMALPH
+- BMALPH check: `bmalph -C /home/kravtsov/Projects/user-service-issue230 status`
+- BMALPH status at trace capture: Phase 1 - Analysis, Agent: Analyst, Status: planning
+- Implementation PR: #285
+
+## Problem
+
+Command handlers currently mutate command objects by calling `setResponse()`.
+That makes commands carry both request input and response state, which weakens
+CQRS separation and forces processors, resolvers, and controllers to read mutable
+state back from dispatched commands.
+
+## Scope
+
+- Make command handlers return typed response DTOs directly.
+- Keep command objects as immutable or request-only input carriers.
+- Update the command bus contract to return handler results.
+- Add runtime guardrails for unsupported handler return values.
+- Update processors, GraphQL resolvers, controllers, and tests to consume
+  dispatch return values instead of command response state.
+
+## Out of Scope
+
+- Changing user-facing API contracts beyond preserving existing response shapes.
+- Reworking unrelated query handlers or event subscriber behavior.
+- Removing existing security and rate-limit behavior.
+
+## Design
+
+Command handlers return `CommandResponseInterface` implementations where a
+response is expected. The Symfony Messenger adapter extracts the handled result
+and returns it from `CommandBusInterface::dispatch()`. Application entry points
+use `CommandResponseTypeGuard` to assert the exact expected response type before
+building REST or GraphQL output.
+
+The design keeps command DTOs focused on input data, moves response creation to
+handler return values, and centralizes response-type validation so misuse fails
+early in tests and runtime.
+
+## Acceptance Criteria Mapping
+
+- Command handlers return response DTOs instead of mutating commands.
+- Processors, resolvers, and controllers consume dispatch return values.
+- Command bus contract supports returning handler results.
+- Invalid or missing command responses are guarded.
+- Existing authentication, registration, password-reset, two-factor, and recovery
+  code flows keep their public response shapes.
+
+## Verification Plan
+
+- Focused PHPUnit coverage for command handlers, command bus, guards, processors,
+  resolvers, and controllers.
+- Psalm static analysis.
+- PHP CS Fixer dry-run.
+- `git diff --check`.
+- GitHub CI checks for the pull request.

--- a/src/Shared/Application/Bus/Command/CommandResponseTypeGuard.php
+++ b/src/Shared/Application/Bus/Command/CommandResponseTypeGuard.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Application\Bus\Command;
+
+use App\Shared\Domain\Bus\Command\CommandResponseInterface;
+
+final class CommandResponseTypeGuard
+{
+    /**
+     * @template TResponse of CommandResponseInterface
+     *
+     * @param class-string<TResponse> $expectedType
+     *
+     * @return TResponse
+     */
+    public static function expect(
+        ?CommandResponseInterface $response,
+        string $expectedType,
+    ): CommandResponseInterface {
+        if (!$response instanceof $expectedType) {
+            $actualType = $response === null ? 'null' : $response::class;
+
+            throw new \LogicException(sprintf(
+                'Expected command bus to return %s, got %s.',
+                $expectedType,
+                $actualType
+            ));
+        }
+
+        return $response;
+    }
+}

--- a/src/Shared/Application/Bus/Command/CommandResponseTypeGuard.php
+++ b/src/Shared/Application/Bus/Command/CommandResponseTypeGuard.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Shared\Application\Bus\Command;
 
 use App\Shared\Domain\Bus\Command\CommandResponseInterface;
+use LogicException;
 
 final class CommandResponseTypeGuard
 {
@@ -15,14 +16,14 @@ final class CommandResponseTypeGuard
      *
      * @return TResponse
      */
-    public static function expect(
+    public function expect(
         ?CommandResponseInterface $response,
         string $expectedType,
     ): CommandResponseInterface {
         if (!$response instanceof $expectedType) {
             $actualType = $response === null ? 'null' : $response::class;
 
-            throw new \LogicException(sprintf(
+            throw new LogicException(sprintf(
                 'Expected command bus to return %s, got %s.',
                 $expectedType,
                 $actualType

--- a/src/Shared/Application/Bus/Guard/CommandResponseTypeGuard.php
+++ b/src/Shared/Application/Bus/Guard/CommandResponseTypeGuard.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Shared\Application\Bus\Command;
+namespace App\Shared\Application\Bus\Guard;
 
 use App\Shared\Domain\Bus\Command\CommandResponseInterface;
 use LogicException;

--- a/src/Shared/Domain/Bus/Command/CommandBusInterface.php
+++ b/src/Shared/Domain/Bus/Command/CommandBusInterface.php
@@ -6,5 +6,5 @@ namespace App\Shared\Domain\Bus\Command;
 
 interface CommandBusInterface
 {
-    public function dispatch(CommandInterface $command): void;
+    public function dispatch(CommandInterface $command): ?CommandResponseInterface;
 }

--- a/src/Shared/Infrastructure/Bus/Command/InMemorySymfonyCommandBus.php
+++ b/src/Shared/Infrastructure/Bus/Command/InMemorySymfonyCommandBus.php
@@ -10,6 +10,7 @@ use App\Shared\Domain\Bus\Command\CommandInterface;
 use App\Shared\Domain\Bus\Command\CommandResponseInterface;
 use App\Shared\Infrastructure\Bus\MessageBusFactory;
 use LogicException;
+use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\HandlerFailedException;
 use Symfony\Component\Messenger\Exception\NoHandlerForMessageException;
 use Symfony\Component\Messenger\MessageBus;
@@ -43,21 +44,44 @@ readonly class InMemorySymfonyCommandBus implements CommandBusInterface
             throw $error->getPrevious() ?? $error;
         }
 
-        $handledStamp = $envelope->last(HandledStamp::class);
+        return $this->extractCommandResponse($command, $envelope);
+    }
+
+    private function extractCommandResponse(
+        CommandInterface $command,
+        Envelope $envelope
+    ): ?CommandResponseInterface {
+        $handledStamp = $this->singleHandledStamp($command, $envelope);
         $result = $handledStamp?->getResult();
 
         if ($result === null) {
             return null;
         }
 
-        if (!$result instanceof CommandResponseInterface) {
+        if ($result instanceof CommandResponseInterface) {
+            return $result;
+        }
+
+        throw new LogicException(sprintf(
+            'Command handler for %s returned unsupported result %s.',
+            $command::class,
+            get_debug_type($result)
+        ));
+    }
+
+    private function singleHandledStamp(
+        CommandInterface $command,
+        Envelope $envelope
+    ): ?HandledStamp {
+        $handledStamps = $envelope->all(HandledStamp::class);
+        if (count($handledStamps) > 1) {
             throw new LogicException(sprintf(
-                'Command handler for %s returned unsupported result %s.',
+                'Command %s resolved to %d handlers; exactly one is required.',
                 $command::class,
-                get_debug_type($result)
+                count($handledStamps)
             ));
         }
 
-        return $result;
+        return $handledStamps[0] ?? null;
     }
 }

--- a/src/Shared/Infrastructure/Bus/Command/InMemorySymfonyCommandBus.php
+++ b/src/Shared/Infrastructure/Bus/Command/InMemorySymfonyCommandBus.php
@@ -7,10 +7,12 @@ namespace App\Shared\Infrastructure\Bus\Command;
 use App\Shared\Domain\Bus\Command\CommandBusInterface;
 use App\Shared\Domain\Bus\Command\CommandHandlerInterface;
 use App\Shared\Domain\Bus\Command\CommandInterface;
+use App\Shared\Domain\Bus\Command\CommandResponseInterface;
 use App\Shared\Infrastructure\Bus\MessageBusFactory;
 use Symfony\Component\Messenger\Exception\HandlerFailedException;
 use Symfony\Component\Messenger\Exception\NoHandlerForMessageException;
 use Symfony\Component\Messenger\MessageBus;
+use Symfony\Component\Messenger\Stamp\HandledStamp;
 
 readonly class InMemorySymfonyCommandBus implements CommandBusInterface
 {
@@ -30,14 +32,31 @@ readonly class InMemorySymfonyCommandBus implements CommandBusInterface
      * @throws \Throwable
      */
     #[\Override]
-    public function dispatch(CommandInterface $command): void
+    public function dispatch(CommandInterface $command): ?CommandResponseInterface
     {
         try {
-            $this->bus->dispatch($command);
+            $envelope = $this->bus->dispatch($command);
         } catch (NoHandlerForMessageException) {
             throw new CommandNotRegisteredException($command);
         } catch (HandlerFailedException $error) {
             throw $error->getPrevious() ?? $error;
         }
+
+        $handledStamp = $envelope->last(HandledStamp::class);
+        $result = $handledStamp?->getResult();
+
+        if ($result === null) {
+            return null;
+        }
+
+        if (!$result instanceof CommandResponseInterface) {
+            throw new \LogicException(sprintf(
+                'Command handler for %s returned unsupported result %s.',
+                $command::class,
+                get_debug_type($result)
+            ));
+        }
+
+        return $result;
     }
 }

--- a/src/Shared/Infrastructure/Bus/Command/InMemorySymfonyCommandBus.php
+++ b/src/Shared/Infrastructure/Bus/Command/InMemorySymfonyCommandBus.php
@@ -9,6 +9,7 @@ use App\Shared\Domain\Bus\Command\CommandHandlerInterface;
 use App\Shared\Domain\Bus\Command\CommandInterface;
 use App\Shared\Domain\Bus\Command\CommandResponseInterface;
 use App\Shared\Infrastructure\Bus\MessageBusFactory;
+use LogicException;
 use Symfony\Component\Messenger\Exception\HandlerFailedException;
 use Symfony\Component\Messenger\Exception\NoHandlerForMessageException;
 use Symfony\Component\Messenger\MessageBus;
@@ -50,7 +51,7 @@ readonly class InMemorySymfonyCommandBus implements CommandBusInterface
         }
 
         if (!$result instanceof CommandResponseInterface) {
-            throw new \LogicException(sprintf(
+            throw new LogicException(sprintf(
                 'Command handler for %s returned unsupported result %s.',
                 $command::class,
                 get_debug_type($result)

--- a/src/User/Application/Command/CompleteTwoFactorCommand.php
+++ b/src/User/Application/Command/CompleteTwoFactorCommand.php
@@ -5,27 +5,14 @@ declare(strict_types=1);
 namespace App\User\Application\Command;
 
 use App\Shared\Domain\Bus\Command\CommandInterface;
-use App\User\Application\DTO\CompleteTwoFactorCommandResponse;
 
 final class CompleteTwoFactorCommand implements CommandInterface
 {
-    private CompleteTwoFactorCommandResponse $response;
-
     public function __construct(
         public readonly string $pendingSessionId,
         public readonly string $twoFactorCode,
         public readonly string $ipAddress,
         public readonly string $userAgent,
     ) {
-    }
-
-    public function getResponse(): CompleteTwoFactorCommandResponse
-    {
-        return $this->response;
-    }
-
-    public function setResponse(CompleteTwoFactorCommandResponse $response): void
-    {
-        $this->response = $response;
     }
 }

--- a/src/User/Application/Command/ConfirmPasswordResetCommand.php
+++ b/src/User/Application/Command/ConfirmPasswordResetCommand.php
@@ -5,33 +5,14 @@ declare(strict_types=1);
 namespace App\User\Application\Command;
 
 use App\Shared\Domain\Bus\Command\CommandInterface;
-use App\User\Application\DTO\ConfirmPasswordResetCommandResponse;
 
 final class ConfirmPasswordResetCommand implements CommandInterface
 {
-    private ConfirmPasswordResetCommandResponse $response;
-
     public function __construct(
         #[\SensitiveParameter]
         public readonly string $token,
         #[\SensitiveParameter]
         public readonly string $newPassword,
     ) {
-    }
-
-    public function getResponse(): ConfirmPasswordResetCommandResponse
-    {
-        return $this->response;
-    }
-
-    public function setResponse(
-        ConfirmPasswordResetCommandResponse $response
-    ): void {
-        $this->response = $response;
-    }
-
-    public function markCompleted(): void
-    {
-        $this->response = new ConfirmPasswordResetCommandResponse();
     }
 }

--- a/src/User/Application/Command/ConfirmTwoFactorCommand.php
+++ b/src/User/Application/Command/ConfirmTwoFactorCommand.php
@@ -5,27 +5,13 @@ declare(strict_types=1);
 namespace App\User\Application\Command;
 
 use App\Shared\Domain\Bus\Command\CommandInterface;
-use App\User\Application\DTO\ConfirmTwoFactorCommandResponse;
 
 final class ConfirmTwoFactorCommand implements CommandInterface
 {
-    private ConfirmTwoFactorCommandResponse $response;
-
     public function __construct(
         public readonly string $userEmail,
         public readonly string $twoFactorCode,
         public readonly string $currentSessionId,
     ) {
-    }
-
-    public function getResponse(): ConfirmTwoFactorCommandResponse
-    {
-        return $this->response;
-    }
-
-    public function setResponse(
-        ConfirmTwoFactorCommandResponse $response
-    ): void {
-        $this->response = $response;
     }
 }

--- a/src/User/Application/Command/RefreshTokenCommand.php
+++ b/src/User/Application/Command/RefreshTokenCommand.php
@@ -5,30 +5,11 @@ declare(strict_types=1);
 namespace App\User\Application\Command;
 
 use App\Shared\Domain\Bus\Command\CommandInterface;
-use App\User\Application\DTO\RefreshTokenCommandResponse;
 
 final class RefreshTokenCommand implements CommandInterface
 {
-    private RefreshTokenCommandResponse $response;
-
     public function __construct(
         public readonly string $refreshToken,
     ) {
-    }
-
-    public function getResponse(): RefreshTokenCommandResponse
-    {
-        return $this->response;
-    }
-
-    public function setResponse(
-        RefreshTokenCommandResponse $response
-    ): void {
-        $this->response = $response;
-    }
-
-    public function setTokens(string $accessToken, string $refreshToken): void
-    {
-        $this->setResponse(new RefreshTokenCommandResponse($accessToken, $refreshToken));
     }
 }

--- a/src/User/Application/Command/RegenerateRecoveryCodesCommand.php
+++ b/src/User/Application/Command/RegenerateRecoveryCodesCommand.php
@@ -5,26 +5,12 @@ declare(strict_types=1);
 namespace App\User\Application\Command;
 
 use App\Shared\Domain\Bus\Command\CommandInterface;
-use App\User\Application\DTO\RegenerateRecoveryCodesCommandResponse;
 
 final class RegenerateRecoveryCodesCommand implements CommandInterface
 {
-    private RegenerateRecoveryCodesCommandResponse $response;
-
     public function __construct(
         public readonly string $userEmail,
         public readonly string $currentSessionId,
     ) {
-    }
-
-    public function getResponse(): RegenerateRecoveryCodesCommandResponse
-    {
-        return $this->response;
-    }
-
-    public function setResponse(
-        RegenerateRecoveryCodesCommandResponse $response
-    ): void {
-        $this->response = $response;
     }
 }

--- a/src/User/Application/Command/RegisterUserBatchCommand.php
+++ b/src/User/Application/Command/RegisterUserBatchCommand.php
@@ -5,26 +5,12 @@ declare(strict_types=1);
 namespace App\User\Application\Command;
 
 use App\Shared\Domain\Bus\Command\CommandInterface;
-use App\User\Application\DTO\RegisterUserBatchCommandResponse;
 use App\User\Domain\Collection\UserCollection;
 
 final class RegisterUserBatchCommand implements CommandInterface
 {
-    private RegisterUserBatchCommandResponse $response;
-
     public function __construct(
         public readonly UserCollection $users,
     ) {
-    }
-
-    public function getResponse(): RegisterUserBatchCommandResponse
-    {
-        return $this->response;
-    }
-
-    public function setResponse(
-        RegisterUserBatchCommandResponse $response
-    ): void {
-        $this->response = $response;
     }
 }

--- a/src/User/Application/Command/RegisterUserCommand.php
+++ b/src/User/Application/Command/RegisterUserCommand.php
@@ -5,26 +5,13 @@ declare(strict_types=1);
 namespace App\User\Application\Command;
 
 use App\Shared\Domain\Bus\Command\CommandInterface;
-use App\User\Application\DTO\RegisterUserCommandResponse;
 
 final class RegisterUserCommand implements CommandInterface
 {
-    private RegisterUserCommandResponse $response;
-
     public function __construct(
         public readonly string $email,
         public readonly string $initials,
         public readonly string $password,
     ) {
-    }
-
-    public function getResponse(): RegisterUserCommandResponse
-    {
-        return $this->response;
-    }
-
-    public function setResponse(RegisterUserCommandResponse $response): void
-    {
-        $this->response = $response;
     }
 }

--- a/src/User/Application/Command/RequestPasswordResetCommand.php
+++ b/src/User/Application/Command/RequestPasswordResetCommand.php
@@ -5,25 +5,11 @@ declare(strict_types=1);
 namespace App\User\Application\Command;
 
 use App\Shared\Domain\Bus\Command\CommandInterface;
-use App\User\Application\DTO\RequestPasswordResetCommandResponse;
 
 final class RequestPasswordResetCommand implements CommandInterface
 {
-    private RequestPasswordResetCommandResponse $response;
-
     public function __construct(
         public readonly string $email,
     ) {
-    }
-
-    public function getResponse(): RequestPasswordResetCommandResponse
-    {
-        return $this->response;
-    }
-
-    public function setResponse(
-        RequestPasswordResetCommandResponse $response
-    ): void {
-        $this->response = $response;
     }
 }

--- a/src/User/Application/Command/SetupTwoFactorCommand.php
+++ b/src/User/Application/Command/SetupTwoFactorCommand.php
@@ -5,23 +5,10 @@ declare(strict_types=1);
 namespace App\User\Application\Command;
 
 use App\Shared\Domain\Bus\Command\CommandInterface;
-use App\User\Application\DTO\SetupTwoFactorCommandResponse;
 
 final class SetupTwoFactorCommand implements CommandInterface
 {
-    private SetupTwoFactorCommandResponse $response;
-
     public function __construct(public readonly string $userEmail)
     {
-    }
-
-    public function getResponse(): SetupTwoFactorCommandResponse
-    {
-        return $this->response;
-    }
-
-    public function setResponse(SetupTwoFactorCommandResponse $response): void
-    {
-        $this->response = $response;
     }
 }

--- a/src/User/Application/Command/SignInCommand.php
+++ b/src/User/Application/Command/SignInCommand.php
@@ -5,12 +5,9 @@ declare(strict_types=1);
 namespace App\User\Application\Command;
 
 use App\Shared\Domain\Bus\Command\CommandInterface;
-use App\User\Application\DTO\SignInCommandResponse;
 
 final class SignInCommand implements CommandInterface
 {
-    private SignInCommandResponse $response;
-
     public function __construct(
         public readonly string $email,
         #[\SensitiveParameter]
@@ -19,15 +16,5 @@ final class SignInCommand implements CommandInterface
         public readonly string $ipAddress,
         public readonly string $userAgent,
     ) {
-    }
-
-    public function getResponse(): SignInCommandResponse
-    {
-        return $this->response;
-    }
-
-    public function setResponse(SignInCommandResponse $response): void
-    {
-        $this->response = $response;
     }
 }

--- a/src/User/Application/CommandHandler/CompleteTwoFactorCommandHandler.php
+++ b/src/User/Application/CommandHandler/CompleteTwoFactorCommandHandler.php
@@ -34,8 +34,9 @@ final readonly class CompleteTwoFactorCommandHandler implements CommandHandlerIn
     ) {
     }
 
-    public function __invoke(CompleteTwoFactorCommand $command): void
-    {
+    public function __invoke(
+        CompleteTwoFactorCommand $command
+    ): CompleteTwoFactorCommandResponse {
         $pendingSession = $this->resolvePendingSession($command->pendingSessionId);
         $user = $this->resolveUser($pendingSession->getUserId());
         $method = $this->twoFactorCodeVerifier->verifyAndResolveMethod(
@@ -51,7 +52,8 @@ final readonly class CompleteTwoFactorCommandHandler implements CommandHandlerIn
         $rememberMe = $pendingSession->isRememberMe();
         $this->consumePendingSessionOrFail($pendingSession->getId());
         $this->consumeRecoveryCodeIfNeeded($user, $command, $method);
-        $this->issueTokensAndComplete($user, $command, $rememberMe, $method);
+
+        return $this->issueTokensAndComplete($user, $command, $rememberMe, $method);
     }
 
     private function issueTokensAndComplete(
@@ -59,7 +61,7 @@ final readonly class CompleteTwoFactorCommandHandler implements CommandHandlerIn
         CompleteTwoFactorCommand $command,
         bool $rememberMe,
         string $method
-    ): void {
+    ): CompleteTwoFactorCommandResponse {
         $issued = $this->issueSession(
             $user,
             $command->ipAddress,
@@ -68,9 +70,9 @@ final readonly class CompleteTwoFactorCommandHandler implements CommandHandlerIn
         );
         $remaining = $this->resolveRemainingCodes($user, $method);
 
-        $command->setResponse($this->buildResponse($issued, $rememberMe, $remaining));
-
         $this->publishEvents($user, $issued, $command, $method, $remaining);
+
+        return $this->buildResponse($issued, $rememberMe, $remaining);
     }
 
     private function issueSession(

--- a/src/User/Application/CommandHandler/ConfirmPasswordResetCommandHandler.php
+++ b/src/User/Application/CommandHandler/ConfirmPasswordResetCommandHandler.php
@@ -19,6 +19,9 @@ use App\User\Domain\Repository\PasswordResetTokenRepositoryInterface;
 use App\User\Domain\Repository\UserRepositoryInterface;
 use App\User\Infrastructure\Publisher\PasswordResetConfirmationPublisherInterface;
 
+/**
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
 final readonly class ConfirmPasswordResetCommandHandler implements
     CommandHandlerInterface
 {

--- a/src/User/Application/CommandHandler/ConfirmPasswordResetCommandHandler.php
+++ b/src/User/Application/CommandHandler/ConfirmPasswordResetCommandHandler.php
@@ -10,26 +10,15 @@ use App\User\Application\Command\ConfirmPasswordResetCommand;
 use App\User\Application\Command\SignOutAllCommand;
 use App\User\Application\DTO\ConfirmPasswordResetCommandResponse;
 use App\User\Application\Provider\AccountLockoutProviderInterface;
-use App\User\Application\Validator\PasswordResetTokenValidatorInterface;
-use App\User\Domain\Contract\PasswordHasherInterface;
-use App\User\Domain\Entity\PasswordResetTokenInterface;
+use App\User\Application\Service\PasswordResetConfirmationService;
 use App\User\Domain\Entity\UserInterface;
-use App\User\Domain\Exception\UserNotFoundException;
-use App\User\Domain\Repository\PasswordResetTokenRepositoryInterface;
-use App\User\Domain\Repository\UserRepositoryInterface;
 use App\User\Infrastructure\Publisher\PasswordResetConfirmationPublisherInterface;
 
-/**
- * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
- */
 final readonly class ConfirmPasswordResetCommandHandler implements
     CommandHandlerInterface
 {
     public function __construct(
-        private PasswordResetTokenRepositoryInterface $tokenRepository,
-        private UserRepositoryInterface $userRepository,
-        private PasswordHasherInterface $passwordHasher,
-        private PasswordResetTokenValidatorInterface $tokenValidator,
+        private PasswordResetConfirmationService $confirmationService,
         private AccountLockoutProviderInterface $accountLockoutGuard,
         private CommandBusInterface $commandBus,
         private PasswordResetConfirmationPublisherInterface $publisher,
@@ -39,11 +28,11 @@ final readonly class ConfirmPasswordResetCommandHandler implements
     public function __invoke(
         ConfirmPasswordResetCommand $command
     ): ConfirmPasswordResetCommandResponse {
-        $passwordResetToken = $this->getValidatedToken($command->token);
-        $user = $this->getUserFromToken($passwordResetToken);
+        $user = $this->confirmationService->confirm(
+            $command->token,
+            $command->newPassword
+        );
 
-        $this->updateUserPassword($user, $command->newPassword);
-        $this->markTokenAsUsed($passwordResetToken);
         $this->accountLockoutGuard->clearFailures(
             strtolower(trim($user->getEmail()))
         );
@@ -55,46 +44,8 @@ final readonly class ConfirmPasswordResetCommandHandler implements
         return new ConfirmPasswordResetCommandResponse();
     }
 
-    private function getValidatedToken(
-        string $token
-    ): PasswordResetTokenInterface {
-        $passwordResetToken = $this->tokenRepository->findByToken($token);
-        $this->tokenValidator->validate($passwordResetToken);
-        assert($passwordResetToken instanceof PasswordResetTokenInterface);
-
-        return $passwordResetToken;
-    }
-
-    private function getUserFromToken(
-        PasswordResetTokenInterface $token
-    ): UserInterface {
-        $user = $this->userRepository->findById($token->getUserID());
-
-        if (!$user instanceof UserInterface) {
-            throw new UserNotFoundException();
-        }
-
-        return $user;
-    }
-
-    private function markTokenAsUsed(
-        PasswordResetTokenInterface $token
-    ): void {
-        $token->markAsUsed();
-        $this->tokenRepository->save($token);
-    }
-
     private function publishEvent(UserInterface $user): void
     {
         $this->publisher->publish($user);
-    }
-
-    private function updateUserPassword(
-        UserInterface $user,
-        string $newPassword
-    ): void {
-        $hashedPassword = $this->passwordHasher->hash($newPassword);
-        $user->setPassword($hashedPassword);
-        $this->userRepository->save($user);
     }
 }

--- a/src/User/Application/CommandHandler/ConfirmPasswordResetCommandHandler.php
+++ b/src/User/Application/CommandHandler/ConfirmPasswordResetCommandHandler.php
@@ -8,6 +8,7 @@ use App\Shared\Domain\Bus\Command\CommandBusInterface;
 use App\Shared\Domain\Bus\Command\CommandHandlerInterface;
 use App\User\Application\Command\ConfirmPasswordResetCommand;
 use App\User\Application\Command\SignOutAllCommand;
+use App\User\Application\DTO\ConfirmPasswordResetCommandResponse;
 use App\User\Application\Provider\AccountLockoutProviderInterface;
 use App\User\Application\Validator\PasswordResetTokenValidatorInterface;
 use App\User\Domain\Contract\PasswordHasherInterface;
@@ -32,8 +33,9 @@ final readonly class ConfirmPasswordResetCommandHandler implements
     ) {
     }
 
-    public function __invoke(ConfirmPasswordResetCommand $command): void
-    {
+    public function __invoke(
+        ConfirmPasswordResetCommand $command
+    ): ConfirmPasswordResetCommandResponse {
         $passwordResetToken = $this->getValidatedToken($command->token);
         $user = $this->getUserFromToken($passwordResetToken);
 
@@ -47,7 +49,7 @@ final readonly class ConfirmPasswordResetCommandHandler implements
         );
         $this->publishEvent($user);
 
-        $command->markCompleted();
+        return new ConfirmPasswordResetCommandResponse();
     }
 
     private function getValidatedToken(

--- a/src/User/Application/CommandHandler/ConfirmTwoFactorCommandHandler.php
+++ b/src/User/Application/CommandHandler/ConfirmTwoFactorCommandHandler.php
@@ -32,8 +32,9 @@ final readonly class ConfirmTwoFactorCommandHandler implements CommandHandlerInt
     ) {
     }
 
-    public function __invoke(ConfirmTwoFactorCommand $command): void
-    {
+    public function __invoke(
+        ConfirmTwoFactorCommand $command
+    ): ConfirmTwoFactorCommandResponse {
         $user = $this->resolveUser($command->userEmail);
         $this->verifyTotpOrFail($user, $command->twoFactorCode);
 
@@ -43,8 +44,9 @@ final readonly class ConfirmTwoFactorCommandHandler implements CommandHandlerInt
         $codes = $this->recoveryCodeBatchFactory->create($user);
         $revokedCount = $this->revokeOtherSessions($user, $command->currentSessionId);
 
-        $command->setResponse(new ConfirmTwoFactorCommandResponse($codes));
         $this->publishEvents($user, $revokedCount);
+
+        return new ConfirmTwoFactorCommandResponse($codes);
     }
 
     private function resolveUser(string $email): User

--- a/src/User/Application/CommandHandler/RefreshTokenCommandHandler.php
+++ b/src/User/Application/CommandHandler/RefreshTokenCommandHandler.php
@@ -6,6 +6,7 @@ namespace App\User\Application\CommandHandler;
 
 use App\Shared\Domain\Bus\Command\CommandHandlerInterface;
 use App\User\Application\Command\RefreshTokenCommand;
+use App\User\Application\DTO\RefreshTokenCommandResponse;
 use App\User\Application\Factory\AccessTokenFactoryInterface;
 use App\User\Application\Factory\AuthTokenFactoryInterface;
 use App\User\Domain\Entity\AuthRefreshToken;
@@ -34,18 +35,26 @@ final readonly class RefreshTokenCommandHandler implements
     ) {
     }
 
-    public function __invoke(RefreshTokenCommand $command): void
-    {
+    public function __invoke(
+        RefreshTokenCommand $command
+    ): RefreshTokenCommandResponse {
         $oldToken = $this->resolveRefreshToken($command->refreshToken);
         $session = $this->resolveSession($oldToken->getSessionId());
         $user = $this->resolveUser($session->getUserId());
         $currentTime = new DateTimeImmutable();
 
-        if ($this->handleIfAlreadyRotated($oldToken, $session, $user, $command, $currentTime)) {
-            return;
+        $alreadyRotatedResponse = $this->handleIfAlreadyRotated(
+            $oldToken,
+            $session,
+            $user,
+            $command,
+            $currentTime
+        );
+        if ($alreadyRotatedResponse instanceof RefreshTokenCommandResponse) {
+            return $alreadyRotatedResponse;
         }
 
-        $this->rotateActiveToken($oldToken, $user, $session, $command, $currentTime);
+        return $this->rotateActiveToken($oldToken, $user, $session, $currentTime);
     }
 
     private function resolveRefreshToken(
@@ -71,16 +80,21 @@ final readonly class RefreshTokenCommandHandler implements
         User $user,
         RefreshTokenCommand $command,
         DateTimeImmutable $currentTime
-    ): bool {
-        if ($this->tryHandleRotatedToken($oldToken, $session, $user, $command, $currentTime)) {
-            return true;
+    ): ?RefreshTokenCommandResponse {
+        $rotatedResponse = $this->tryHandleRotatedToken(
+            $oldToken,
+            $session,
+            $user,
+            $currentTime
+        );
+        if ($rotatedResponse instanceof RefreshTokenCommandResponse) {
+            return $rotatedResponse;
         }
 
         return $this->tryHandleConcurrentRotation(
             $oldToken->getTokenHash(),
             $session,
             $user,
-            $command,
             $currentTime,
             $command->refreshToken
         );
@@ -90,9 +104,8 @@ final readonly class RefreshTokenCommandHandler implements
         AuthRefreshToken $oldToken,
         AuthSession $session,
         User $user,
-        RefreshTokenCommand $command,
         DateTimeImmutable $currentTime
-    ): void {
+    ): RefreshTokenCommandResponse {
         if (!$oldToken->isWithinGracePeriod(
             $currentTime,
             $this->refreshTokenGraceWindowSeconds
@@ -101,11 +114,10 @@ final readonly class RefreshTokenCommandHandler implements
         }
 
         $tokens = $this->refreshTokenRepository->findBySessionId($session->getId());
-        $this->handleGraceWindowReuse(
+        return $this->handleGraceWindowReuse(
             $oldToken,
             $session,
             $user,
-            $command,
             $currentTime,
             $tokens
         );
@@ -160,10 +172,9 @@ final readonly class RefreshTokenCommandHandler implements
         AuthRefreshToken $oldToken,
         AuthSession $session,
         User $user,
-        RefreshTokenCommand $command,
         DateTimeImmutable $currentTime,
         array $tokens
-    ): void {
+    ): RefreshTokenCommandResponse {
         if ($this->hasLaterRotation($oldToken, $tokens)) {
             $this->handleTheftDetection(
                 $oldToken,
@@ -176,8 +187,10 @@ final readonly class RefreshTokenCommandHandler implements
 
         $this->assertGraceWindowIsEligible($oldToken, $session, $user, $currentTime, $tokens);
         $oldToken->markGraceUsed();
-        $this->setResponseWithNewTokens($command, $user, $session);
+        $response = $this->issueNewTokens($user, $session);
         $this->publishRotatedEvent($session, $user);
+
+        return $response;
     }
 
     /**
@@ -278,32 +291,28 @@ final readonly class RefreshTokenCommandHandler implements
         AuthRefreshToken $oldToken,
         AuthSession $session,
         User $user,
-        RefreshTokenCommand $command,
         DateTimeImmutable $currentTime
-    ): bool {
+    ): ?RefreshTokenCommandResponse {
         if (!$oldToken->isRotated()) {
-            return false;
+            return null;
         }
 
-        $this->handleRotatedToken($oldToken, $session, $user, $command, $currentTime);
-
-        return true;
+        return $this->handleRotatedToken($oldToken, $session, $user, $currentTime);
     }
 
     private function tryHandleConcurrentRotation(
         string $tokenHash,
         AuthSession $session,
         User $user,
-        RefreshTokenCommand $command,
         DateTimeImmutable $currentTime,
         string $plainToken
-    ): bool {
+    ): ?RefreshTokenCommandResponse {
         $markedSuccessfully = $this->refreshTokenRepository->markAsRotatedIfActive(
             $tokenHash,
             $currentTime
         );
         if ($markedSuccessfully) {
-            return false;
+            return null;
         }
 
         $latestToken = $this->resolveRefreshToken($plainToken);
@@ -311,34 +320,31 @@ final readonly class RefreshTokenCommandHandler implements
             $this->throwUnauthorized();
         }
 
-        $this->handleRotatedToken(
+        return $this->handleRotatedToken(
             $latestToken,
             $session,
             $user,
-            $command,
             $currentTime
         );
-
-        return true;
     }
 
     private function rotateActiveToken(
         AuthRefreshToken $oldToken,
         User $user,
         AuthSession $session,
-        RefreshTokenCommand $command,
         DateTimeImmutable $currentTime
-    ): void {
+    ): RefreshTokenCommandResponse {
         $oldToken->markAsRotated($currentTime);
-        $this->setResponseWithNewTokens($command, $user, $session);
+        $response = $this->issueNewTokens($user, $session);
         $this->publishRotatedEvent($session, $user);
+
+        return $response;
     }
 
-    private function setResponseWithNewTokens(
-        RefreshTokenCommand $command,
+    private function issueNewTokens(
         User $user,
         AuthSession $session
-    ): void {
+    ): RefreshTokenCommandResponse {
         $issuedAt = new DateTimeImmutable();
 
         $newRefreshPlain = $this->authTokenFactory->generateOpaqueToken();
@@ -354,7 +360,7 @@ final readonly class RefreshTokenCommandHandler implements
             $this->authTokenFactory->buildJwtPayload($user, $session->getId(), $issuedAt)
         );
 
-        $command->setTokens($accessToken, $newRefreshPlain);
+        return new RefreshTokenCommandResponse($accessToken, $newRefreshPlain);
     }
 
     /**

--- a/src/User/Application/CommandHandler/RefreshTokenCommandHandler.php
+++ b/src/User/Application/CommandHandler/RefreshTokenCommandHandler.php
@@ -7,21 +7,17 @@ namespace App\User\Application\CommandHandler;
 use App\Shared\Domain\Bus\Command\CommandHandlerInterface;
 use App\User\Application\Command\RefreshTokenCommand;
 use App\User\Application\DTO\RefreshTokenCommandResponse;
-use App\User\Application\Factory\AccessTokenFactoryInterface;
-use App\User\Application\Factory\AuthTokenFactoryInterface;
+use App\User\Application\Service\RefreshTokenIssuer;
+use App\User\Application\Service\RefreshTokenTheftDetector;
 use App\User\Domain\Entity\AuthRefreshToken;
 use App\User\Domain\Entity\AuthSession;
 use App\User\Domain\Entity\User;
 use App\User\Domain\Repository\AuthRefreshTokenRepositoryInterface;
 use App\User\Domain\Repository\AuthSessionRepositoryInterface;
 use App\User\Domain\Repository\UserRepositoryInterface;
-use App\User\Infrastructure\Publisher\RefreshTokenPublisherInterface;
 use DateTimeImmutable;
 use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
 
-/**
- * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
- */
 final readonly class RefreshTokenCommandHandler implements
     CommandHandlerInterface
 {
@@ -31,9 +27,8 @@ final readonly class RefreshTokenCommandHandler implements
         private AuthRefreshTokenRepositoryInterface $refreshTokenRepository,
         private AuthSessionRepositoryInterface $authSessionRepository,
         private UserRepositoryInterface $userRepository,
-        private AccessTokenFactoryInterface $accessTokenFactory,
-        private AuthTokenFactoryInterface $authTokenFactory,
-        private RefreshTokenPublisherInterface $publisher,
+        private RefreshTokenIssuer $tokenIssuer,
+        private RefreshTokenTheftDetector $theftDetector,
         private int $refreshTokenGraceWindowSeconds = self::DEFAULT_GRACE_WINDOW_SECONDS,
     ) {
     }
@@ -113,7 +108,7 @@ final readonly class RefreshTokenCommandHandler implements
             $currentTime,
             $this->refreshTokenGraceWindowSeconds
         )) {
-            $this->handleTheftDetection($oldToken, $session, $user, 'grace_period_expired');
+            $this->theftDetector->detect($oldToken, $session, $user, 'grace_period_expired');
         }
 
         $tokens = $this->refreshTokenRepository->findBySessionId($session->getId());
@@ -179,7 +174,7 @@ final readonly class RefreshTokenCommandHandler implements
         array $tokens
     ): RefreshTokenCommandResponse {
         if ($this->hasLaterRotation($oldToken, $tokens)) {
-            $this->handleTheftDetection(
+            $this->theftDetector->detect(
                 $oldToken,
                 $session,
                 $user,
@@ -190,91 +185,8 @@ final readonly class RefreshTokenCommandHandler implements
 
         $this->assertGraceWindowIsEligible($oldToken, $session, $user, $currentTime, $tokens);
         $oldToken->markGraceUsed();
-        $response = $this->issueNewTokens($user, $session);
-        $this->publishRotatedEvent($session, $user);
 
-        return $response;
-    }
-
-    /**
-     * @param list<AuthRefreshToken>|null $tokens
-     */
-    private function handleTheftDetection(
-        AuthRefreshToken $oldToken,
-        AuthSession $session,
-        User $user,
-        string $reason,
-        ?array $tokens = null
-    ): never {
-        $this->revokeSessionAndTokens($oldToken, $session, $tokens);
-        $this->publisher->publishTheftDetected(
-            $session->getId(),
-            $user->getId(),
-            $session->getIpAddress(),
-            $reason
-        );
-
-        $this->throwUnauthorized();
-    }
-
-    /**
-     * @param list<AuthRefreshToken>|null $tokens
-     */
-    private function revokeSessionAndTokens(
-        AuthRefreshToken $oldToken,
-        AuthSession $session,
-        ?array $tokens = null
-    ): void {
-        if (!$session->isRevoked()) {
-            $session->revoke();
-            $this->authSessionRepository->save($session);
-        }
-
-        $this->revokeRefreshTokens(
-            $this->resolveTokensForRevocation(
-                $oldToken,
-                $session,
-                $tokens
-            )
-        );
-    }
-
-    /**
-     * @param list<AuthRefreshToken>|null $tokens
-     *
-     * @return list<AuthRefreshToken>
-     */
-    private function resolveTokensForRevocation(
-        AuthRefreshToken $oldToken,
-        AuthSession $session,
-        ?array $tokens
-    ): array {
-        if ($tokens === null) {
-            $tokens = $this->refreshTokenRepository->findBySessionId(
-                $session->getId()
-            );
-        }
-
-        if ($tokens !== []) {
-            return $tokens;
-        }
-
-        return [$oldToken];
-    }
-
-    /**
-     * @param list<AuthRefreshToken> $tokens
-     */
-    private function revokeRefreshTokens(array $tokens): void
-    {
-        foreach ($tokens as $token) {
-            if ($token->isRevoked()) {
-                continue;
-            }
-
-            $token->revoke();
-            $this->refreshTokenRepository->save($token);
-        }
+        return $this->tokenIssuer->issueRotatedTokens($user, $session);
     }
 
     private function resolveSession(string $sessionId): AuthSession
@@ -338,32 +250,8 @@ final readonly class RefreshTokenCommandHandler implements
         DateTimeImmutable $currentTime
     ): RefreshTokenCommandResponse {
         $oldToken->markAsRotated($currentTime);
-        $response = $this->issueNewTokens($user, $session);
-        $this->publishRotatedEvent($session, $user);
 
-        return $response;
-    }
-
-    private function issueNewTokens(
-        User $user,
-        AuthSession $session
-    ): RefreshTokenCommandResponse {
-        $issuedAt = new DateTimeImmutable();
-
-        $newRefreshPlain = $this->authTokenFactory->generateOpaqueToken();
-        $this->refreshTokenRepository->save(
-            $this->authTokenFactory->createRefreshToken(
-                $session->getId(),
-                $newRefreshPlain,
-                $issuedAt
-            )
-        );
-
-        $accessToken = $this->accessTokenFactory->create(
-            $this->authTokenFactory->buildJwtPayload($user, $session->getId(), $issuedAt)
-        );
-
-        return new RefreshTokenCommandResponse($accessToken, $newRefreshPlain);
+        return $this->tokenIssuer->issueRotatedTokens($user, $session);
     }
 
     /**
@@ -380,7 +268,7 @@ final readonly class RefreshTokenCommandHandler implements
             return;
         }
 
-        $this->handleTheftDetection(
+        $this->theftDetector->detect(
             $oldToken,
             $session,
             $user,
@@ -416,16 +304,6 @@ final readonly class RefreshTokenCommandHandler implements
         }
 
         return $user;
-    }
-
-    private function publishRotatedEvent(
-        AuthSession $session,
-        User $user
-    ): void {
-        $this->publisher->publishTokenRotated(
-            $session->getId(),
-            $user->getId()
-        );
     }
 
     private function throwUnauthorized(): never

--- a/src/User/Application/CommandHandler/RefreshTokenCommandHandler.php
+++ b/src/User/Application/CommandHandler/RefreshTokenCommandHandler.php
@@ -19,6 +19,9 @@ use App\User\Infrastructure\Publisher\RefreshTokenPublisherInterface;
 use DateTimeImmutable;
 use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
 
+/**
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
 final readonly class RefreshTokenCommandHandler implements
     CommandHandlerInterface
 {

--- a/src/User/Application/CommandHandler/RefreshTokenCommandHandler.php
+++ b/src/User/Application/CommandHandler/RefreshTokenCommandHandler.php
@@ -7,16 +7,14 @@ namespace App\User\Application\CommandHandler;
 use App\Shared\Domain\Bus\Command\CommandHandlerInterface;
 use App\User\Application\Command\RefreshTokenCommand;
 use App\User\Application\DTO\RefreshTokenCommandResponse;
+use App\User\Application\Service\RefreshTokenContextResolver;
 use App\User\Application\Service\RefreshTokenIssuer;
 use App\User\Application\Service\RefreshTokenTheftDetector;
 use App\User\Domain\Entity\AuthRefreshToken;
 use App\User\Domain\Entity\AuthSession;
 use App\User\Domain\Entity\User;
 use App\User\Domain\Repository\AuthRefreshTokenRepositoryInterface;
-use App\User\Domain\Repository\AuthSessionRepositoryInterface;
-use App\User\Domain\Repository\UserRepositoryInterface;
 use DateTimeImmutable;
-use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
 
 final readonly class RefreshTokenCommandHandler implements
     CommandHandlerInterface
@@ -25,8 +23,7 @@ final readonly class RefreshTokenCommandHandler implements
 
     public function __construct(
         private AuthRefreshTokenRepositoryInterface $refreshTokenRepository,
-        private AuthSessionRepositoryInterface $authSessionRepository,
-        private UserRepositoryInterface $userRepository,
+        private RefreshTokenContextResolver $contextResolver,
         private RefreshTokenIssuer $tokenIssuer,
         private RefreshTokenTheftDetector $theftDetector,
         private int $refreshTokenGraceWindowSeconds = self::DEFAULT_GRACE_WINDOW_SECONDS,
@@ -36,9 +33,9 @@ final readonly class RefreshTokenCommandHandler implements
     public function __invoke(
         RefreshTokenCommand $command
     ): RefreshTokenCommandResponse {
-        $oldToken = $this->resolveRefreshToken($command->refreshToken);
-        $session = $this->resolveSession($oldToken->getSessionId());
-        $user = $this->resolveUser($session->getUserId());
+        [$oldToken, $session, $user] = $this->contextResolver->resolve(
+            $command->refreshToken
+        );
         $currentTime = new DateTimeImmutable();
 
         $alreadyRotatedResponse = $this->handleIfAlreadyRotated(
@@ -53,23 +50,6 @@ final readonly class RefreshTokenCommandHandler implements
         }
 
         return $this->rotateActiveToken($oldToken, $user, $session, $currentTime);
-    }
-
-    private function resolveRefreshToken(
-        string $plainToken
-    ): AuthRefreshToken {
-        $hash = hash('sha256', $plainToken);
-        $token = $this->refreshTokenRepository->findByTokenHash($hash);
-
-        if (!$token instanceof AuthRefreshToken) {
-            $this->throwUnauthorized();
-        }
-
-        if ($token->isExpired() || $token->isRevoked()) {
-            $this->throwUnauthorized();
-        }
-
-        return $token;
     }
 
     private function handleIfAlreadyRotated(
@@ -108,7 +88,12 @@ final readonly class RefreshTokenCommandHandler implements
             $currentTime,
             $this->refreshTokenGraceWindowSeconds
         )) {
-            $this->theftDetector->detect($oldToken, $session, $user, 'grace_period_expired');
+            $this->theftDetector->respondToTheft(
+                $oldToken,
+                $session,
+                $user,
+                'grace_period_expired'
+            );
         }
 
         $tokens = $this->refreshTokenRepository->findBySessionId($session->getId());
@@ -174,7 +159,7 @@ final readonly class RefreshTokenCommandHandler implements
         array $tokens
     ): RefreshTokenCommandResponse {
         if ($this->hasLaterRotation($oldToken, $tokens)) {
-            $this->theftDetector->detect(
+            $this->theftDetector->respondToTheft(
                 $oldToken,
                 $session,
                 $user,
@@ -187,19 +172,6 @@ final readonly class RefreshTokenCommandHandler implements
         $oldToken->markGraceUsed();
 
         return $this->tokenIssuer->issueRotatedTokens($user, $session);
-    }
-
-    private function resolveSession(string $sessionId): AuthSession
-    {
-        $session = $this->authSessionRepository->findById($sessionId);
-        if (!$session instanceof AuthSession) {
-            $this->throwUnauthorized();
-        }
-        if ($session->isRevoked() || $session->isExpired()) {
-            $this->throwUnauthorized();
-        }
-
-        return $session;
     }
 
     private function tryHandleRotatedToken(
@@ -230,11 +202,7 @@ final readonly class RefreshTokenCommandHandler implements
             return null;
         }
 
-        $latestToken = $this->resolveRefreshToken($plainToken);
-        if (!$latestToken->isRotated()) {
-            $this->throwUnauthorized();
-        }
-
+        $latestToken = $this->contextResolver->resolveRotatedRefreshToken($plainToken);
         return $this->handleRotatedToken(
             $latestToken,
             $session,
@@ -268,7 +236,7 @@ final readonly class RefreshTokenCommandHandler implements
             return;
         }
 
-        $this->theftDetector->detect(
+        $this->theftDetector->respondToTheft(
             $oldToken,
             $session,
             $user,
@@ -293,24 +261,6 @@ final readonly class RefreshTokenCommandHandler implements
             $oldToken->getTokenHash(),
             $graceWindowStartedAt,
             $currentTime
-        );
-    }
-
-    private function resolveUser(string $userId): User
-    {
-        $user = $this->userRepository->findById($userId);
-        if (!$user instanceof User) {
-            $this->throwUnauthorized();
-        }
-
-        return $user;
-    }
-
-    private function throwUnauthorized(): never
-    {
-        throw new UnauthorizedHttpException(
-            'Bearer',
-            'Invalid refresh token.'
         );
     }
 }

--- a/src/User/Application/CommandHandler/RegenerateRecoveryCodesCommandHandler.php
+++ b/src/User/Application/CommandHandler/RegenerateRecoveryCodesCommandHandler.php
@@ -33,15 +33,16 @@ final readonly class RegenerateRecoveryCodesCommandHandler implements CommandHan
     ) {
     }
 
-    public function __invoke(RegenerateRecoveryCodesCommand $command): void
-    {
+    public function __invoke(
+        RegenerateRecoveryCodesCommand $command
+    ): RegenerateRecoveryCodesCommandResponse {
         $user = $this->resolveUser($command->userEmail);
         $this->verifySudoMode($command->currentSessionId);
 
         $this->recoveryCodeRepository->deleteByUserId($user->getId());
         $codes = $this->recoveryCodeBatchFactory->create($user);
 
-        $command->setResponse(new RegenerateRecoveryCodesCommandResponse($codes));
+        return new RegenerateRecoveryCodesCommandResponse($codes);
     }
 
     private function resolveUser(string $email): User

--- a/src/User/Application/CommandHandler/RegisterUserBatchCommandHandler.php
+++ b/src/User/Application/CommandHandler/RegisterUserBatchCommandHandler.php
@@ -23,14 +23,11 @@ final readonly class RegisterUserBatchCommandHandler implements
     ) {
     }
 
-    public function __invoke(RegisterUserBatchCommand $command): void
-    {
+    public function __invoke(
+        RegisterUserBatchCommand $command
+    ): RegisterUserBatchCommandResponse {
         if ($command->users->count() === 0) {
-            $command->setResponse(new RegisterUserBatchCommandResponse(
-                new UserCollection()
-            ));
-
-            return;
+            return new RegisterUserBatchCommandResponse(new UserCollection());
         }
 
         $knownUsers = $this->userRepository->findByEmails(
@@ -43,11 +40,11 @@ final readonly class RegisterUserBatchCommandHandler implements
 
         $this->persistUsersIfNeeded($registrationResult->usersToPersist);
 
-        $command->setResponse(new RegisterUserBatchCommandResponse(
-            $registrationResult->returnedUsers
-        ));
-
         $this->publishEventsIfNeeded($registrationResult->events);
+
+        return new RegisterUserBatchCommandResponse(
+            $registrationResult->returnedUsers
+        );
     }
 
     private function persistUsersIfNeeded(UserCollection $users): void

--- a/src/User/Application/CommandHandler/RegisterUserCommandHandler.php
+++ b/src/User/Application/CommandHandler/RegisterUserCommandHandler.php
@@ -28,16 +28,13 @@ final readonly class RegisterUserCommandHandler implements
     ) {
     }
 
-    public function __invoke(RegisterUserCommand $command): void
-    {
+    public function __invoke(
+        RegisterUserCommand $command
+    ): RegisterUserCommandResponse {
         $existingUser = $this->userRepository->findByEmail($command->email);
 
         if ($existingUser !== null) {
-            $command->setResponse(
-                new RegisterUserCommandResponse($existingUser)
-            );
-
-            return;
+            return new RegisterUserCommandResponse($existingUser);
         }
 
         $user = $this->transformer->transformToUser($command);
@@ -47,7 +44,6 @@ final readonly class RegisterUserCommandHandler implements
         $user->setPassword($hashedPassword);
 
         $this->userRepository->save($user);
-        $command->setResponse(new RegisterUserCommandResponse($user));
 
         $this->eventBus->publish(
             $this->registeredEventFactory->create(
@@ -55,5 +51,7 @@ final readonly class RegisterUserCommandHandler implements
                 (string) $this->uuidFactory->create()
             )
         );
+
+        return new RegisterUserCommandResponse($user);
     }
 }

--- a/src/User/Application/CommandHandler/RequestPasswordResetCommandHandler.php
+++ b/src/User/Application/CommandHandler/RequestPasswordResetCommandHandler.php
@@ -30,15 +30,13 @@ final readonly class RequestPasswordResetCommandHandler implements
     }
 
     #[\Override]
-    public function __invoke(RequestPasswordResetCommand $command): void
-    {
+    public function __invoke(
+        RequestPasswordResetCommand $command
+    ): RequestPasswordResetCommandResponse {
         $user = $this->userRepository->findByEmail($command->email);
 
         if (!$user instanceof UserInterface) {
-            $command->setResponse(
-                new RequestPasswordResetCommandResponse()
-            );
-            return;
+            return new RequestPasswordResetCommandResponse();
         }
 
         $token = $this->tokenFactory->create($user->getId());
@@ -52,8 +50,6 @@ final readonly class RequestPasswordResetCommandHandler implements
             )
         );
 
-        $command->setResponse(
-            new RequestPasswordResetCommandResponse()
-        );
+        return new RequestPasswordResetCommandResponse();
     }
 }

--- a/src/User/Application/CommandHandler/RequestPasswordResetHandlerInterface.php
+++ b/src/User/Application/CommandHandler/RequestPasswordResetHandlerInterface.php
@@ -5,8 +5,11 @@ declare(strict_types=1);
 namespace App\User\Application\CommandHandler;
 
 use App\User\Application\Command\RequestPasswordResetCommand;
+use App\User\Application\DTO\RequestPasswordResetCommandResponse;
 
 interface RequestPasswordResetHandlerInterface
 {
-    public function __invoke(RequestPasswordResetCommand $command): void;
+    public function __invoke(
+        RequestPasswordResetCommand $command
+    ): RequestPasswordResetCommandResponse;
 }

--- a/src/User/Application/CommandHandler/SetupTwoFactorCommandHandler.php
+++ b/src/User/Application/CommandHandler/SetupTwoFactorCommandHandler.php
@@ -23,8 +23,9 @@ final readonly class SetupTwoFactorCommandHandler implements CommandHandlerInter
     ) {
     }
 
-    public function __invoke(SetupTwoFactorCommand $command): void
-    {
+    public function __invoke(
+        SetupTwoFactorCommand $command
+    ): SetupTwoFactorCommandResponse {
         $user = $this->resolveUser($command->userEmail);
 
         if ($user->isTwoFactorEnabled()) {
@@ -39,11 +40,9 @@ final readonly class SetupTwoFactorCommandHandler implements CommandHandlerInter
         );
         $this->userRepository->save($user);
 
-        $command->setResponse(
-            new SetupTwoFactorCommandResponse(
-                $totpData['otpauth_uri'],
-                $secret
-            )
+        return new SetupTwoFactorCommandResponse(
+            $totpData['otpauth_uri'],
+            $secret
         );
     }
 

--- a/src/User/Application/CommandHandler/SignInCommandHandler.php
+++ b/src/User/Application/CommandHandler/SignInCommandHandler.php
@@ -37,7 +37,7 @@ final class SignInCommandHandler implements CommandHandlerInterface
     ) {
     }
 
-    public function __invoke(SignInCommand $command): void
+    public function __invoke(SignInCommand $command): SignInCommandResponse
     {
         $authenticated = $this->credentialValidator->validate(
             $command->email,
@@ -49,32 +49,28 @@ final class SignInCommandHandler implements CommandHandlerInterface
         $now = new DateTimeImmutable();
 
         if ($authenticated->isTwoFactorEnabled()) {
-            $this->handleTwoFactorPath($authenticated, $command, $now);
-
-            return;
+            return $this->handleTwoFactorPath($authenticated, $command, $now);
         }
 
-        $this->handleDirectSignIn($authenticated, $command, $now);
+        return $this->handleDirectSignIn($authenticated, $command, $now);
     }
 
     private function handleTwoFactorPath(
         User $user,
         SignInCommand $command,
         DateTimeImmutable $now
-    ): void {
+    ): SignInCommandResponse {
         $pending = $this->createPendingTwoFactor($user->getId(), $now, $command->rememberMe);
         $this->pendingTwoFactorRepository->save($pending);
 
-        $command->setResponse(
-            new SignInCommandResponse(true, null, null, $pending->getId())
-        );
+        return new SignInCommandResponse(true, null, null, $pending->getId());
     }
 
     private function handleDirectSignIn(
         User $user,
         SignInCommand $command,
         DateTimeImmutable $now
-    ): void {
+    ): SignInCommandResponse {
         $issued = $this->issuedSessionFactory->create(
             $user,
             $command->ipAddress,
@@ -83,12 +79,6 @@ final class SignInCommandHandler implements CommandHandlerInterface
             $now
         );
 
-        $command->setResponse(new SignInCommandResponse(
-            false,
-            $issued->accessToken,
-            $issued->refreshToken
-        ));
-
         $this->signInPublisher->publishSignedIn(
             $user->getId(),
             $user->getEmail(),
@@ -96,6 +86,12 @@ final class SignInCommandHandler implements CommandHandlerInterface
             $command->ipAddress,
             $command->userAgent,
             false
+        );
+
+        return new SignInCommandResponse(
+            false,
+            $issued->accessToken,
+            $issued->refreshToken
         );
     }
 

--- a/src/User/Application/Controller/ConfirmPasswordResetController.php
+++ b/src/User/Application/Controller/ConfirmPasswordResetController.php
@@ -6,6 +6,7 @@ namespace App\User\Application\Controller;
 
 use App\Shared\Domain\Bus\Command\CommandBusInterface;
 use App\User\Application\Command\ConfirmPasswordResetCommand;
+use App\User\Application\DTO\ConfirmPasswordResetCommandResponse;
 use App\User\Application\DTO\ConfirmPasswordResetDto;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -26,7 +27,8 @@ final class ConfirmPasswordResetController extends AbstractController
             $confirmPasswordResetDto->token,
             $confirmPasswordResetDto->newPassword
         );
-        $this->commandBus->dispatch($command);
+        $commandResponse = $this->commandBus->dispatch($command);
+        assert($commandResponse instanceof ConfirmPasswordResetCommandResponse);
 
         return new JsonResponse(null, 204);
     }

--- a/src/User/Application/Controller/ConfirmPasswordResetController.php
+++ b/src/User/Application/Controller/ConfirmPasswordResetController.php
@@ -28,7 +28,7 @@ final class ConfirmPasswordResetController extends AbstractController
             $confirmPasswordResetDto->token,
             $confirmPasswordResetDto->newPassword
         );
-        CommandResponseTypeGuard::expect(
+        (new CommandResponseTypeGuard())->expect(
             $this->commandBus->dispatch($command),
             ConfirmPasswordResetCommandResponse::class
         );

--- a/src/User/Application/Controller/ConfirmPasswordResetController.php
+++ b/src/User/Application/Controller/ConfirmPasswordResetController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\User\Application\Controller;
 
+use App\Shared\Application\Bus\Command\CommandResponseTypeGuard;
 use App\Shared\Domain\Bus\Command\CommandBusInterface;
 use App\User\Application\Command\ConfirmPasswordResetCommand;
 use App\User\Application\DTO\ConfirmPasswordResetCommandResponse;
@@ -27,8 +28,10 @@ final class ConfirmPasswordResetController extends AbstractController
             $confirmPasswordResetDto->token,
             $confirmPasswordResetDto->newPassword
         );
-        $commandResponse = $this->commandBus->dispatch($command);
-        assert($commandResponse instanceof ConfirmPasswordResetCommandResponse);
+        CommandResponseTypeGuard::expect(
+            $this->commandBus->dispatch($command),
+            ConfirmPasswordResetCommandResponse::class
+        );
 
         return new JsonResponse(null, 204);
     }

--- a/src/User/Application/Controller/ConfirmPasswordResetController.php
+++ b/src/User/Application/Controller/ConfirmPasswordResetController.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\User\Application\Controller;
 
-use App\Shared\Application\Bus\Command\CommandResponseTypeGuard;
+use App\Shared\Application\Bus\Guard\CommandResponseTypeGuard;
 use App\Shared\Domain\Bus\Command\CommandBusInterface;
 use App\User\Application\Command\ConfirmPasswordResetCommand;
 use App\User\Application\DTO\ConfirmPasswordResetCommandResponse;
@@ -17,6 +17,7 @@ final class ConfirmPasswordResetController extends AbstractController
 {
     public function __construct(
         private readonly CommandBusInterface $commandBus,
+        private readonly CommandResponseTypeGuard $commandResponseTypeGuard,
     ) {
     }
 
@@ -28,7 +29,7 @@ final class ConfirmPasswordResetController extends AbstractController
             $confirmPasswordResetDto->token,
             $confirmPasswordResetDto->newPassword
         );
-        (new CommandResponseTypeGuard())->expect(
+        $this->commandResponseTypeGuard->expect(
             $this->commandBus->dispatch($command),
             ConfirmPasswordResetCommandResponse::class
         );

--- a/src/User/Application/DTO/CompleteTwoFactorCommandResponse.php
+++ b/src/User/Application/DTO/CompleteTwoFactorCommandResponse.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace App\User\Application\DTO;
 
-final class CompleteTwoFactorCommandResponse
+use App\Shared\Domain\Bus\Command\CommandResponseInterface;
+
+final class CompleteTwoFactorCommandResponse implements CommandResponseInterface
 {
     private bool $rememberMe = false;
 

--- a/src/User/Application/DTO/ConfirmPasswordResetCommandResponse.php
+++ b/src/User/Application/DTO/ConfirmPasswordResetCommandResponse.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\User\Application\DTO;
 
-final class ConfirmPasswordResetCommandResponse
+use App\Shared\Domain\Bus\Command\CommandResponseInterface;
+
+final class ConfirmPasswordResetCommandResponse implements CommandResponseInterface
 {
 }

--- a/src/User/Application/DTO/ConfirmTwoFactorCommandResponse.php
+++ b/src/User/Application/DTO/ConfirmTwoFactorCommandResponse.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace App\User\Application\DTO;
 
-final readonly class ConfirmTwoFactorCommandResponse
+use App\Shared\Domain\Bus\Command\CommandResponseInterface;
+
+final readonly class ConfirmTwoFactorCommandResponse implements
+    CommandResponseInterface
 {
     /**
      * @param array<string> $recoveryCodes

--- a/src/User/Application/DTO/RefreshTokenCommandResponse.php
+++ b/src/User/Application/DTO/RefreshTokenCommandResponse.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace App\User\Application\DTO;
 
-final readonly class RefreshTokenCommandResponse
+use App\Shared\Domain\Bus\Command\CommandResponseInterface;
+
+final readonly class RefreshTokenCommandResponse implements CommandResponseInterface
 {
     public function __construct(
         private string $accessToken,

--- a/src/User/Application/DTO/RegenerateRecoveryCodesCommandResponse.php
+++ b/src/User/Application/DTO/RegenerateRecoveryCodesCommandResponse.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace App\User\Application\DTO;
 
-final readonly class RegenerateRecoveryCodesCommandResponse
+use App\Shared\Domain\Bus\Command\CommandResponseInterface;
+
+final readonly class RegenerateRecoveryCodesCommandResponse implements
+    CommandResponseInterface
 {
     /**
      * @param array<string> $recoveryCodes

--- a/src/User/Application/DTO/RequestPasswordResetCommandResponse.php
+++ b/src/User/Application/DTO/RequestPasswordResetCommandResponse.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\User\Application\DTO;
 
-final class RequestPasswordResetCommandResponse
+use App\Shared\Domain\Bus\Command\CommandResponseInterface;
+
+final class RequestPasswordResetCommandResponse implements CommandResponseInterface
 {
 }

--- a/src/User/Application/DTO/SetupTwoFactorCommandResponse.php
+++ b/src/User/Application/DTO/SetupTwoFactorCommandResponse.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace App\User\Application\DTO;
 
-final readonly class SetupTwoFactorCommandResponse
+use App\Shared\Domain\Bus\Command\CommandResponseInterface;
+
+final readonly class SetupTwoFactorCommandResponse implements
+    CommandResponseInterface
 {
     public function __construct(
         private string $otpauthUri,

--- a/src/User/Application/DTO/SignInCommandResponse.php
+++ b/src/User/Application/DTO/SignInCommandResponse.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace App\User\Application\DTO;
 
-final readonly class SignInCommandResponse
+use App\Shared\Domain\Bus\Command\CommandResponseInterface;
+
+final readonly class SignInCommandResponse implements CommandResponseInterface
 {
     public function __construct(
         private bool $twoFactorEnabled,

--- a/src/User/Application/Processor/CompleteTwoFactorProcessor.php
+++ b/src/User/Application/Processor/CompleteTwoFactorProcessor.php
@@ -43,19 +43,7 @@ final readonly class CompleteTwoFactorProcessor implements ProcessorInterface
         array $uriVariables = [],
         array $context = []
     ): Response {
-        $request = $this->httpRequestContextResolver->resolveRequest($context['request'] ?? null);
-
-        $command = $this->completeTwoFactorCommandFactory->create(
-            $data->pendingSessionIdValue(),
-            $data->twoFactorCodeValue(),
-            $this->httpRequestContextResolver->resolveIpAddress($request),
-            $this->httpRequestContextResolver->resolveUserAgent($request)
-        );
-
-        $commandResponse = (new CommandResponseTypeGuard())->expect(
-            $this->commandBus->dispatch($command),
-            CompleteTwoFactorCommandResponse::class
-        );
+        $commandResponse = $this->dispatchCommand($data, $context);
 
         $response = new JsonResponse($this->buildResponseBody($commandResponse));
         $accessToken = $commandResponse->getAccessToken();
@@ -69,6 +57,28 @@ final readonly class CompleteTwoFactorProcessor implements ProcessorInterface
         }
 
         return $response;
+    }
+
+    /**
+     * @param array{request?: object|null, ...} $context
+     */
+    private function dispatchCommand(
+        CompleteTwoFactorDto $data,
+        array $context
+    ): CompleteTwoFactorCommandResponse {
+        $request = $this->httpRequestContextResolver->resolveRequest($context['request'] ?? null);
+
+        $command = $this->completeTwoFactorCommandFactory->create(
+            $data->pendingSessionIdValue(),
+            $data->twoFactorCodeValue(),
+            $this->httpRequestContextResolver->resolveIpAddress($request),
+            $this->httpRequestContextResolver->resolveUserAgent($request)
+        );
+
+        return (new CommandResponseTypeGuard())->expect(
+            $this->commandBus->dispatch($command),
+            CompleteTwoFactorCommandResponse::class
+        );
     }
 
     /**

--- a/src/User/Application/Processor/CompleteTwoFactorProcessor.php
+++ b/src/User/Application/Processor/CompleteTwoFactorProcessor.php
@@ -51,8 +51,8 @@ final readonly class CompleteTwoFactorProcessor implements ProcessorInterface
             $this->httpRequestContextResolver->resolveUserAgent($request)
         );
 
-        $this->commandBus->dispatch($command);
-        $commandResponse = $command->getResponse();
+        $commandResponse = $this->commandBus->dispatch($command);
+        assert($commandResponse instanceof CompleteTwoFactorCommandResponse);
 
         $response = new JsonResponse($this->buildResponseBody($commandResponse));
         $accessToken = $commandResponse->getAccessToken();

--- a/src/User/Application/Processor/CompleteTwoFactorProcessor.php
+++ b/src/User/Application/Processor/CompleteTwoFactorProcessor.php
@@ -6,6 +6,7 @@ namespace App\User\Application\Processor;
 
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProcessorInterface;
+use App\Shared\Application\Bus\Command\CommandResponseTypeGuard;
 use App\Shared\Domain\Bus\Command\CommandBusInterface;
 use App\User\Application\DTO\CompleteTwoFactorCommandResponse;
 use App\User\Application\DTO\CompleteTwoFactorDto;
@@ -51,8 +52,10 @@ final readonly class CompleteTwoFactorProcessor implements ProcessorInterface
             $this->httpRequestContextResolver->resolveUserAgent($request)
         );
 
-        $commandResponse = $this->commandBus->dispatch($command);
-        assert($commandResponse instanceof CompleteTwoFactorCommandResponse);
+        $commandResponse = CommandResponseTypeGuard::expect(
+            $this->commandBus->dispatch($command),
+            CompleteTwoFactorCommandResponse::class
+        );
 
         $response = new JsonResponse($this->buildResponseBody($commandResponse));
         $accessToken = $commandResponse->getAccessToken();

--- a/src/User/Application/Processor/CompleteTwoFactorProcessor.php
+++ b/src/User/Application/Processor/CompleteTwoFactorProcessor.php
@@ -6,7 +6,7 @@ namespace App\User\Application\Processor;
 
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProcessorInterface;
-use App\Shared\Application\Bus\Command\CommandResponseTypeGuard;
+use App\Shared\Application\Bus\Guard\CommandResponseTypeGuard;
 use App\Shared\Domain\Bus\Command\CommandBusInterface;
 use App\User\Application\DTO\CompleteTwoFactorCommandResponse;
 use App\User\Application\DTO\CompleteTwoFactorDto;
@@ -23,6 +23,7 @@ final readonly class CompleteTwoFactorProcessor implements ProcessorInterface
 {
     public function __construct(
         private CommandBusInterface $commandBus,
+        private CommandResponseTypeGuard $commandResponseTypeGuard,
         private CompleteTwoFactorCommandFactoryInterface $completeTwoFactorCommandFactory,
         private HttpRequestContextResolverInterface $httpRequestContextResolver,
         private AuthCookieFactoryInterface $authCookieFactory,
@@ -75,7 +76,7 @@ final readonly class CompleteTwoFactorProcessor implements ProcessorInterface
             $this->httpRequestContextResolver->resolveUserAgent($request)
         );
 
-        return (new CommandResponseTypeGuard())->expect(
+        return $this->commandResponseTypeGuard->expect(
             $this->commandBus->dispatch($command),
             CompleteTwoFactorCommandResponse::class
         );

--- a/src/User/Application/Processor/CompleteTwoFactorProcessor.php
+++ b/src/User/Application/Processor/CompleteTwoFactorProcessor.php
@@ -52,7 +52,7 @@ final readonly class CompleteTwoFactorProcessor implements ProcessorInterface
             $this->httpRequestContextResolver->resolveUserAgent($request)
         );
 
-        $commandResponse = CommandResponseTypeGuard::expect(
+        $commandResponse = (new CommandResponseTypeGuard())->expect(
             $this->commandBus->dispatch($command),
             CompleteTwoFactorCommandResponse::class
         );

--- a/src/User/Application/Processor/CompleteTwoFactorProcessor.php
+++ b/src/User/Application/Processor/CompleteTwoFactorProcessor.php
@@ -6,13 +6,10 @@ namespace App\User\Application\Processor;
 
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProcessorInterface;
-use App\Shared\Application\Bus\Guard\CommandResponseTypeGuard;
-use App\Shared\Domain\Bus\Command\CommandBusInterface;
 use App\User\Application\DTO\CompleteTwoFactorCommandResponse;
 use App\User\Application\DTO\CompleteTwoFactorDto;
 use App\User\Application\Factory\AuthCookieFactoryInterface;
-use App\User\Application\Factory\CompleteTwoFactorCommandFactoryInterface;
-use App\User\Application\Resolver\HttpRequestContextResolverInterface;
+use App\User\Application\Service\CompleteTwoFactorCommandDispatcher;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -22,10 +19,7 @@ use Symfony\Component\HttpFoundation\Response;
 final readonly class CompleteTwoFactorProcessor implements ProcessorInterface
 {
     public function __construct(
-        private CommandBusInterface $commandBus,
-        private CommandResponseTypeGuard $commandResponseTypeGuard,
-        private CompleteTwoFactorCommandFactoryInterface $completeTwoFactorCommandFactory,
-        private HttpRequestContextResolverInterface $httpRequestContextResolver,
+        private CompleteTwoFactorCommandDispatcher $commandDispatcher,
         private AuthCookieFactoryInterface $authCookieFactory,
     ) {
     }
@@ -44,7 +38,7 @@ final readonly class CompleteTwoFactorProcessor implements ProcessorInterface
         array $uriVariables = [],
         array $context = []
     ): Response {
-        $commandResponse = $this->dispatchCommand($data, $context);
+        $commandResponse = $this->commandDispatcher->dispatch($data, $context);
 
         $response = new JsonResponse($this->buildResponseBody($commandResponse));
         $accessToken = $commandResponse->getAccessToken();
@@ -58,28 +52,6 @@ final readonly class CompleteTwoFactorProcessor implements ProcessorInterface
         }
 
         return $response;
-    }
-
-    /**
-     * @param array{request?: object|null, ...} $context
-     */
-    private function dispatchCommand(
-        CompleteTwoFactorDto $data,
-        array $context
-    ): CompleteTwoFactorCommandResponse {
-        $request = $this->httpRequestContextResolver->resolveRequest($context['request'] ?? null);
-
-        $command = $this->completeTwoFactorCommandFactory->create(
-            $data->pendingSessionIdValue(),
-            $data->twoFactorCodeValue(),
-            $this->httpRequestContextResolver->resolveIpAddress($request),
-            $this->httpRequestContextResolver->resolveUserAgent($request)
-        );
-
-        return $this->commandResponseTypeGuard->expect(
-            $this->commandBus->dispatch($command),
-            CompleteTwoFactorCommandResponse::class
-        );
     }
 
     /**

--- a/src/User/Application/Processor/ConfirmTwoFactorProcessor.php
+++ b/src/User/Application/Processor/ConfirmTwoFactorProcessor.php
@@ -50,7 +50,7 @@ final readonly class ConfirmTwoFactorProcessor implements ProcessorInterface
             $sessionId
         );
 
-        $response = CommandResponseTypeGuard::expect(
+        $response = (new CommandResponseTypeGuard())->expect(
             $this->commandBus->dispatch($command),
             ConfirmTwoFactorCommandResponse::class
         );

--- a/src/User/Application/Processor/ConfirmTwoFactorProcessor.php
+++ b/src/User/Application/Processor/ConfirmTwoFactorProcessor.php
@@ -6,12 +6,8 @@ namespace App\User\Application\Processor;
 
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProcessorInterface;
-use App\Shared\Application\Bus\Guard\CommandResponseTypeGuard;
-use App\Shared\Domain\Bus\Command\CommandBusInterface;
-use App\User\Application\DTO\ConfirmTwoFactorCommandResponse;
 use App\User\Application\DTO\ConfirmTwoFactorDto;
-use App\User\Application\Factory\ConfirmTwoFactorCommandFactoryInterface;
-use App\User\Application\Resolver\CurrentUserIdentityResolver;
+use App\User\Application\Service\ConfirmTwoFactorCommandDispatcher;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -21,10 +17,7 @@ use Symfony\Component\HttpFoundation\Response;
 final readonly class ConfirmTwoFactorProcessor implements ProcessorInterface
 {
     public function __construct(
-        private CommandBusInterface $commandBus,
-        private CommandResponseTypeGuard $commandResponseTypeGuard,
-        private CurrentUserIdentityResolver $userIdentityResolver,
-        private ConfirmTwoFactorCommandFactoryInterface $confirmTwoFactorCommandFactory,
+        private ConfirmTwoFactorCommandDispatcher $commandDispatcher,
     ) {
     }
 
@@ -42,19 +35,7 @@ final readonly class ConfirmTwoFactorProcessor implements ProcessorInterface
         array $uriVariables = [],
         array $context = []
     ): Response {
-        $email = $this->userIdentityResolver->resolveEmail();
-        $sessionId = $this->userIdentityResolver->resolveSessionId();
-
-        $command = $this->confirmTwoFactorCommandFactory->create(
-            $email,
-            $data->twoFactorCodeValue(),
-            $sessionId
-        );
-
-        $response = $this->commandResponseTypeGuard->expect(
-            $this->commandBus->dispatch($command),
-            ConfirmTwoFactorCommandResponse::class
-        );
+        $response = $this->commandDispatcher->dispatch($data);
 
         return new JsonResponse(
             [

--- a/src/User/Application/Processor/ConfirmTwoFactorProcessor.php
+++ b/src/User/Application/Processor/ConfirmTwoFactorProcessor.php
@@ -7,6 +7,7 @@ namespace App\User\Application\Processor;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProcessorInterface;
 use App\Shared\Domain\Bus\Command\CommandBusInterface;
+use App\User\Application\DTO\ConfirmTwoFactorCommandResponse;
 use App\User\Application\DTO\ConfirmTwoFactorDto;
 use App\User\Application\Factory\ConfirmTwoFactorCommandFactoryInterface;
 use App\User\Application\Resolver\CurrentUserIdentityResolver;
@@ -48,13 +49,12 @@ final readonly class ConfirmTwoFactorProcessor implements ProcessorInterface
             $sessionId
         );
 
-        $this->commandBus->dispatch($command);
+        $response = $this->commandBus->dispatch($command);
+        assert($response instanceof ConfirmTwoFactorCommandResponse);
 
         return new JsonResponse(
             [
-                'recovery_codes' => $command
-                    ->getResponse()
-                    ->getRecoveryCodes(),
+                'recovery_codes' => $response->getRecoveryCodes(),
             ],
             Response::HTTP_OK
         );

--- a/src/User/Application/Processor/ConfirmTwoFactorProcessor.php
+++ b/src/User/Application/Processor/ConfirmTwoFactorProcessor.php
@@ -6,7 +6,7 @@ namespace App\User\Application\Processor;
 
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProcessorInterface;
-use App\Shared\Application\Bus\Command\CommandResponseTypeGuard;
+use App\Shared\Application\Bus\Guard\CommandResponseTypeGuard;
 use App\Shared\Domain\Bus\Command\CommandBusInterface;
 use App\User\Application\DTO\ConfirmTwoFactorCommandResponse;
 use App\User\Application\DTO\ConfirmTwoFactorDto;
@@ -22,6 +22,7 @@ final readonly class ConfirmTwoFactorProcessor implements ProcessorInterface
 {
     public function __construct(
         private CommandBusInterface $commandBus,
+        private CommandResponseTypeGuard $commandResponseTypeGuard,
         private CurrentUserIdentityResolver $userIdentityResolver,
         private ConfirmTwoFactorCommandFactoryInterface $confirmTwoFactorCommandFactory,
     ) {
@@ -50,7 +51,7 @@ final readonly class ConfirmTwoFactorProcessor implements ProcessorInterface
             $sessionId
         );
 
-        $response = (new CommandResponseTypeGuard())->expect(
+        $response = $this->commandResponseTypeGuard->expect(
             $this->commandBus->dispatch($command),
             ConfirmTwoFactorCommandResponse::class
         );

--- a/src/User/Application/Processor/ConfirmTwoFactorProcessor.php
+++ b/src/User/Application/Processor/ConfirmTwoFactorProcessor.php
@@ -6,6 +6,7 @@ namespace App\User\Application\Processor;
 
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProcessorInterface;
+use App\Shared\Application\Bus\Command\CommandResponseTypeGuard;
 use App\Shared\Domain\Bus\Command\CommandBusInterface;
 use App\User\Application\DTO\ConfirmTwoFactorCommandResponse;
 use App\User\Application\DTO\ConfirmTwoFactorDto;
@@ -49,8 +50,10 @@ final readonly class ConfirmTwoFactorProcessor implements ProcessorInterface
             $sessionId
         );
 
-        $response = $this->commandBus->dispatch($command);
-        assert($response instanceof ConfirmTwoFactorCommandResponse);
+        $response = CommandResponseTypeGuard::expect(
+            $this->commandBus->dispatch($command),
+            ConfirmTwoFactorCommandResponse::class
+        );
 
         return new JsonResponse(
             [

--- a/src/User/Application/Processor/RefreshTokenProcessor.php
+++ b/src/User/Application/Processor/RefreshTokenProcessor.php
@@ -39,9 +39,9 @@ final readonly class RefreshTokenProcessor implements ProcessorInterface
         array $context = []
     ): Response {
         $command = $this->refreshTokenCommandFactory->create($data->refreshTokenValue());
-        $this->commandBus->dispatch($command);
+        $commandResponse = $this->commandBus->dispatch($command);
+        assert($commandResponse instanceof RefreshTokenCommandResponse);
 
-        $commandResponse = $command->getResponse();
         return new JsonResponse(
             $this->buildResponseBody($commandResponse)
         );

--- a/src/User/Application/Processor/RefreshTokenProcessor.php
+++ b/src/User/Application/Processor/RefreshTokenProcessor.php
@@ -40,7 +40,7 @@ final readonly class RefreshTokenProcessor implements ProcessorInterface
         array $context = []
     ): Response {
         $command = $this->refreshTokenCommandFactory->create($data->refreshTokenValue());
-        $commandResponse = CommandResponseTypeGuard::expect(
+        $commandResponse = (new CommandResponseTypeGuard())->expect(
             $this->commandBus->dispatch($command),
             RefreshTokenCommandResponse::class
         );

--- a/src/User/Application/Processor/RefreshTokenProcessor.php
+++ b/src/User/Application/Processor/RefreshTokenProcessor.php
@@ -6,7 +6,7 @@ namespace App\User\Application\Processor;
 
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProcessorInterface;
-use App\Shared\Application\Bus\Command\CommandResponseTypeGuard;
+use App\Shared\Application\Bus\Guard\CommandResponseTypeGuard;
 use App\Shared\Domain\Bus\Command\CommandBusInterface;
 use App\User\Application\DTO\RefreshTokenCommandResponse;
 use App\User\Application\DTO\RefreshTokenDto;
@@ -21,6 +21,7 @@ final readonly class RefreshTokenProcessor implements ProcessorInterface
 {
     public function __construct(
         private CommandBusInterface $commandBus,
+        private CommandResponseTypeGuard $commandResponseTypeGuard,
         private RefreshTokenCommandFactoryInterface $refreshTokenCommandFactory,
     ) {
     }
@@ -40,7 +41,7 @@ final readonly class RefreshTokenProcessor implements ProcessorInterface
         array $context = []
     ): Response {
         $command = $this->refreshTokenCommandFactory->create($data->refreshTokenValue());
-        $commandResponse = (new CommandResponseTypeGuard())->expect(
+        $commandResponse = $this->commandResponseTypeGuard->expect(
             $this->commandBus->dispatch($command),
             RefreshTokenCommandResponse::class
         );

--- a/src/User/Application/Processor/RefreshTokenProcessor.php
+++ b/src/User/Application/Processor/RefreshTokenProcessor.php
@@ -6,6 +6,7 @@ namespace App\User\Application\Processor;
 
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProcessorInterface;
+use App\Shared\Application\Bus\Command\CommandResponseTypeGuard;
 use App\Shared\Domain\Bus\Command\CommandBusInterface;
 use App\User\Application\DTO\RefreshTokenCommandResponse;
 use App\User\Application\DTO\RefreshTokenDto;
@@ -39,8 +40,10 @@ final readonly class RefreshTokenProcessor implements ProcessorInterface
         array $context = []
     ): Response {
         $command = $this->refreshTokenCommandFactory->create($data->refreshTokenValue());
-        $commandResponse = $this->commandBus->dispatch($command);
-        assert($commandResponse instanceof RefreshTokenCommandResponse);
+        $commandResponse = CommandResponseTypeGuard::expect(
+            $this->commandBus->dispatch($command),
+            RefreshTokenCommandResponse::class
+        );
 
         return new JsonResponse(
             $this->buildResponseBody($commandResponse)

--- a/src/User/Application/Processor/RegenerateRecoveryCodesProcessor.php
+++ b/src/User/Application/Processor/RegenerateRecoveryCodesProcessor.php
@@ -6,7 +6,7 @@ namespace App\User\Application\Processor;
 
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProcessorInterface;
-use App\Shared\Application\Bus\Command\CommandResponseTypeGuard;
+use App\Shared\Application\Bus\Guard\CommandResponseTypeGuard;
 use App\Shared\Domain\Bus\Command\CommandBusInterface;
 use App\User\Application\DTO\RegenerateRecoveryCodesCommandResponse;
 use App\User\Application\DTO\RegenerateRecoveryCodesDto;
@@ -23,6 +23,7 @@ final readonly class RegenerateRecoveryCodesProcessor implements
 {
     public function __construct(
         private CommandBusInterface $commandBus,
+        private CommandResponseTypeGuard $commandResponseTypeGuard,
         private CurrentUserIdentityResolver $userIdentityResolver,
         private RegenerateRecoveryCodesCommandFactoryInterface $regenerateCodesCommandFactory,
     ) {
@@ -50,7 +51,7 @@ final readonly class RegenerateRecoveryCodesProcessor implements
             $sessionId
         );
 
-        $response = (new CommandResponseTypeGuard())->expect(
+        $response = $this->commandResponseTypeGuard->expect(
             $this->commandBus->dispatch($command),
             RegenerateRecoveryCodesCommandResponse::class
         );

--- a/src/User/Application/Processor/RegenerateRecoveryCodesProcessor.php
+++ b/src/User/Application/Processor/RegenerateRecoveryCodesProcessor.php
@@ -50,7 +50,7 @@ final readonly class RegenerateRecoveryCodesProcessor implements
             $sessionId
         );
 
-        $response = CommandResponseTypeGuard::expect(
+        $response = (new CommandResponseTypeGuard())->expect(
             $this->commandBus->dispatch($command),
             RegenerateRecoveryCodesCommandResponse::class
         );

--- a/src/User/Application/Processor/RegenerateRecoveryCodesProcessor.php
+++ b/src/User/Application/Processor/RegenerateRecoveryCodesProcessor.php
@@ -7,6 +7,7 @@ namespace App\User\Application\Processor;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProcessorInterface;
 use App\Shared\Domain\Bus\Command\CommandBusInterface;
+use App\User\Application\DTO\RegenerateRecoveryCodesCommandResponse;
 use App\User\Application\DTO\RegenerateRecoveryCodesDto;
 use App\User\Application\Factory\RegenerateRecoveryCodesCommandFactoryInterface;
 use App\User\Application\Resolver\CurrentUserIdentityResolver;
@@ -48,13 +49,12 @@ final readonly class RegenerateRecoveryCodesProcessor implements
             $sessionId
         );
 
-        $this->commandBus->dispatch($command);
+        $response = $this->commandBus->dispatch($command);
+        assert($response instanceof RegenerateRecoveryCodesCommandResponse);
 
         return new JsonResponse(
             [
-                'recovery_codes' => $command
-                    ->getResponse()
-                    ->getRecoveryCodes(),
+                'recovery_codes' => $response->getRecoveryCodes(),
             ],
             Response::HTTP_OK
         );

--- a/src/User/Application/Processor/RegenerateRecoveryCodesProcessor.php
+++ b/src/User/Application/Processor/RegenerateRecoveryCodesProcessor.php
@@ -6,6 +6,7 @@ namespace App\User\Application\Processor;
 
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProcessorInterface;
+use App\Shared\Application\Bus\Command\CommandResponseTypeGuard;
 use App\Shared\Domain\Bus\Command\CommandBusInterface;
 use App\User\Application\DTO\RegenerateRecoveryCodesCommandResponse;
 use App\User\Application\DTO\RegenerateRecoveryCodesDto;
@@ -49,8 +50,10 @@ final readonly class RegenerateRecoveryCodesProcessor implements
             $sessionId
         );
 
-        $response = $this->commandBus->dispatch($command);
-        assert($response instanceof RegenerateRecoveryCodesCommandResponse);
+        $response = CommandResponseTypeGuard::expect(
+            $this->commandBus->dispatch($command),
+            RegenerateRecoveryCodesCommandResponse::class
+        );
 
         return new JsonResponse(
             [

--- a/src/User/Application/Processor/RegisterUserBatchProcessor.php
+++ b/src/User/Application/Processor/RegisterUserBatchProcessor.php
@@ -6,6 +6,7 @@ namespace App\User\Application\Processor;
 
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProcessorInterface;
+use App\Shared\Application\Bus\Command\CommandResponseTypeGuard;
 use App\Shared\Domain\Bus\Command\CommandBusInterface;
 use App\User\Application\DTO\RegisterUserBatchCommandResponse;
 use App\User\Application\DTO\UserRegisterBatchDto;
@@ -45,8 +46,10 @@ final readonly class RegisterUserBatchProcessor implements ProcessorInterface
         $command = $this->commandFactory->create(
             new UserCollection($data->users)
         );
-        $commandResponse = $this->commandBus->dispatch($command);
-        assert($commandResponse instanceof RegisterUserBatchCommandResponse);
+        $commandResponse = CommandResponseTypeGuard::expect(
+            $this->commandBus->dispatch($command),
+            RegisterUserBatchCommandResponse::class
+        );
 
         return new Response(
             content: $this->serializer->serialize(

--- a/src/User/Application/Processor/RegisterUserBatchProcessor.php
+++ b/src/User/Application/Processor/RegisterUserBatchProcessor.php
@@ -6,7 +6,7 @@ namespace App\User\Application\Processor;
 
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProcessorInterface;
-use App\Shared\Application\Bus\Command\CommandResponseTypeGuard;
+use App\Shared\Application\Bus\Guard\CommandResponseTypeGuard;
 use App\Shared\Domain\Bus\Command\CommandBusInterface;
 use App\User\Application\DTO\RegisterUserBatchCommandResponse;
 use App\User\Application\DTO\UserRegisterBatchDto;
@@ -25,6 +25,7 @@ final readonly class RegisterUserBatchProcessor implements ProcessorInterface
     public function __construct(
         private SerializerInterface $serializer,
         private CommandBusInterface $commandBus,
+        private CommandResponseTypeGuard $commandResponseTypeGuard,
         private RegisterUserBatchCommandFactoryInterface $commandFactory
     ) {
     }
@@ -46,7 +47,7 @@ final readonly class RegisterUserBatchProcessor implements ProcessorInterface
         $command = $this->commandFactory->create(
             new UserCollection($data->users)
         );
-        $commandResponse = (new CommandResponseTypeGuard())->expect(
+        $commandResponse = $this->commandResponseTypeGuard->expect(
             $this->commandBus->dispatch($command),
             RegisterUserBatchCommandResponse::class
         );

--- a/src/User/Application/Processor/RegisterUserBatchProcessor.php
+++ b/src/User/Application/Processor/RegisterUserBatchProcessor.php
@@ -46,7 +46,7 @@ final readonly class RegisterUserBatchProcessor implements ProcessorInterface
         $command = $this->commandFactory->create(
             new UserCollection($data->users)
         );
-        $commandResponse = CommandResponseTypeGuard::expect(
+        $commandResponse = (new CommandResponseTypeGuard())->expect(
             $this->commandBus->dispatch($command),
             RegisterUserBatchCommandResponse::class
         );

--- a/src/User/Application/Processor/RegisterUserBatchProcessor.php
+++ b/src/User/Application/Processor/RegisterUserBatchProcessor.php
@@ -7,6 +7,7 @@ namespace App\User\Application\Processor;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProcessorInterface;
 use App\Shared\Domain\Bus\Command\CommandBusInterface;
+use App\User\Application\DTO\RegisterUserBatchCommandResponse;
 use App\User\Application\DTO\UserRegisterBatchDto;
 use App\User\Application\Factory\RegisterUserBatchCommandFactoryInterface;
 use App\User\Domain\Collection\UserCollection;
@@ -44,11 +45,12 @@ final readonly class RegisterUserBatchProcessor implements ProcessorInterface
         $command = $this->commandFactory->create(
             new UserCollection($data->users)
         );
-        $this->commandBus->dispatch($command);
+        $commandResponse = $this->commandBus->dispatch($command);
+        assert($commandResponse instanceof RegisterUserBatchCommandResponse);
 
         return new Response(
             content: $this->serializer->serialize(
-                $command->getResponse()->users,
+                $commandResponse->users,
                 JsonEncoder::FORMAT,
                 ['groups' => $normalizationGroups]
             ),

--- a/src/User/Application/Processor/RegisterUserProcessor.php
+++ b/src/User/Application/Processor/RegisterUserProcessor.php
@@ -7,6 +7,7 @@ namespace App\User\Application\Processor;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProcessorInterface;
 use App\Shared\Domain\Bus\Command\CommandBusInterface;
+use App\User\Application\DTO\RegisterUserCommandResponse;
 use App\User\Application\DTO\UserRegisterDto;
 use App\User\Application\Factory\SignUpCommandFactoryInterface;
 use App\User\Domain\Entity\User;
@@ -39,8 +40,9 @@ final readonly class RegisterUserProcessor implements ProcessorInterface
             $data->initials,
             $data->password
         );
-        $this->commandBus->dispatch($command);
+        $commandResponse = $this->commandBus->dispatch($command);
+        assert($commandResponse instanceof RegisterUserCommandResponse);
 
-        return $command->getResponse()->createdUser;
+        return $commandResponse->createdUser;
     }
 }

--- a/src/User/Application/Processor/RegisterUserProcessor.php
+++ b/src/User/Application/Processor/RegisterUserProcessor.php
@@ -41,7 +41,7 @@ final readonly class RegisterUserProcessor implements ProcessorInterface
             $data->initials,
             $data->password
         );
-        $commandResponse = CommandResponseTypeGuard::expect(
+        $commandResponse = (new CommandResponseTypeGuard())->expect(
             $this->commandBus->dispatch($command),
             RegisterUserCommandResponse::class
         );

--- a/src/User/Application/Processor/RegisterUserProcessor.php
+++ b/src/User/Application/Processor/RegisterUserProcessor.php
@@ -6,7 +6,7 @@ namespace App\User\Application\Processor;
 
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProcessorInterface;
-use App\Shared\Application\Bus\Command\CommandResponseTypeGuard;
+use App\Shared\Application\Bus\Guard\CommandResponseTypeGuard;
 use App\Shared\Domain\Bus\Command\CommandBusInterface;
 use App\User\Application\DTO\RegisterUserCommandResponse;
 use App\User\Application\DTO\UserRegisterDto;
@@ -20,6 +20,7 @@ final readonly class RegisterUserProcessor implements ProcessorInterface
 {
     public function __construct(
         private CommandBusInterface $commandBus,
+        private CommandResponseTypeGuard $commandResponseTypeGuard,
         private SignUpCommandFactoryInterface $signUpCommandFactory
     ) {
     }
@@ -41,7 +42,7 @@ final readonly class RegisterUserProcessor implements ProcessorInterface
             $data->initials,
             $data->password
         );
-        $commandResponse = (new CommandResponseTypeGuard())->expect(
+        $commandResponse = $this->commandResponseTypeGuard->expect(
             $this->commandBus->dispatch($command),
             RegisterUserCommandResponse::class
         );

--- a/src/User/Application/Processor/RegisterUserProcessor.php
+++ b/src/User/Application/Processor/RegisterUserProcessor.php
@@ -6,6 +6,7 @@ namespace App\User\Application\Processor;
 
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProcessorInterface;
+use App\Shared\Application\Bus\Command\CommandResponseTypeGuard;
 use App\Shared\Domain\Bus\Command\CommandBusInterface;
 use App\User\Application\DTO\RegisterUserCommandResponse;
 use App\User\Application\DTO\UserRegisterDto;
@@ -40,8 +41,10 @@ final readonly class RegisterUserProcessor implements ProcessorInterface
             $data->initials,
             $data->password
         );
-        $commandResponse = $this->commandBus->dispatch($command);
-        assert($commandResponse instanceof RegisterUserCommandResponse);
+        $commandResponse = CommandResponseTypeGuard::expect(
+            $this->commandBus->dispatch($command),
+            RegisterUserCommandResponse::class
+        );
 
         return $commandResponse->createdUser;
     }

--- a/src/User/Application/Processor/SetupTwoFactorProcessor.php
+++ b/src/User/Application/Processor/SetupTwoFactorProcessor.php
@@ -53,7 +53,7 @@ final readonly class SetupTwoFactorProcessor implements ProcessorInterface
         $command = $this->setupTwoFactorCommandFactory->create(
             $this->userIdentityResolver->resolveEmail()
         );
-        $response = CommandResponseTypeGuard::expect(
+        $response = (new CommandResponseTypeGuard())->expect(
             $this->commandBus->dispatch($command),
             SetupTwoFactorCommandResponse::class
         );

--- a/src/User/Application/Processor/SetupTwoFactorProcessor.php
+++ b/src/User/Application/Processor/SetupTwoFactorProcessor.php
@@ -6,7 +6,7 @@ namespace App\User\Application\Processor;
 
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProcessorInterface;
-use App\Shared\Application\Bus\Command\CommandResponseTypeGuard;
+use App\Shared\Application\Bus\Guard\CommandResponseTypeGuard;
 use App\Shared\Application\Validator\Http\EmptyJsonObjectRequestValidator;
 use App\Shared\Domain\Bus\Command\CommandBusInterface;
 use App\User\Application\DTO\SetupTwoFactorCommandResponse;
@@ -24,6 +24,7 @@ final readonly class SetupTwoFactorProcessor implements ProcessorInterface
 {
     public function __construct(
         private CommandBusInterface $commandBus,
+        private CommandResponseTypeGuard $commandResponseTypeGuard,
         private CurrentUserIdentityResolver $userIdentityResolver,
         private SetupTwoFactorCommandFactoryInterface $setupTwoFactorCommandFactory,
         private HttpRequestContextResolverInterface $httpRequestContextResolver,
@@ -53,7 +54,7 @@ final readonly class SetupTwoFactorProcessor implements ProcessorInterface
         $command = $this->setupTwoFactorCommandFactory->create(
             $this->userIdentityResolver->resolveEmail()
         );
-        $response = (new CommandResponseTypeGuard())->expect(
+        $response = $this->commandResponseTypeGuard->expect(
             $this->commandBus->dispatch($command),
             SetupTwoFactorCommandResponse::class
         );

--- a/src/User/Application/Processor/SetupTwoFactorProcessor.php
+++ b/src/User/Application/Processor/SetupTwoFactorProcessor.php
@@ -6,6 +6,7 @@ namespace App\User\Application\Processor;
 
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProcessorInterface;
+use App\Shared\Application\Bus\Command\CommandResponseTypeGuard;
 use App\Shared\Application\Validator\Http\EmptyJsonObjectRequestValidator;
 use App\Shared\Domain\Bus\Command\CommandBusInterface;
 use App\User\Application\DTO\SetupTwoFactorCommandResponse;
@@ -52,8 +53,10 @@ final readonly class SetupTwoFactorProcessor implements ProcessorInterface
         $command = $this->setupTwoFactorCommandFactory->create(
             $this->userIdentityResolver->resolveEmail()
         );
-        $response = $this->commandBus->dispatch($command);
-        assert($response instanceof SetupTwoFactorCommandResponse);
+        $response = CommandResponseTypeGuard::expect(
+            $this->commandBus->dispatch($command),
+            SetupTwoFactorCommandResponse::class
+        );
 
         return new JsonResponse(
             [

--- a/src/User/Application/Processor/SetupTwoFactorProcessor.php
+++ b/src/User/Application/Processor/SetupTwoFactorProcessor.php
@@ -8,6 +8,7 @@ use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProcessorInterface;
 use App\Shared\Application\Validator\Http\EmptyJsonObjectRequestValidator;
 use App\Shared\Domain\Bus\Command\CommandBusInterface;
+use App\User\Application\DTO\SetupTwoFactorCommandResponse;
 use App\User\Application\DTO\SetupTwoFactorDto;
 use App\User\Application\Factory\SetupTwoFactorCommandFactoryInterface;
 use App\User\Application\Resolver\CurrentUserIdentityResolver;
@@ -51,8 +52,8 @@ final readonly class SetupTwoFactorProcessor implements ProcessorInterface
         $command = $this->setupTwoFactorCommandFactory->create(
             $this->userIdentityResolver->resolveEmail()
         );
-        $this->commandBus->dispatch($command);
-        $response = $command->getResponse();
+        $response = $this->commandBus->dispatch($command);
+        assert($response instanceof SetupTwoFactorCommandResponse);
 
         return new JsonResponse(
             [

--- a/src/User/Application/Processor/SignInProcessor.php
+++ b/src/User/Application/Processor/SignInProcessor.php
@@ -43,20 +43,7 @@ final readonly class SignInProcessor implements ProcessorInterface
         array $uriVariables = [],
         array $context = []
     ): Response {
-        $request = $this->httpRequestContextResolver->resolveRequest($context['request'] ?? null);
-
-        $command = $this->signInCommandFactory->create(
-            $data->emailValue(),
-            $data->passwordValue(),
-            $data->isRememberMe(),
-            $this->httpRequestContextResolver->resolveIpAddress($request),
-            $this->httpRequestContextResolver->resolveUserAgent($request)
-        );
-
-        $commandResponse = (new CommandResponseTypeGuard())->expect(
-            $this->commandBus->dispatch($command),
-            SignInCommandResponse::class
-        );
+        $commandResponse = $this->dispatchCommand($data, $context);
 
         $response = new JsonResponse($this->buildResponseBody($commandResponse));
 
@@ -70,6 +57,29 @@ final readonly class SignInProcessor implements ProcessorInterface
         }
 
         return $response;
+    }
+
+    /**
+     * @param array{request?: object|null, ...} $context
+     */
+    private function dispatchCommand(
+        SignInDto $data,
+        array $context
+    ): SignInCommandResponse {
+        $request = $this->httpRequestContextResolver->resolveRequest($context['request'] ?? null);
+
+        $command = $this->signInCommandFactory->create(
+            $data->emailValue(),
+            $data->passwordValue(),
+            $data->isRememberMe(),
+            $this->httpRequestContextResolver->resolveIpAddress($request),
+            $this->httpRequestContextResolver->resolveUserAgent($request)
+        );
+
+        return (new CommandResponseTypeGuard())->expect(
+            $this->commandBus->dispatch($command),
+            SignInCommandResponse::class
+        );
     }
 
     /**

--- a/src/User/Application/Processor/SignInProcessor.php
+++ b/src/User/Application/Processor/SignInProcessor.php
@@ -53,7 +53,7 @@ final readonly class SignInProcessor implements ProcessorInterface
             $this->httpRequestContextResolver->resolveUserAgent($request)
         );
 
-        $commandResponse = CommandResponseTypeGuard::expect(
+        $commandResponse = (new CommandResponseTypeGuard())->expect(
             $this->commandBus->dispatch($command),
             SignInCommandResponse::class
         );

--- a/src/User/Application/Processor/SignInProcessor.php
+++ b/src/User/Application/Processor/SignInProcessor.php
@@ -52,8 +52,8 @@ final readonly class SignInProcessor implements ProcessorInterface
             $this->httpRequestContextResolver->resolveUserAgent($request)
         );
 
-        $this->commandBus->dispatch($command);
-        $commandResponse = $command->getResponse();
+        $commandResponse = $this->commandBus->dispatch($command);
+        assert($commandResponse instanceof SignInCommandResponse);
 
         $response = new JsonResponse($this->buildResponseBody($commandResponse));
 

--- a/src/User/Application/Processor/SignInProcessor.php
+++ b/src/User/Application/Processor/SignInProcessor.php
@@ -6,6 +6,7 @@ namespace App\User\Application\Processor;
 
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProcessorInterface;
+use App\Shared\Application\Bus\Command\CommandResponseTypeGuard;
 use App\Shared\Domain\Bus\Command\CommandBusInterface;
 use App\User\Application\DTO\SignInCommandResponse;
 use App\User\Application\DTO\SignInDto;
@@ -52,8 +53,10 @@ final readonly class SignInProcessor implements ProcessorInterface
             $this->httpRequestContextResolver->resolveUserAgent($request)
         );
 
-        $commandResponse = $this->commandBus->dispatch($command);
-        assert($commandResponse instanceof SignInCommandResponse);
+        $commandResponse = CommandResponseTypeGuard::expect(
+            $this->commandBus->dispatch($command),
+            SignInCommandResponse::class
+        );
 
         $response = new JsonResponse($this->buildResponseBody($commandResponse));
 

--- a/src/User/Application/Processor/SignInProcessor.php
+++ b/src/User/Application/Processor/SignInProcessor.php
@@ -6,13 +6,10 @@ namespace App\User\Application\Processor;
 
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProcessorInterface;
-use App\Shared\Application\Bus\Command\CommandResponseTypeGuard;
-use App\Shared\Domain\Bus\Command\CommandBusInterface;
 use App\User\Application\DTO\SignInCommandResponse;
 use App\User\Application\DTO\SignInDto;
 use App\User\Application\Factory\AuthCookieFactoryInterface;
-use App\User\Application\Factory\SignInCommandFactoryInterface;
-use App\User\Application\Resolver\HttpRequestContextResolverInterface;
+use App\User\Application\Service\SignInCommandDispatcher;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -22,9 +19,7 @@ use Symfony\Component\HttpFoundation\Response;
 final readonly class SignInProcessor implements ProcessorInterface
 {
     public function __construct(
-        private CommandBusInterface $commandBus,
-        private SignInCommandFactoryInterface $signInCommandFactory,
-        private HttpRequestContextResolverInterface $httpRequestContextResolver,
+        private SignInCommandDispatcher $signInCommandDispatcher,
         private AuthCookieFactoryInterface $authCookieFactory,
     ) {
     }
@@ -43,7 +38,10 @@ final readonly class SignInProcessor implements ProcessorInterface
         array $uriVariables = [],
         array $context = []
     ): Response {
-        $commandResponse = $this->dispatchCommand($data, $context);
+        $commandResponse = $this->signInCommandDispatcher->dispatch(
+            $data,
+            $context
+        );
 
         $response = new JsonResponse($this->buildResponseBody($commandResponse));
 
@@ -57,29 +55,6 @@ final readonly class SignInProcessor implements ProcessorInterface
         }
 
         return $response;
-    }
-
-    /**
-     * @param array{request?: object|null, ...} $context
-     */
-    private function dispatchCommand(
-        SignInDto $data,
-        array $context
-    ): SignInCommandResponse {
-        $request = $this->httpRequestContextResolver->resolveRequest($context['request'] ?? null);
-
-        $command = $this->signInCommandFactory->create(
-            $data->emailValue(),
-            $data->passwordValue(),
-            $data->isRememberMe(),
-            $this->httpRequestContextResolver->resolveIpAddress($request),
-            $this->httpRequestContextResolver->resolveUserAgent($request)
-        );
-
-        return (new CommandResponseTypeGuard())->expect(
-            $this->commandBus->dispatch($command),
-            SignInCommandResponse::class
-        );
     }
 
     /**

--- a/src/User/Application/Resolver/CompleteTwoFactorAuthMutationResolver.php
+++ b/src/User/Application/Resolver/CompleteTwoFactorAuthMutationResolver.php
@@ -46,7 +46,7 @@ final readonly class CompleteTwoFactorAuthMutationResolver implements
             $this->httpRequestContextResolver->resolveUserAgent($request)
         );
 
-        $response = CommandResponseTypeGuard::expect(
+        $response = (new CommandResponseTypeGuard())->expect(
             $this->commandBus->dispatch($command),
             CompleteTwoFactorCommandResponse::class
         );

--- a/src/User/Application/Resolver/CompleteTwoFactorAuthMutationResolver.php
+++ b/src/User/Application/Resolver/CompleteTwoFactorAuthMutationResolver.php
@@ -6,6 +6,7 @@ namespace App\User\Application\Resolver;
 
 use ApiPlatform\GraphQl\Resolver\MutationResolverInterface;
 use App\Shared\Domain\Bus\Command\CommandBusInterface;
+use App\User\Application\DTO\CompleteTwoFactorCommandResponse;
 use App\User\Application\DTO\CompleteTwoFactorDto;
 use App\User\Application\Factory\AuthPayloadFactory;
 use App\User\Application\Factory\CompleteTwoFactorCommandFactoryInterface;
@@ -44,10 +45,11 @@ final readonly class CompleteTwoFactorAuthMutationResolver implements
             $this->httpRequestContextResolver->resolveUserAgent($request)
         );
 
-        $this->commandBus->dispatch($command);
+        $response = $this->commandBus->dispatch($command);
+        assert($response instanceof CompleteTwoFactorCommandResponse);
 
         return $this->authPayloadFactory->createFromCompleteTwoFactorResponse(
-            $command->getResponse()
+            $response
         );
     }
 }

--- a/src/User/Application/Resolver/CompleteTwoFactorAuthMutationResolver.php
+++ b/src/User/Application/Resolver/CompleteTwoFactorAuthMutationResolver.php
@@ -5,12 +5,9 @@ declare(strict_types=1);
 namespace App\User\Application\Resolver;
 
 use ApiPlatform\GraphQl\Resolver\MutationResolverInterface;
-use App\Shared\Application\Bus\Guard\CommandResponseTypeGuard;
-use App\Shared\Domain\Bus\Command\CommandBusInterface;
-use App\User\Application\DTO\CompleteTwoFactorCommandResponse;
 use App\User\Application\DTO\CompleteTwoFactorDto;
 use App\User\Application\Factory\AuthPayloadFactory;
-use App\User\Application\Factory\CompleteTwoFactorCommandFactoryInterface;
+use App\User\Application\Service\CompleteTwoFactorCommandDispatcher;
 use App\User\Application\Validator\MutationInputValidator;
 
 final readonly class CompleteTwoFactorAuthMutationResolver implements
@@ -18,11 +15,8 @@ final readonly class CompleteTwoFactorAuthMutationResolver implements
 {
     public function __construct(
         private MutationInputValidator $validator,
-        private CommandBusInterface $commandBus,
-        private CommandResponseTypeGuard $commandResponseTypeGuard,
         private AuthPayloadFactory $authPayloadFactory,
-        private CompleteTwoFactorCommandFactoryInterface $completeTwoFactorCommandFactory,
-        private HttpRequestContextResolverInterface $httpRequestContextResolver,
+        private CompleteTwoFactorCommandDispatcher $commandDispatcher,
     ) {
     }
 
@@ -39,18 +33,7 @@ final readonly class CompleteTwoFactorAuthMutationResolver implements
         );
         $this->validator->validate($dto);
 
-        $request = $this->httpRequestContextResolver->resolveRequest($context['request'] ?? null);
-        $command = $this->completeTwoFactorCommandFactory->create(
-            $dto->pendingSessionIdValue(),
-            $dto->twoFactorCodeValue(),
-            $this->httpRequestContextResolver->resolveIpAddress($request),
-            $this->httpRequestContextResolver->resolveUserAgent($request)
-        );
-
-        $response = $this->commandResponseTypeGuard->expect(
-            $this->commandBus->dispatch($command),
-            CompleteTwoFactorCommandResponse::class
-        );
+        $response = $this->commandDispatcher->dispatch($dto, $context);
 
         return $this->authPayloadFactory->createFromCompleteTwoFactorResponse(
             $response

--- a/src/User/Application/Resolver/CompleteTwoFactorAuthMutationResolver.php
+++ b/src/User/Application/Resolver/CompleteTwoFactorAuthMutationResolver.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace App\User\Application\Resolver;
 
 use ApiPlatform\GraphQl\Resolver\MutationResolverInterface;
-use App\Shared\Application\Bus\Command\CommandResponseTypeGuard;
+use App\Shared\Application\Bus\Guard\CommandResponseTypeGuard;
 use App\Shared\Domain\Bus\Command\CommandBusInterface;
 use App\User\Application\DTO\CompleteTwoFactorCommandResponse;
 use App\User\Application\DTO\CompleteTwoFactorDto;
@@ -19,6 +19,7 @@ final readonly class CompleteTwoFactorAuthMutationResolver implements
     public function __construct(
         private MutationInputValidator $validator,
         private CommandBusInterface $commandBus,
+        private CommandResponseTypeGuard $commandResponseTypeGuard,
         private AuthPayloadFactory $authPayloadFactory,
         private CompleteTwoFactorCommandFactoryInterface $completeTwoFactorCommandFactory,
         private HttpRequestContextResolverInterface $httpRequestContextResolver,
@@ -46,7 +47,7 @@ final readonly class CompleteTwoFactorAuthMutationResolver implements
             $this->httpRequestContextResolver->resolveUserAgent($request)
         );
 
-        $response = (new CommandResponseTypeGuard())->expect(
+        $response = $this->commandResponseTypeGuard->expect(
             $this->commandBus->dispatch($command),
             CompleteTwoFactorCommandResponse::class
         );

--- a/src/User/Application/Resolver/CompleteTwoFactorAuthMutationResolver.php
+++ b/src/User/Application/Resolver/CompleteTwoFactorAuthMutationResolver.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\User\Application\Resolver;
 
 use ApiPlatform\GraphQl\Resolver\MutationResolverInterface;
+use App\Shared\Application\Bus\Command\CommandResponseTypeGuard;
 use App\Shared\Domain\Bus\Command\CommandBusInterface;
 use App\User\Application\DTO\CompleteTwoFactorCommandResponse;
 use App\User\Application\DTO\CompleteTwoFactorDto;
@@ -45,8 +46,10 @@ final readonly class CompleteTwoFactorAuthMutationResolver implements
             $this->httpRequestContextResolver->resolveUserAgent($request)
         );
 
-        $response = $this->commandBus->dispatch($command);
-        assert($response instanceof CompleteTwoFactorCommandResponse);
+        $response = CommandResponseTypeGuard::expect(
+            $this->commandBus->dispatch($command),
+            CompleteTwoFactorCommandResponse::class
+        );
 
         return $this->authPayloadFactory->createFromCompleteTwoFactorResponse(
             $response

--- a/src/User/Application/Resolver/ConfirmPasswordResetMutationResolver.php
+++ b/src/User/Application/Resolver/ConfirmPasswordResetMutationResolver.php
@@ -7,6 +7,7 @@ namespace App\User\Application\Resolver;
 use ApiPlatform\GraphQl\Resolver\MutationResolverInterface;
 use App\Shared\Domain\Bus\Command\CommandBusInterface;
 use App\User\Application\Command\ConfirmPasswordResetCommand;
+use App\User\Application\DTO\ConfirmPasswordResetCommandResponse;
 use App\User\Application\MutationInput\ConfirmPasswordResetMutationInput;
 use App\User\Application\Validator\MutationInputValidator;
 
@@ -38,7 +39,8 @@ final readonly class ConfirmPasswordResetMutationResolver implements
             $args['token'],
             $args['newPassword']
         );
-        $this->commandBus->dispatch($command);
+        $commandResponse = $this->commandBus->dispatch($command);
+        assert($commandResponse instanceof ConfirmPasswordResetCommandResponse);
 
         return null;
     }

--- a/src/User/Application/Resolver/ConfirmPasswordResetMutationResolver.php
+++ b/src/User/Application/Resolver/ConfirmPasswordResetMutationResolver.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\User\Application\Resolver;
 
 use ApiPlatform\GraphQl\Resolver\MutationResolverInterface;
+use App\Shared\Application\Bus\Command\CommandResponseTypeGuard;
 use App\Shared\Domain\Bus\Command\CommandBusInterface;
 use App\User\Application\Command\ConfirmPasswordResetCommand;
 use App\User\Application\DTO\ConfirmPasswordResetCommandResponse;
@@ -39,8 +40,10 @@ final readonly class ConfirmPasswordResetMutationResolver implements
             $args['token'],
             $args['newPassword']
         );
-        $commandResponse = $this->commandBus->dispatch($command);
-        assert($commandResponse instanceof ConfirmPasswordResetCommandResponse);
+        CommandResponseTypeGuard::expect(
+            $this->commandBus->dispatch($command),
+            ConfirmPasswordResetCommandResponse::class
+        );
 
         return null;
     }

--- a/src/User/Application/Resolver/ConfirmPasswordResetMutationResolver.php
+++ b/src/User/Application/Resolver/ConfirmPasswordResetMutationResolver.php
@@ -40,7 +40,7 @@ final readonly class ConfirmPasswordResetMutationResolver implements
             $args['token'],
             $args['newPassword']
         );
-        CommandResponseTypeGuard::expect(
+        (new CommandResponseTypeGuard())->expect(
             $this->commandBus->dispatch($command),
             ConfirmPasswordResetCommandResponse::class
         );

--- a/src/User/Application/Resolver/ConfirmPasswordResetMutationResolver.php
+++ b/src/User/Application/Resolver/ConfirmPasswordResetMutationResolver.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace App\User\Application\Resolver;
 
 use ApiPlatform\GraphQl\Resolver\MutationResolverInterface;
-use App\Shared\Application\Bus\Command\CommandResponseTypeGuard;
+use App\Shared\Application\Bus\Guard\CommandResponseTypeGuard;
 use App\Shared\Domain\Bus\Command\CommandBusInterface;
 use App\User\Application\Command\ConfirmPasswordResetCommand;
 use App\User\Application\DTO\ConfirmPasswordResetCommandResponse;
@@ -17,6 +17,7 @@ final readonly class ConfirmPasswordResetMutationResolver implements
 {
     public function __construct(
         private CommandBusInterface $commandBus,
+        private CommandResponseTypeGuard $commandResponseTypeGuard,
         private MutationInputValidator $validator,
     ) {
     }
@@ -40,7 +41,7 @@ final readonly class ConfirmPasswordResetMutationResolver implements
             $args['token'],
             $args['newPassword']
         );
-        (new CommandResponseTypeGuard())->expect(
+        $this->commandResponseTypeGuard->expect(
             $this->commandBus->dispatch($command),
             ConfirmPasswordResetCommandResponse::class
         );

--- a/src/User/Application/Resolver/ConfirmTwoFactorAuthMutationResolver.php
+++ b/src/User/Application/Resolver/ConfirmTwoFactorAuthMutationResolver.php
@@ -5,12 +5,9 @@ declare(strict_types=1);
 namespace App\User\Application\Resolver;
 
 use ApiPlatform\GraphQl\Resolver\MutationResolverInterface;
-use App\Shared\Application\Bus\Guard\CommandResponseTypeGuard;
-use App\Shared\Domain\Bus\Command\CommandBusInterface;
-use App\User\Application\DTO\ConfirmTwoFactorCommandResponse;
 use App\User\Application\DTO\ConfirmTwoFactorDto;
 use App\User\Application\Factory\AuthPayloadFactory;
-use App\User\Application\Factory\ConfirmTwoFactorCommandFactoryInterface;
+use App\User\Application\Service\ConfirmTwoFactorCommandDispatcher;
 use App\User\Application\Validator\MutationInputValidator;
 
 final readonly class ConfirmTwoFactorAuthMutationResolver implements
@@ -18,11 +15,8 @@ final readonly class ConfirmTwoFactorAuthMutationResolver implements
 {
     public function __construct(
         private MutationInputValidator $validator,
-        private CommandBusInterface $commandBus,
-        private CommandResponseTypeGuard $commandResponseTypeGuard,
         private AuthPayloadFactory $authPayloadFactory,
-        private CurrentUserIdentityResolver $currentUserIdentityResolver,
-        private ConfirmTwoFactorCommandFactoryInterface $confirmTwoFactorCommandFactory,
+        private ConfirmTwoFactorCommandDispatcher $commandDispatcher,
     ) {
     }
 
@@ -36,15 +30,7 @@ final readonly class ConfirmTwoFactorAuthMutationResolver implements
         $dto = new ConfirmTwoFactorDto($args['twoFactorCode'] ?? '');
         $this->validator->validate($dto);
 
-        $command = $this->confirmTwoFactorCommandFactory->create(
-            $this->currentUserIdentityResolver->resolveEmail(),
-            $dto->twoFactorCodeValue(),
-            $this->currentUserIdentityResolver->resolveSessionId()
-        );
-        $response = $this->commandResponseTypeGuard->expect(
-            $this->commandBus->dispatch($command),
-            ConfirmTwoFactorCommandResponse::class
-        );
+        $response = $this->commandDispatcher->dispatch($dto);
 
         return $this->authPayloadFactory->createFromConfirmTwoFactorResponse(
             $response

--- a/src/User/Application/Resolver/ConfirmTwoFactorAuthMutationResolver.php
+++ b/src/User/Application/Resolver/ConfirmTwoFactorAuthMutationResolver.php
@@ -40,7 +40,7 @@ final readonly class ConfirmTwoFactorAuthMutationResolver implements
             $dto->twoFactorCodeValue(),
             $this->currentUserIdentityResolver->resolveSessionId()
         );
-        $response = CommandResponseTypeGuard::expect(
+        $response = (new CommandResponseTypeGuard())->expect(
             $this->commandBus->dispatch($command),
             ConfirmTwoFactorCommandResponse::class
         );

--- a/src/User/Application/Resolver/ConfirmTwoFactorAuthMutationResolver.php
+++ b/src/User/Application/Resolver/ConfirmTwoFactorAuthMutationResolver.php
@@ -6,6 +6,7 @@ namespace App\User\Application\Resolver;
 
 use ApiPlatform\GraphQl\Resolver\MutationResolverInterface;
 use App\Shared\Domain\Bus\Command\CommandBusInterface;
+use App\User\Application\DTO\ConfirmTwoFactorCommandResponse;
 use App\User\Application\DTO\ConfirmTwoFactorDto;
 use App\User\Application\Factory\AuthPayloadFactory;
 use App\User\Application\Factory\ConfirmTwoFactorCommandFactoryInterface;
@@ -38,10 +39,11 @@ final readonly class ConfirmTwoFactorAuthMutationResolver implements
             $dto->twoFactorCodeValue(),
             $this->currentUserIdentityResolver->resolveSessionId()
         );
-        $this->commandBus->dispatch($command);
+        $response = $this->commandBus->dispatch($command);
+        assert($response instanceof ConfirmTwoFactorCommandResponse);
 
         return $this->authPayloadFactory->createFromConfirmTwoFactorResponse(
-            $command->getResponse()
+            $response
         );
     }
 }

--- a/src/User/Application/Resolver/ConfirmTwoFactorAuthMutationResolver.php
+++ b/src/User/Application/Resolver/ConfirmTwoFactorAuthMutationResolver.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace App\User\Application\Resolver;
 
 use ApiPlatform\GraphQl\Resolver\MutationResolverInterface;
-use App\Shared\Application\Bus\Command\CommandResponseTypeGuard;
+use App\Shared\Application\Bus\Guard\CommandResponseTypeGuard;
 use App\Shared\Domain\Bus\Command\CommandBusInterface;
 use App\User\Application\DTO\ConfirmTwoFactorCommandResponse;
 use App\User\Application\DTO\ConfirmTwoFactorDto;
@@ -19,6 +19,7 @@ final readonly class ConfirmTwoFactorAuthMutationResolver implements
     public function __construct(
         private MutationInputValidator $validator,
         private CommandBusInterface $commandBus,
+        private CommandResponseTypeGuard $commandResponseTypeGuard,
         private AuthPayloadFactory $authPayloadFactory,
         private CurrentUserIdentityResolver $currentUserIdentityResolver,
         private ConfirmTwoFactorCommandFactoryInterface $confirmTwoFactorCommandFactory,
@@ -40,7 +41,7 @@ final readonly class ConfirmTwoFactorAuthMutationResolver implements
             $dto->twoFactorCodeValue(),
             $this->currentUserIdentityResolver->resolveSessionId()
         );
-        $response = (new CommandResponseTypeGuard())->expect(
+        $response = $this->commandResponseTypeGuard->expect(
             $this->commandBus->dispatch($command),
             ConfirmTwoFactorCommandResponse::class
         );

--- a/src/User/Application/Resolver/ConfirmTwoFactorAuthMutationResolver.php
+++ b/src/User/Application/Resolver/ConfirmTwoFactorAuthMutationResolver.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\User\Application\Resolver;
 
 use ApiPlatform\GraphQl\Resolver\MutationResolverInterface;
+use App\Shared\Application\Bus\Command\CommandResponseTypeGuard;
 use App\Shared\Domain\Bus\Command\CommandBusInterface;
 use App\User\Application\DTO\ConfirmTwoFactorCommandResponse;
 use App\User\Application\DTO\ConfirmTwoFactorDto;
@@ -39,8 +40,10 @@ final readonly class ConfirmTwoFactorAuthMutationResolver implements
             $dto->twoFactorCodeValue(),
             $this->currentUserIdentityResolver->resolveSessionId()
         );
-        $response = $this->commandBus->dispatch($command);
-        assert($response instanceof ConfirmTwoFactorCommandResponse);
+        $response = CommandResponseTypeGuard::expect(
+            $this->commandBus->dispatch($command),
+            ConfirmTwoFactorCommandResponse::class
+        );
 
         return $this->authPayloadFactory->createFromConfirmTwoFactorResponse(
             $response

--- a/src/User/Application/Resolver/RefreshTokenAuthMutationResolver.php
+++ b/src/User/Application/Resolver/RefreshTokenAuthMutationResolver.php
@@ -6,6 +6,7 @@ namespace App\User\Application\Resolver;
 
 use ApiPlatform\GraphQl\Resolver\MutationResolverInterface;
 use App\Shared\Domain\Bus\Command\CommandBusInterface;
+use App\User\Application\DTO\RefreshTokenCommandResponse;
 use App\User\Application\DTO\RefreshTokenDto;
 use App\User\Application\Factory\AuthPayloadFactory;
 use App\User\Application\Factory\RefreshTokenCommandFactoryInterface;
@@ -34,10 +35,11 @@ final readonly class RefreshTokenAuthMutationResolver implements MutationResolve
         $command = $this->refreshTokenCommandFactory->create(
             $dto->refreshTokenValue()
         );
-        $this->commandBus->dispatch($command);
+        $response = $this->commandBus->dispatch($command);
+        assert($response instanceof RefreshTokenCommandResponse);
 
         return $this->authPayloadFactory->createFromRefreshTokenResponse(
-            $command->getResponse()
+            $response
         );
     }
 }

--- a/src/User/Application/Resolver/RefreshTokenAuthMutationResolver.php
+++ b/src/User/Application/Resolver/RefreshTokenAuthMutationResolver.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\User\Application\Resolver;
 
 use ApiPlatform\GraphQl\Resolver\MutationResolverInterface;
+use App\Shared\Application\Bus\Command\CommandResponseTypeGuard;
 use App\Shared\Domain\Bus\Command\CommandBusInterface;
 use App\User\Application\DTO\RefreshTokenCommandResponse;
 use App\User\Application\DTO\RefreshTokenDto;
@@ -35,8 +36,10 @@ final readonly class RefreshTokenAuthMutationResolver implements MutationResolve
         $command = $this->refreshTokenCommandFactory->create(
             $dto->refreshTokenValue()
         );
-        $response = $this->commandBus->dispatch($command);
-        assert($response instanceof RefreshTokenCommandResponse);
+        $response = CommandResponseTypeGuard::expect(
+            $this->commandBus->dispatch($command),
+            RefreshTokenCommandResponse::class
+        );
 
         return $this->authPayloadFactory->createFromRefreshTokenResponse(
             $response

--- a/src/User/Application/Resolver/RefreshTokenAuthMutationResolver.php
+++ b/src/User/Application/Resolver/RefreshTokenAuthMutationResolver.php
@@ -36,7 +36,7 @@ final readonly class RefreshTokenAuthMutationResolver implements MutationResolve
         $command = $this->refreshTokenCommandFactory->create(
             $dto->refreshTokenValue()
         );
-        $response = CommandResponseTypeGuard::expect(
+        $response = (new CommandResponseTypeGuard())->expect(
             $this->commandBus->dispatch($command),
             RefreshTokenCommandResponse::class
         );

--- a/src/User/Application/Resolver/RefreshTokenAuthMutationResolver.php
+++ b/src/User/Application/Resolver/RefreshTokenAuthMutationResolver.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace App\User\Application\Resolver;
 
 use ApiPlatform\GraphQl\Resolver\MutationResolverInterface;
-use App\Shared\Application\Bus\Command\CommandResponseTypeGuard;
+use App\Shared\Application\Bus\Guard\CommandResponseTypeGuard;
 use App\Shared\Domain\Bus\Command\CommandBusInterface;
 use App\User\Application\DTO\RefreshTokenCommandResponse;
 use App\User\Application\DTO\RefreshTokenDto;
@@ -18,6 +18,7 @@ final readonly class RefreshTokenAuthMutationResolver implements MutationResolve
     public function __construct(
         private MutationInputValidator $validator,
         private CommandBusInterface $commandBus,
+        private CommandResponseTypeGuard $commandResponseTypeGuard,
         private AuthPayloadFactory $authPayloadFactory,
         private RefreshTokenCommandFactoryInterface $refreshTokenCommandFactory,
     ) {
@@ -36,7 +37,7 @@ final readonly class RefreshTokenAuthMutationResolver implements MutationResolve
         $command = $this->refreshTokenCommandFactory->create(
             $dto->refreshTokenValue()
         );
-        $response = (new CommandResponseTypeGuard())->expect(
+        $response = $this->commandResponseTypeGuard->expect(
             $this->commandBus->dispatch($command),
             RefreshTokenCommandResponse::class
         );

--- a/src/User/Application/Resolver/RegenerateRecoveryCodesAuthMutationResolver.php
+++ b/src/User/Application/Resolver/RegenerateRecoveryCodesAuthMutationResolver.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\User\Application\Resolver;
 
 use ApiPlatform\GraphQl\Resolver\MutationResolverInterface;
+use App\Shared\Application\Bus\Command\CommandResponseTypeGuard;
 use App\Shared\Domain\Bus\Command\CommandBusInterface;
 use App\User\Application\DTO\RegenerateRecoveryCodesCommandResponse;
 use App\User\Application\Factory as UserFactory;
@@ -31,8 +32,10 @@ final readonly class RegenerateRecoveryCodesAuthMutationResolver implements
             $this->currentUserIdentityResolver->resolveEmail(),
             $this->currentUserIdentityResolver->resolveSessionId()
         );
-        $response = $this->commandBus->dispatch($command);
-        assert($response instanceof RegenerateRecoveryCodesCommandResponse);
+        $response = CommandResponseTypeGuard::expect(
+            $this->commandBus->dispatch($command),
+            RegenerateRecoveryCodesCommandResponse::class
+        );
 
         return $this->authPayloadFactory
             ->createFromRegenerateRecoveryCodesResponse(

--- a/src/User/Application/Resolver/RegenerateRecoveryCodesAuthMutationResolver.php
+++ b/src/User/Application/Resolver/RegenerateRecoveryCodesAuthMutationResolver.php
@@ -6,6 +6,7 @@ namespace App\User\Application\Resolver;
 
 use ApiPlatform\GraphQl\Resolver\MutationResolverInterface;
 use App\Shared\Domain\Bus\Command\CommandBusInterface;
+use App\User\Application\DTO\RegenerateRecoveryCodesCommandResponse;
 use App\User\Application\Factory as UserFactory;
 use App\User\Application\Factory\AuthPayloadFactory;
 
@@ -30,11 +31,12 @@ final readonly class RegenerateRecoveryCodesAuthMutationResolver implements
             $this->currentUserIdentityResolver->resolveEmail(),
             $this->currentUserIdentityResolver->resolveSessionId()
         );
-        $this->commandBus->dispatch($command);
+        $response = $this->commandBus->dispatch($command);
+        assert($response instanceof RegenerateRecoveryCodesCommandResponse);
 
         return $this->authPayloadFactory
             ->createFromRegenerateRecoveryCodesResponse(
-                $command->getResponse()
+                $response
             );
     }
 }

--- a/src/User/Application/Resolver/RegenerateRecoveryCodesAuthMutationResolver.php
+++ b/src/User/Application/Resolver/RegenerateRecoveryCodesAuthMutationResolver.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace App\User\Application\Resolver;
 
 use ApiPlatform\GraphQl\Resolver\MutationResolverInterface;
-use App\Shared\Application\Bus\Command\CommandResponseTypeGuard;
+use App\Shared\Application\Bus\Guard\CommandResponseTypeGuard;
 use App\Shared\Domain\Bus\Command\CommandBusInterface;
 use App\User\Application\DTO\RegenerateRecoveryCodesCommandResponse;
 use App\User\Application\Factory as UserFactory;
@@ -16,6 +16,7 @@ final readonly class RegenerateRecoveryCodesAuthMutationResolver implements
 {
     public function __construct(
         private CommandBusInterface $commandBus,
+        private CommandResponseTypeGuard $commandResponseTypeGuard,
         private AuthPayloadFactory $authPayloadFactory,
         private CurrentUserIdentityResolver $currentUserIdentityResolver,
         private UserFactory\RegenerateRecoveryCodesCommandFactoryInterface $commandFactory,
@@ -32,7 +33,7 @@ final readonly class RegenerateRecoveryCodesAuthMutationResolver implements
             $this->currentUserIdentityResolver->resolveEmail(),
             $this->currentUserIdentityResolver->resolveSessionId()
         );
-        $response = (new CommandResponseTypeGuard())->expect(
+        $response = $this->commandResponseTypeGuard->expect(
             $this->commandBus->dispatch($command),
             RegenerateRecoveryCodesCommandResponse::class
         );

--- a/src/User/Application/Resolver/RegenerateRecoveryCodesAuthMutationResolver.php
+++ b/src/User/Application/Resolver/RegenerateRecoveryCodesAuthMutationResolver.php
@@ -32,7 +32,7 @@ final readonly class RegenerateRecoveryCodesAuthMutationResolver implements
             $this->currentUserIdentityResolver->resolveEmail(),
             $this->currentUserIdentityResolver->resolveSessionId()
         );
-        $response = CommandResponseTypeGuard::expect(
+        $response = (new CommandResponseTypeGuard())->expect(
             $this->commandBus->dispatch($command),
             RegenerateRecoveryCodesCommandResponse::class
         );

--- a/src/User/Application/Resolver/RegisterUserMutationResolver.php
+++ b/src/User/Application/Resolver/RegisterUserMutationResolver.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\User\Application\Resolver;
 
 use ApiPlatform\GraphQl\Resolver\MutationResolverInterface;
+use App\Shared\Application\Bus\Command\CommandResponseTypeGuard;
 use App\Shared\Domain\Bus\Command\CommandBusInterface;
 use App\User\Application\DTO\RegisterUserCommandResponse;
 use App\User\Application\Factory\SignUpCommandFactoryInterface;
@@ -39,8 +40,10 @@ final readonly class RegisterUserMutationResolver implements
             $args['initials'],
             $args['password']
         );
-        $commandResponse = $this->commandBus->dispatch($command);
-        assert($commandResponse instanceof RegisterUserCommandResponse);
+        $commandResponse = CommandResponseTypeGuard::expect(
+            $this->commandBus->dispatch($command),
+            RegisterUserCommandResponse::class
+        );
 
         return $commandResponse->createdUser;
     }

--- a/src/User/Application/Resolver/RegisterUserMutationResolver.php
+++ b/src/User/Application/Resolver/RegisterUserMutationResolver.php
@@ -6,6 +6,7 @@ namespace App\User\Application\Resolver;
 
 use ApiPlatform\GraphQl\Resolver\MutationResolverInterface;
 use App\Shared\Domain\Bus\Command\CommandBusInterface;
+use App\User\Application\DTO\RegisterUserCommandResponse;
 use App\User\Application\Factory\SignUpCommandFactoryInterface;
 use App\User\Application\Transformer\CreateUserMutationInputTransformer;
 use App\User\Application\Validator\MutationInputValidator;
@@ -38,8 +39,9 @@ final readonly class RegisterUserMutationResolver implements
             $args['initials'],
             $args['password']
         );
-        $this->commandBus->dispatch($command);
+        $commandResponse = $this->commandBus->dispatch($command);
+        assert($commandResponse instanceof RegisterUserCommandResponse);
 
-        return $command->getResponse()->createdUser;
+        return $commandResponse->createdUser;
     }
 }

--- a/src/User/Application/Resolver/RegisterUserMutationResolver.php
+++ b/src/User/Application/Resolver/RegisterUserMutationResolver.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace App\User\Application\Resolver;
 
 use ApiPlatform\GraphQl\Resolver\MutationResolverInterface;
-use App\Shared\Application\Bus\Command\CommandResponseTypeGuard;
+use App\Shared\Application\Bus\Guard\CommandResponseTypeGuard;
 use App\Shared\Domain\Bus\Command\CommandBusInterface;
 use App\User\Application\DTO\RegisterUserCommandResponse;
 use App\User\Application\Factory\SignUpCommandFactoryInterface;
@@ -17,6 +17,7 @@ final readonly class RegisterUserMutationResolver implements
 {
     public function __construct(
         private CommandBusInterface $commandBus,
+        private CommandResponseTypeGuard $commandResponseTypeGuard,
         private MutationInputValidator $validator,
         private CreateUserMutationInputTransformer $transformer,
         private SignUpCommandFactoryInterface $signUpCommandFactory
@@ -40,7 +41,7 @@ final readonly class RegisterUserMutationResolver implements
             $args['initials'],
             $args['password']
         );
-        $commandResponse = (new CommandResponseTypeGuard())->expect(
+        $commandResponse = $this->commandResponseTypeGuard->expect(
             $this->commandBus->dispatch($command),
             RegisterUserCommandResponse::class
         );

--- a/src/User/Application/Resolver/RegisterUserMutationResolver.php
+++ b/src/User/Application/Resolver/RegisterUserMutationResolver.php
@@ -40,7 +40,7 @@ final readonly class RegisterUserMutationResolver implements
             $args['initials'],
             $args['password']
         );
-        $commandResponse = CommandResponseTypeGuard::expect(
+        $commandResponse = (new CommandResponseTypeGuard())->expect(
             $this->commandBus->dispatch($command),
             RegisterUserCommandResponse::class
         );

--- a/src/User/Application/Resolver/SetupTwoFactorAuthMutationResolver.php
+++ b/src/User/Application/Resolver/SetupTwoFactorAuthMutationResolver.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\User\Application\Resolver;
 
 use ApiPlatform\GraphQl\Resolver\MutationResolverInterface;
+use App\Shared\Application\Bus\Command\CommandResponseTypeGuard;
 use App\Shared\Domain\Bus\Command\CommandBusInterface;
 use App\User\Application\DTO\SetupTwoFactorCommandResponse;
 use App\User\Application\Factory\AuthPayloadFactory;
@@ -29,8 +30,10 @@ final readonly class SetupTwoFactorAuthMutationResolver implements MutationResol
         $command = $this->setupTwoFactorCommandFactory->create(
             $this->currentUserIdentityResolver->resolveEmail()
         );
-        $response = $this->commandBus->dispatch($command);
-        assert($response instanceof SetupTwoFactorCommandResponse);
+        $response = CommandResponseTypeGuard::expect(
+            $this->commandBus->dispatch($command),
+            SetupTwoFactorCommandResponse::class
+        );
 
         return $this->authPayloadFactory->createFromSetupTwoFactorResponse(
             $response

--- a/src/User/Application/Resolver/SetupTwoFactorAuthMutationResolver.php
+++ b/src/User/Application/Resolver/SetupTwoFactorAuthMutationResolver.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace App\User\Application\Resolver;
 
 use ApiPlatform\GraphQl\Resolver\MutationResolverInterface;
-use App\Shared\Application\Bus\Command\CommandResponseTypeGuard;
+use App\Shared\Application\Bus\Guard\CommandResponseTypeGuard;
 use App\Shared\Domain\Bus\Command\CommandBusInterface;
 use App\User\Application\DTO\SetupTwoFactorCommandResponse;
 use App\User\Application\Factory\AuthPayloadFactory;
@@ -15,6 +15,7 @@ final readonly class SetupTwoFactorAuthMutationResolver implements MutationResol
 {
     public function __construct(
         private CommandBusInterface $commandBus,
+        private CommandResponseTypeGuard $commandResponseTypeGuard,
         private AuthPayloadFactory $authPayloadFactory,
         private CurrentUserIdentityResolver $currentUserIdentityResolver,
         private SetupTwoFactorCommandFactoryInterface $setupTwoFactorCommandFactory,
@@ -30,7 +31,7 @@ final readonly class SetupTwoFactorAuthMutationResolver implements MutationResol
         $command = $this->setupTwoFactorCommandFactory->create(
             $this->currentUserIdentityResolver->resolveEmail()
         );
-        $response = (new CommandResponseTypeGuard())->expect(
+        $response = $this->commandResponseTypeGuard->expect(
             $this->commandBus->dispatch($command),
             SetupTwoFactorCommandResponse::class
         );

--- a/src/User/Application/Resolver/SetupTwoFactorAuthMutationResolver.php
+++ b/src/User/Application/Resolver/SetupTwoFactorAuthMutationResolver.php
@@ -30,7 +30,7 @@ final readonly class SetupTwoFactorAuthMutationResolver implements MutationResol
         $command = $this->setupTwoFactorCommandFactory->create(
             $this->currentUserIdentityResolver->resolveEmail()
         );
-        $response = CommandResponseTypeGuard::expect(
+        $response = (new CommandResponseTypeGuard())->expect(
             $this->commandBus->dispatch($command),
             SetupTwoFactorCommandResponse::class
         );

--- a/src/User/Application/Resolver/SetupTwoFactorAuthMutationResolver.php
+++ b/src/User/Application/Resolver/SetupTwoFactorAuthMutationResolver.php
@@ -6,6 +6,7 @@ namespace App\User\Application\Resolver;
 
 use ApiPlatform\GraphQl\Resolver\MutationResolverInterface;
 use App\Shared\Domain\Bus\Command\CommandBusInterface;
+use App\User\Application\DTO\SetupTwoFactorCommandResponse;
 use App\User\Application\Factory\AuthPayloadFactory;
 use App\User\Application\Factory\SetupTwoFactorCommandFactoryInterface;
 
@@ -28,10 +29,11 @@ final readonly class SetupTwoFactorAuthMutationResolver implements MutationResol
         $command = $this->setupTwoFactorCommandFactory->create(
             $this->currentUserIdentityResolver->resolveEmail()
         );
-        $this->commandBus->dispatch($command);
+        $response = $this->commandBus->dispatch($command);
+        assert($response instanceof SetupTwoFactorCommandResponse);
 
         return $this->authPayloadFactory->createFromSetupTwoFactorResponse(
-            $command->getResponse()
+            $response
         );
     }
 }

--- a/src/User/Application/Resolver/SignInAuthMutationResolver.php
+++ b/src/User/Application/Resolver/SignInAuthMutationResolver.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\User\Application\Resolver;
 
 use ApiPlatform\GraphQl\Resolver\MutationResolverInterface;
+use App\Shared\Application\Bus\Command\CommandResponseTypeGuard;
 use App\Shared\Domain\Bus\Command\CommandBusInterface;
 use App\User\Application\DTO\SignInCommandResponse;
 use App\User\Application\DTO\SignInDto;
@@ -47,8 +48,10 @@ final readonly class SignInAuthMutationResolver implements MutationResolverInter
             $this->httpRequestContextResolver->resolveUserAgent($request)
         );
 
-        $response = $this->commandBus->dispatch($command);
-        assert($response instanceof SignInCommandResponse);
+        $response = CommandResponseTypeGuard::expect(
+            $this->commandBus->dispatch($command),
+            SignInCommandResponse::class
+        );
 
         return $this->authPayloadFactory->createFromSignInResponse(
             $response

--- a/src/User/Application/Resolver/SignInAuthMutationResolver.php
+++ b/src/User/Application/Resolver/SignInAuthMutationResolver.php
@@ -48,7 +48,7 @@ final readonly class SignInAuthMutationResolver implements MutationResolverInter
             $this->httpRequestContextResolver->resolveUserAgent($request)
         );
 
-        $response = CommandResponseTypeGuard::expect(
+        $response = (new CommandResponseTypeGuard())->expect(
             $this->commandBus->dispatch($command),
             SignInCommandResponse::class
         );

--- a/src/User/Application/Resolver/SignInAuthMutationResolver.php
+++ b/src/User/Application/Resolver/SignInAuthMutationResolver.php
@@ -6,6 +6,7 @@ namespace App\User\Application\Resolver;
 
 use ApiPlatform\GraphQl\Resolver\MutationResolverInterface;
 use App\Shared\Domain\Bus\Command\CommandBusInterface;
+use App\User\Application\DTO\SignInCommandResponse;
 use App\User\Application\DTO\SignInDto;
 use App\User\Application\Factory\AuthPayloadFactory;
 use App\User\Application\Factory\SignInCommandFactoryInterface;
@@ -46,10 +47,11 @@ final readonly class SignInAuthMutationResolver implements MutationResolverInter
             $this->httpRequestContextResolver->resolveUserAgent($request)
         );
 
-        $this->commandBus->dispatch($command);
+        $response = $this->commandBus->dispatch($command);
+        assert($response instanceof SignInCommandResponse);
 
         return $this->authPayloadFactory->createFromSignInResponse(
-            $command->getResponse()
+            $response
         );
     }
 }

--- a/src/User/Application/Resolver/SignInAuthMutationResolver.php
+++ b/src/User/Application/Resolver/SignInAuthMutationResolver.php
@@ -5,22 +5,17 @@ declare(strict_types=1);
 namespace App\User\Application\Resolver;
 
 use ApiPlatform\GraphQl\Resolver\MutationResolverInterface;
-use App\Shared\Application\Bus\Command\CommandResponseTypeGuard;
-use App\Shared\Domain\Bus\Command\CommandBusInterface;
-use App\User\Application\DTO\SignInCommandResponse;
 use App\User\Application\DTO\SignInDto;
 use App\User\Application\Factory\AuthPayloadFactory;
-use App\User\Application\Factory\SignInCommandFactoryInterface;
+use App\User\Application\Service\SignInCommandDispatcher;
 use App\User\Application\Validator\MutationInputValidator;
 
 final readonly class SignInAuthMutationResolver implements MutationResolverInterface
 {
     public function __construct(
         private MutationInputValidator $validator,
-        private CommandBusInterface $commandBus,
         private AuthPayloadFactory $authPayloadFactory,
-        private SignInCommandFactoryInterface $signInCommandFactory,
-        private HttpRequestContextResolverInterface $httpRequestContextResolver,
+        private SignInCommandDispatcher $signInCommandDispatcher,
     ) {
     }
 
@@ -39,32 +34,10 @@ final readonly class SignInAuthMutationResolver implements MutationResolverInter
         $dto->setRememberMe((bool) ($args['rememberMe'] ?? false));
         $this->validator->validate($dto);
 
-        $response = $this->dispatchCommand($dto, $context);
+        $response = $this->signInCommandDispatcher->dispatch($dto, $context);
 
         return $this->authPayloadFactory->createFromSignInResponse(
             $response
-        );
-    }
-
-    /**
-     * @param array{request?: object|null, ...} $context
-     */
-    private function dispatchCommand(
-        SignInDto $dto,
-        array $context
-    ): SignInCommandResponse {
-        $request = $this->httpRequestContextResolver->resolveRequest($context['request'] ?? null);
-        $command = $this->signInCommandFactory->create(
-            $dto->emailValue(),
-            $dto->passwordValue(),
-            $dto->isRememberMe(),
-            $this->httpRequestContextResolver->resolveIpAddress($request),
-            $this->httpRequestContextResolver->resolveUserAgent($request)
-        );
-
-        return (new CommandResponseTypeGuard())->expect(
-            $this->commandBus->dispatch($command),
-            SignInCommandResponse::class
         );
     }
 }

--- a/src/User/Application/Resolver/SignInAuthMutationResolver.php
+++ b/src/User/Application/Resolver/SignInAuthMutationResolver.php
@@ -39,6 +39,20 @@ final readonly class SignInAuthMutationResolver implements MutationResolverInter
         $dto->setRememberMe((bool) ($args['rememberMe'] ?? false));
         $this->validator->validate($dto);
 
+        $response = $this->dispatchCommand($dto, $context);
+
+        return $this->authPayloadFactory->createFromSignInResponse(
+            $response
+        );
+    }
+
+    /**
+     * @param array{request?: object|null, ...} $context
+     */
+    private function dispatchCommand(
+        SignInDto $dto,
+        array $context
+    ): SignInCommandResponse {
         $request = $this->httpRequestContextResolver->resolveRequest($context['request'] ?? null);
         $command = $this->signInCommandFactory->create(
             $dto->emailValue(),
@@ -48,13 +62,9 @@ final readonly class SignInAuthMutationResolver implements MutationResolverInter
             $this->httpRequestContextResolver->resolveUserAgent($request)
         );
 
-        $response = (new CommandResponseTypeGuard())->expect(
+        return (new CommandResponseTypeGuard())->expect(
             $this->commandBus->dispatch($command),
             SignInCommandResponse::class
-        );
-
-        return $this->authPayloadFactory->createFromSignInResponse(
-            $response
         );
     }
 }

--- a/src/User/Application/Service/CompleteTwoFactorCommandDispatcher.php
+++ b/src/User/Application/Service/CompleteTwoFactorCommandDispatcher.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\User\Application\Service;
+
+use App\Shared\Application\Bus\Guard\CommandResponseTypeGuard;
+use App\Shared\Domain\Bus\Command\CommandBusInterface;
+use App\User\Application\DTO\CompleteTwoFactorCommandResponse;
+use App\User\Application\DTO\CompleteTwoFactorDto;
+use App\User\Application\Factory\CompleteTwoFactorCommandFactoryInterface;
+use App\User\Application\Resolver\HttpRequestContextResolverInterface;
+
+final readonly class CompleteTwoFactorCommandDispatcher
+{
+    public function __construct(
+        private CommandBusInterface $commandBus,
+        private CommandResponseTypeGuard $commandResponseTypeGuard,
+        private CompleteTwoFactorCommandFactoryInterface $commandFactory,
+        private HttpRequestContextResolverInterface $httpRequestContextResolver,
+    ) {
+    }
+
+    /**
+     * @param array{request?: object|null, ...} $context
+     */
+    public function dispatch(
+        CompleteTwoFactorDto $dto,
+        array $context
+    ): CompleteTwoFactorCommandResponse {
+        $request = $this->httpRequestContextResolver->resolveRequest(
+            $context['request'] ?? null
+        );
+
+        $command = $this->commandFactory->create(
+            $dto->pendingSessionIdValue(),
+            $dto->twoFactorCodeValue(),
+            $this->httpRequestContextResolver->resolveIpAddress($request),
+            $this->httpRequestContextResolver->resolveUserAgent($request)
+        );
+
+        return $this->commandResponseTypeGuard->expect(
+            $this->commandBus->dispatch($command),
+            CompleteTwoFactorCommandResponse::class
+        );
+    }
+}

--- a/src/User/Application/Service/ConfirmTwoFactorCommandDispatcher.php
+++ b/src/User/Application/Service/ConfirmTwoFactorCommandDispatcher.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\User\Application\Service;
+
+use App\Shared\Application\Bus\Guard\CommandResponseTypeGuard;
+use App\Shared\Domain\Bus\Command\CommandBusInterface;
+use App\User\Application\DTO\ConfirmTwoFactorCommandResponse;
+use App\User\Application\DTO\ConfirmTwoFactorDto;
+use App\User\Application\Factory\ConfirmTwoFactorCommandFactoryInterface;
+use App\User\Application\Resolver\CurrentUserIdentityResolver;
+
+final readonly class ConfirmTwoFactorCommandDispatcher
+{
+    public function __construct(
+        private CommandBusInterface $commandBus,
+        private CommandResponseTypeGuard $commandResponseTypeGuard,
+        private CurrentUserIdentityResolver $userIdentityResolver,
+        private ConfirmTwoFactorCommandFactoryInterface $commandFactory,
+    ) {
+    }
+
+    public function dispatch(
+        ConfirmTwoFactorDto $dto
+    ): ConfirmTwoFactorCommandResponse {
+        $command = $this->commandFactory->create(
+            $this->userIdentityResolver->resolveEmail(),
+            $dto->twoFactorCodeValue(),
+            $this->userIdentityResolver->resolveSessionId()
+        );
+
+        return $this->commandResponseTypeGuard->expect(
+            $this->commandBus->dispatch($command),
+            ConfirmTwoFactorCommandResponse::class
+        );
+    }
+}

--- a/src/User/Application/Service/PasswordResetConfirmationService.php
+++ b/src/User/Application/Service/PasswordResetConfirmationService.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\User\Application\Service;
+
+use App\User\Application\Validator\PasswordResetTokenValidatorInterface;
+use App\User\Domain\Contract\PasswordHasherInterface;
+use App\User\Domain\Entity\PasswordResetTokenInterface;
+use App\User\Domain\Entity\UserInterface;
+use App\User\Domain\Exception\UserNotFoundException;
+use App\User\Domain\Repository\PasswordResetTokenRepositoryInterface;
+use App\User\Domain\Repository\UserRepositoryInterface;
+
+final readonly class PasswordResetConfirmationService
+{
+    public function __construct(
+        private PasswordResetTokenRepositoryInterface $tokenRepository,
+        private UserRepositoryInterface $userRepository,
+        private PasswordHasherInterface $passwordHasher,
+        private PasswordResetTokenValidatorInterface $tokenValidator,
+    ) {
+    }
+
+    public function confirm(string $token, string $newPassword): UserInterface
+    {
+        $passwordResetToken = $this->getValidatedToken($token);
+        $user = $this->getUserFromToken($passwordResetToken);
+
+        $this->updateUserPassword($user, $newPassword);
+        $this->markTokenAsUsed($passwordResetToken);
+
+        return $user;
+    }
+
+    private function getValidatedToken(
+        string $token
+    ): PasswordResetTokenInterface {
+        $passwordResetToken = $this->tokenRepository->findByToken($token);
+        $this->tokenValidator->validate($passwordResetToken);
+        assert($passwordResetToken instanceof PasswordResetTokenInterface);
+
+        return $passwordResetToken;
+    }
+
+    private function getUserFromToken(
+        PasswordResetTokenInterface $token
+    ): UserInterface {
+        $user = $this->userRepository->findById($token->getUserID());
+
+        if (!$user instanceof UserInterface) {
+            throw new UserNotFoundException();
+        }
+
+        return $user;
+    }
+
+    private function markTokenAsUsed(
+        PasswordResetTokenInterface $token
+    ): void {
+        $token->markAsUsed();
+        $this->tokenRepository->save($token);
+    }
+
+    private function updateUserPassword(
+        UserInterface $user,
+        string $newPassword
+    ): void {
+        $hashedPassword = $this->passwordHasher->hash($newPassword);
+        $user->setPassword($hashedPassword);
+        $this->userRepository->save($user);
+    }
+}

--- a/src/User/Application/Service/RefreshTokenContextResolver.php
+++ b/src/User/Application/Service/RefreshTokenContextResolver.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\User\Application\Service;
+
+use App\User\Domain\Entity\AuthRefreshToken;
+use App\User\Domain\Entity\AuthSession;
+use App\User\Domain\Entity\User;
+use App\User\Domain\Repository\AuthRefreshTokenRepositoryInterface;
+use App\User\Domain\Repository\AuthSessionRepositoryInterface;
+use App\User\Domain\Repository\UserRepositoryInterface;
+use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
+
+final readonly class RefreshTokenContextResolver
+{
+    public function __construct(
+        private AuthRefreshTokenRepositoryInterface $refreshTokenRepository,
+        private AuthSessionRepositoryInterface $authSessionRepository,
+        private UserRepositoryInterface $userRepository,
+    ) {
+    }
+
+    /**
+     * @return array{AuthRefreshToken, AuthSession, User}
+     */
+    public function resolve(string $plainToken): array
+    {
+        $refreshToken = $this->resolveRefreshToken($plainToken);
+        $session = $this->resolveSession($refreshToken->getSessionId());
+
+        return [
+            $refreshToken,
+            $session,
+            $this->resolveUser($session->getUserId()),
+        ];
+    }
+
+    public function resolveRotatedRefreshToken(
+        string $plainToken
+    ): AuthRefreshToken {
+        $refreshToken = $this->resolveRefreshToken($plainToken);
+
+        if (!$refreshToken->isRotated()) {
+            $this->throwUnauthorized();
+        }
+
+        return $refreshToken;
+    }
+
+    private function resolveRefreshToken(
+        string $plainToken
+    ): AuthRefreshToken {
+        $hash = hash('sha256', $plainToken);
+        $token = $this->refreshTokenRepository->findByTokenHash($hash);
+
+        if (!$token instanceof AuthRefreshToken) {
+            $this->throwUnauthorized();
+        }
+
+        if ($token->isExpired() || $token->isRevoked()) {
+            $this->throwUnauthorized();
+        }
+
+        return $token;
+    }
+
+    private function resolveSession(string $sessionId): AuthSession
+    {
+        $session = $this->authSessionRepository->findById($sessionId);
+        if (!$session instanceof AuthSession) {
+            $this->throwUnauthorized();
+        }
+        if ($session->isRevoked() || $session->isExpired()) {
+            $this->throwUnauthorized();
+        }
+
+        return $session;
+    }
+
+    private function resolveUser(string $userId): User
+    {
+        $user = $this->userRepository->findById($userId);
+        if (!$user instanceof User) {
+            $this->throwUnauthorized();
+        }
+
+        return $user;
+    }
+
+    private function throwUnauthorized(): never
+    {
+        throw new UnauthorizedHttpException(
+            'Bearer',
+            'Invalid refresh token.'
+        );
+    }
+}

--- a/src/User/Application/Service/RefreshTokenContextResolver.php
+++ b/src/User/Application/Service/RefreshTokenContextResolver.php
@@ -51,7 +51,7 @@ final readonly class RefreshTokenContextResolver
     private function resolveRefreshToken(
         string $plainToken
     ): AuthRefreshToken {
-        $hash = hash('sha256', $plainToken);
+        $hash = AuthRefreshToken::hashPlainToken($plainToken);
         $token = $this->refreshTokenRepository->findByTokenHash($hash);
 
         if (!$token instanceof AuthRefreshToken) {

--- a/src/User/Application/Service/RefreshTokenContextResolver.php
+++ b/src/User/Application/Service/RefreshTokenContextResolver.php
@@ -51,8 +51,7 @@ final readonly class RefreshTokenContextResolver
     private function resolveRefreshToken(
         string $plainToken
     ): AuthRefreshToken {
-        $hash = AuthRefreshToken::hashPlainToken($plainToken);
-        $token = $this->refreshTokenRepository->findByTokenHash($hash);
+        $token = $this->refreshTokenRepository->findByPlainToken($plainToken);
 
         if (!$token instanceof AuthRefreshToken) {
             $this->throwUnauthorized();

--- a/src/User/Application/Service/RefreshTokenIssuer.php
+++ b/src/User/Application/Service/RefreshTokenIssuer.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\User\Application\Service;
+
+use App\User\Application\DTO\RefreshTokenCommandResponse;
+use App\User\Application\Factory\AccessTokenFactoryInterface;
+use App\User\Application\Factory\AuthTokenFactoryInterface;
+use App\User\Domain\Entity\AuthRefreshToken;
+use App\User\Domain\Entity\AuthSession;
+use App\User\Domain\Entity\User;
+use App\User\Domain\Repository\AuthRefreshTokenRepositoryInterface;
+use App\User\Infrastructure\Publisher\RefreshTokenPublisherInterface;
+use DateTimeImmutable;
+
+final readonly class RefreshTokenIssuer
+{
+    public function __construct(
+        private AuthRefreshTokenRepositoryInterface $refreshTokenRepository,
+        private AccessTokenFactoryInterface $accessTokenFactory,
+        private AuthTokenFactoryInterface $authTokenFactory,
+        private RefreshTokenPublisherInterface $publisher,
+    ) {
+    }
+
+    public function issueRotatedTokens(
+        User $user,
+        AuthSession $session
+    ): RefreshTokenCommandResponse {
+        $issuedAt = new DateTimeImmutable();
+
+        $newRefreshPlain = $this->authTokenFactory->generateOpaqueToken();
+        $this->refreshTokenRepository->save(
+            $this->createRefreshToken($session, $newRefreshPlain, $issuedAt)
+        );
+
+        $accessToken = $this->accessTokenFactory->create(
+            $this->authTokenFactory->buildJwtPayload(
+                $user,
+                $session->getId(),
+                $issuedAt
+            )
+        );
+
+        $this->publisher->publishTokenRotated(
+            $session->getId(),
+            $user->getId()
+        );
+
+        return new RefreshTokenCommandResponse($accessToken, $newRefreshPlain);
+    }
+
+    private function createRefreshToken(
+        AuthSession $session,
+        string $plainToken,
+        DateTimeImmutable $issuedAt
+    ): AuthRefreshToken {
+        return $this->authTokenFactory->createRefreshToken(
+            $session->getId(),
+            $plainToken,
+            $issuedAt
+        );
+    }
+}

--- a/src/User/Application/Service/RefreshTokenTheftDetector.php
+++ b/src/User/Application/Service/RefreshTokenTheftDetector.php
@@ -24,7 +24,7 @@ final readonly class RefreshTokenTheftDetector
     /**
      * @param list<AuthRefreshToken>|null $tokens
      */
-    public function detect(
+    public function respondToTheft(
         AuthRefreshToken $oldToken,
         AuthSession $session,
         User $user,
@@ -32,14 +32,16 @@ final readonly class RefreshTokenTheftDetector
         ?array $tokens = null
     ): never {
         $this->revokeSessionAndTokens($oldToken, $session, $tokens);
-        $this->publisher->publishTheftDetected(
-            $session->getId(),
-            $user->getId(),
-            $session->getIpAddress(),
-            $reason
-        );
-
-        $this->throwUnauthorized();
+        try {
+            $this->publisher->publishTheftDetected(
+                $session->getId(),
+                $user->getId(),
+                $session->getIpAddress(),
+                $reason
+            );
+        } finally {
+            $this->throwUnauthorized();
+        }
     }
 
     /**

--- a/src/User/Application/Service/RefreshTokenTheftDetector.php
+++ b/src/User/Application/Service/RefreshTokenTheftDetector.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\User\Application\Service;
+
+use App\User\Domain\Entity\AuthRefreshToken;
+use App\User\Domain\Entity\AuthSession;
+use App\User\Domain\Entity\User;
+use App\User\Domain\Repository\AuthRefreshTokenRepositoryInterface;
+use App\User\Domain\Repository\AuthSessionRepositoryInterface;
+use App\User\Infrastructure\Publisher\RefreshTokenPublisherInterface;
+use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
+
+final readonly class RefreshTokenTheftDetector
+{
+    public function __construct(
+        private AuthRefreshTokenRepositoryInterface $refreshTokenRepository,
+        private AuthSessionRepositoryInterface $authSessionRepository,
+        private RefreshTokenPublisherInterface $publisher,
+    ) {
+    }
+
+    /**
+     * @param list<AuthRefreshToken>|null $tokens
+     */
+    public function detect(
+        AuthRefreshToken $oldToken,
+        AuthSession $session,
+        User $user,
+        string $reason,
+        ?array $tokens = null
+    ): never {
+        $this->revokeSessionAndTokens($oldToken, $session, $tokens);
+        $this->publisher->publishTheftDetected(
+            $session->getId(),
+            $user->getId(),
+            $session->getIpAddress(),
+            $reason
+        );
+
+        $this->throwUnauthorized();
+    }
+
+    /**
+     * @param list<AuthRefreshToken>|null $tokens
+     */
+    private function revokeSessionAndTokens(
+        AuthRefreshToken $oldToken,
+        AuthSession $session,
+        ?array $tokens = null
+    ): void {
+        if (!$session->isRevoked()) {
+            $session->revoke();
+            $this->authSessionRepository->save($session);
+        }
+
+        $this->revokeRefreshTokens(
+            $this->resolveTokensForRevocation(
+                $oldToken,
+                $session,
+                $tokens
+            )
+        );
+    }
+
+    /**
+     * @param list<AuthRefreshToken>|null $tokens
+     *
+     * @return list<AuthRefreshToken>
+     */
+    private function resolveTokensForRevocation(
+        AuthRefreshToken $oldToken,
+        AuthSession $session,
+        ?array $tokens
+    ): array {
+        if ($tokens === null) {
+            $tokens = $this->refreshTokenRepository->findBySessionId(
+                $session->getId()
+            );
+        }
+
+        if ($tokens !== []) {
+            return $tokens;
+        }
+
+        return [$oldToken];
+    }
+
+    /**
+     * @param list<AuthRefreshToken> $tokens
+     */
+    private function revokeRefreshTokens(array $tokens): void
+    {
+        foreach ($tokens as $token) {
+            if ($token->isRevoked()) {
+                continue;
+            }
+
+            $token->revoke();
+            $this->refreshTokenRepository->save($token);
+        }
+    }
+
+    private function throwUnauthorized(): never
+    {
+        throw new UnauthorizedHttpException(
+            'Bearer',
+            'Invalid refresh token.'
+        );
+    }
+}

--- a/src/User/Application/Service/SignInCommandDispatcher.php
+++ b/src/User/Application/Service/SignInCommandDispatcher.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\User\Application\Service;
+
+use App\Shared\Application\Bus\Guard\CommandResponseTypeGuard;
+use App\Shared\Domain\Bus\Command\CommandBusInterface;
+use App\User\Application\DTO\SignInCommandResponse;
+use App\User\Application\DTO\SignInDto;
+use App\User\Application\Factory\SignInCommandFactoryInterface;
+use App\User\Application\Resolver\HttpRequestContextResolverInterface;
+
+final readonly class SignInCommandDispatcher
+{
+    public function __construct(
+        private CommandBusInterface $commandBus,
+        private CommandResponseTypeGuard $commandResponseTypeGuard,
+        private SignInCommandFactoryInterface $signInCommandFactory,
+        private HttpRequestContextResolverInterface $httpRequestContextResolver,
+    ) {
+    }
+
+    /**
+     * @param array{request?: object|null, ...} $context
+     */
+    public function dispatch(SignInDto $dto, array $context): SignInCommandResponse
+    {
+        $request = $this->httpRequestContextResolver->resolveRequest(
+            $context['request'] ?? null
+        );
+
+        $command = $this->signInCommandFactory->create(
+            $dto->emailValue(),
+            $dto->passwordValue(),
+            $dto->isRememberMe(),
+            $this->httpRequestContextResolver->resolveIpAddress($request),
+            $this->httpRequestContextResolver->resolveUserAgent($request)
+        );
+
+        return $this->commandResponseTypeGuard->expect(
+            $this->commandBus->dispatch($command),
+            SignInCommandResponse::class
+        );
+    }
+}

--- a/src/User/Domain/Entity/AuthRefreshToken.php
+++ b/src/User/Domain/Entity/AuthRefreshToken.php
@@ -20,12 +20,7 @@ final class AuthRefreshToken
         string $plainToken,
         private DateTimeImmutable $expiresAt
     ) {
-        $this->tokenHash = self::hashPlainToken($plainToken);
-    }
-
-    public static function hashPlainToken(string $plainToken): string
-    {
-        return hash('sha256', $plainToken);
+        $this->tokenHash = $this->hash($plainToken);
     }
 
     public function getId(): string
@@ -110,6 +105,11 @@ final class AuthRefreshToken
 
     public function matchesToken(string $plainToken): bool
     {
-        return hash_equals($this->tokenHash, self::hashPlainToken($plainToken));
+        return hash_equals($this->tokenHash, $this->hash($plainToken));
+    }
+
+    private function hash(string $value): string
+    {
+        return hash('sha256', $value);
     }
 }

--- a/src/User/Domain/Entity/AuthRefreshToken.php
+++ b/src/User/Domain/Entity/AuthRefreshToken.php
@@ -20,7 +20,12 @@ final class AuthRefreshToken
         string $plainToken,
         private DateTimeImmutable $expiresAt
     ) {
-        $this->tokenHash = $this->hash($plainToken);
+        $this->tokenHash = self::hashPlainToken($plainToken);
+    }
+
+    public static function hashPlainToken(string $plainToken): string
+    {
+        return hash('sha256', $plainToken);
     }
 
     public function getId(): string
@@ -105,11 +110,6 @@ final class AuthRefreshToken
 
     public function matchesToken(string $plainToken): bool
     {
-        return hash_equals($this->tokenHash, $this->hash($plainToken));
-    }
-
-    private function hash(string $value): string
-    {
-        return hash('sha256', $value);
+        return hash_equals($this->tokenHash, self::hashPlainToken($plainToken));
     }
 }

--- a/src/User/Infrastructure/Decorator/RateLimitedRequestPasswordResetHandlerDecorator.php
+++ b/src/User/Infrastructure/Decorator/RateLimitedRequestPasswordResetHandlerDecorator.php
@@ -6,6 +6,7 @@ namespace App\User\Infrastructure\Decorator;
 
 use App\User\Application\Command\RequestPasswordResetCommand;
 use App\User\Application\CommandHandler\RequestPasswordResetHandlerInterface;
+use App\User\Application\DTO\RequestPasswordResetCommandResponse;
 use App\User\Domain\Exception\PasswordResetRateLimitExceededException;
 use Symfony\Component\RateLimiter\RateLimiterFactory;
 
@@ -19,10 +20,11 @@ final readonly class RateLimitedRequestPasswordResetHandlerDecorator implements
     }
 
     #[\Override]
-    public function __invoke(RequestPasswordResetCommand $command): void
-    {
+    public function __invoke(
+        RequestPasswordResetCommand $command
+    ): RequestPasswordResetCommandResponse {
         $this->checkRateLimit($command->email);
-        $this->inner->__invoke($command);
+        return $this->inner->__invoke($command);
     }
 
     private function checkRateLimit(string $key): void

--- a/tests/Integration/User/Application/CommandHandler/SignInCommandHandlerIntegrationTest.php
+++ b/tests/Integration/User/Application/CommandHandler/SignInCommandHandlerIntegrationTest.php
@@ -9,6 +9,7 @@ use App\Tests\Integration\JwtPayloadDecoder;
 use App\Tests\Integration\User\UserIntegrationTestCase;
 use App\User\Application\Command\SignInCommand;
 use App\User\Application\CommandHandler\SignInCommandHandler;
+use App\User\Application\DTO\SignInCommandResponse;
 use App\User\Application\Factory\IdFactoryInterface;
 use App\User\Application\Factory\IssuedSessionFactoryInterface;
 use App\User\Application\Validator\UserCredentialValidatorInterface;
@@ -74,12 +75,11 @@ final class SignInCommandHandlerIntegrationTest extends UserIntegrationTestCase
             $ipAddress,
             $userAgent
         );
-        $this->createSignInHandler()->__invoke($command);
-        $response = $command->getResponse();
+        $response = $this->createSignInHandler()->__invoke($command);
         $this->assertFalse($response->isTwoFactorEnabled());
         $this->assertNotEmpty($response->getAccessToken());
         $this->assertNotEmpty($response->getRefreshToken());
-        $this->assertSessionAndTokenPersistence($command, $user, $ipAddress, $userAgent);
+        $this->assertSessionAndTokenPersistence($response, $user, $ipAddress, $userAgent);
     }
 
     private function createAndSaveUser(string $plainPassword): User
@@ -108,12 +108,11 @@ final class SignInCommandHandlerIntegrationTest extends UserIntegrationTestCase
     }
 
     private function assertSessionAndTokenPersistence(
-        SignInCommand $command,
+        SignInCommandResponse $response,
         User $user,
         string $ipAddress,
         string $userAgent
     ): void {
-        $response = $command->getResponse();
         $payload = JwtPayloadDecoder::decode($response->getAccessToken());
         $this->assertSame($user->getId(), $payload['sub'] ?? null);
         $sessionId = (string) ($payload['sid'] ?? '');

--- a/tests/Unit/Shared/Application/Bus/Command/CommandResponseTypeGuardTest.php
+++ b/tests/Unit/Shared/Application/Bus/Command/CommandResponseTypeGuardTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Shared\Application\Bus\Command;
+
+use App\Shared\Application\Bus\Command\CommandResponseTypeGuard;
+use App\Shared\Domain\Bus\Command\CommandResponseInterface;
+use App\Tests\Unit\UnitTestCase;
+
+final class CommandResponseTypeGuardTest extends UnitTestCase
+{
+    public function testExpectReturnsResponseWhenTypeMatches(): void
+    {
+        $response = new MatchingCommandResponse();
+
+        $this->assertSame(
+            $response,
+            CommandResponseTypeGuard::expect(
+                $response,
+                MatchingCommandResponse::class
+            )
+        );
+    }
+
+    public function testExpectThrowsWhenResponseIsMissing(): void
+    {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage(
+            'Expected command bus to return App\Tests\Unit\Shared\Application\Bus\Command\MatchingCommandResponse, got null.'
+        );
+
+        CommandResponseTypeGuard::expect(null, MatchingCommandResponse::class);
+    }
+
+    public function testExpectThrowsWhenTypeDoesNotMatch(): void
+    {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage(
+            'Expected command bus to return App\Tests\Unit\Shared\Application\Bus\Command\MatchingCommandResponse, got App\Tests\Unit\Shared\Application\Bus\Command\OtherCommandResponse.'
+        );
+
+        CommandResponseTypeGuard::expect(
+            new OtherCommandResponse(),
+            MatchingCommandResponse::class
+        );
+    }
+}
+
+final class MatchingCommandResponse implements CommandResponseInterface
+{
+}
+
+final class OtherCommandResponse implements CommandResponseInterface
+{
+}

--- a/tests/Unit/Shared/Application/Bus/Command/CommandResponseTypeGuardTest.php
+++ b/tests/Unit/Shared/Application/Bus/Command/CommandResponseTypeGuardTest.php
@@ -17,7 +17,7 @@ final class CommandResponseTypeGuardTest extends UnitTestCase
 
         $this->assertSame(
             $response,
-            CommandResponseTypeGuard::expect(
+            (new CommandResponseTypeGuard())->expect(
                 $response,
                 RequestPasswordResetCommandResponse::class
             )
@@ -32,7 +32,7 @@ final class CommandResponseTypeGuardTest extends UnitTestCase
             RequestPasswordResetCommandResponse::class
         ));
 
-        CommandResponseTypeGuard::expect(
+        (new CommandResponseTypeGuard())->expect(
             null,
             RequestPasswordResetCommandResponse::class
         );
@@ -47,7 +47,7 @@ final class CommandResponseTypeGuardTest extends UnitTestCase
             ConfirmPasswordResetCommandResponse::class
         ));
 
-        CommandResponseTypeGuard::expect(
+        (new CommandResponseTypeGuard())->expect(
             new ConfirmPasswordResetCommandResponse(),
             RequestPasswordResetCommandResponse::class
         );

--- a/tests/Unit/Shared/Application/Bus/Command/CommandResponseTypeGuardTest.php
+++ b/tests/Unit/Shared/Application/Bus/Command/CommandResponseTypeGuardTest.php
@@ -5,20 +5,21 @@ declare(strict_types=1);
 namespace App\Tests\Unit\Shared\Application\Bus\Command;
 
 use App\Shared\Application\Bus\Command\CommandResponseTypeGuard;
-use App\Shared\Domain\Bus\Command\CommandResponseInterface;
 use App\Tests\Unit\UnitTestCase;
+use App\User\Application\DTO\ConfirmPasswordResetCommandResponse;
+use App\User\Application\DTO\RequestPasswordResetCommandResponse;
 
 final class CommandResponseTypeGuardTest extends UnitTestCase
 {
     public function testExpectReturnsResponseWhenTypeMatches(): void
     {
-        $response = new MatchingCommandResponse();
+        $response = new RequestPasswordResetCommandResponse();
 
         $this->assertSame(
             $response,
             CommandResponseTypeGuard::expect(
                 $response,
-                MatchingCommandResponse::class
+                RequestPasswordResetCommandResponse::class
             )
         );
     }
@@ -26,31 +27,29 @@ final class CommandResponseTypeGuardTest extends UnitTestCase
     public function testExpectThrowsWhenResponseIsMissing(): void
     {
         $this->expectException(\LogicException::class);
-        $this->expectExceptionMessage(
-            'Expected command bus to return App\Tests\Unit\Shared\Application\Bus\Command\MatchingCommandResponse, got null.'
-        );
+        $this->expectExceptionMessage(sprintf(
+            'Expected command bus to return %s, got null.',
+            RequestPasswordResetCommandResponse::class
+        ));
 
-        CommandResponseTypeGuard::expect(null, MatchingCommandResponse::class);
+        CommandResponseTypeGuard::expect(
+            null,
+            RequestPasswordResetCommandResponse::class
+        );
     }
 
     public function testExpectThrowsWhenTypeDoesNotMatch(): void
     {
         $this->expectException(\LogicException::class);
-        $this->expectExceptionMessage(
-            'Expected command bus to return App\Tests\Unit\Shared\Application\Bus\Command\MatchingCommandResponse, got App\Tests\Unit\Shared\Application\Bus\Command\OtherCommandResponse.'
-        );
+        $this->expectExceptionMessage(sprintf(
+            'Expected command bus to return %s, got %s.',
+            RequestPasswordResetCommandResponse::class,
+            ConfirmPasswordResetCommandResponse::class
+        ));
 
         CommandResponseTypeGuard::expect(
-            new OtherCommandResponse(),
-            MatchingCommandResponse::class
+            new ConfirmPasswordResetCommandResponse(),
+            RequestPasswordResetCommandResponse::class
         );
     }
-}
-
-final class MatchingCommandResponse implements CommandResponseInterface
-{
-}
-
-final class OtherCommandResponse implements CommandResponseInterface
-{
 }

--- a/tests/Unit/Shared/Application/Bus/Guard/CommandResponseTypeGuardTest.php
+++ b/tests/Unit/Shared/Application/Bus/Guard/CommandResponseTypeGuardTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace App\Tests\Unit\Shared\Application\Bus\Command;
+namespace App\Tests\Unit\Shared\Application\Bus\Guard;
 
-use App\Shared\Application\Bus\Command\CommandResponseTypeGuard;
+use App\Shared\Application\Bus\Guard\CommandResponseTypeGuard;
 use App\Tests\Unit\UnitTestCase;
 use App\User\Application\DTO\ConfirmPasswordResetCommandResponse;
 use App\User\Application\DTO\RequestPasswordResetCommandResponse;

--- a/tests/Unit/Shared/Infrastructure/Bus/Command/InMemorySymfonyCommandBusTest.php
+++ b/tests/Unit/Shared/Infrastructure/Bus/Command/InMemorySymfonyCommandBusTest.php
@@ -138,21 +138,7 @@ final class InMemorySymfonyCommandBusTest extends UnitTestCase
     public function testDispatchReturnsNullWhenHandlerReturnsNull(): void
     {
         $command = $this->createMock(CommandInterface::class);
-        $messageBus = $this->createMock(MessageBus::class);
-        $messageBus->expects($this->once())
-            ->method('dispatch')
-            ->with($command)
-            ->willReturn(
-                (new Envelope($command))->with(
-                    new HandledStamp(null, 'handler')
-                )
-            );
-        $this->messageBusFactory->method('create')
-            ->willReturn($messageBus);
-        $commandBus = new InMemorySymfonyCommandBus(
-            $this->messageBusFactory,
-            $this->commandHandlers
-        );
+        $commandBus = $this->createCommandBusReturning($command, null);
 
         $this->assertNull($commandBus->dispatch($command));
     }
@@ -160,21 +146,7 @@ final class InMemorySymfonyCommandBusTest extends UnitTestCase
     public function testDispatchRejectsUnsupportedHandlerResult(): void
     {
         $command = $this->createMock(CommandInterface::class);
-        $messageBus = $this->createMock(MessageBus::class);
-        $messageBus->expects($this->once())
-            ->method('dispatch')
-            ->with($command)
-            ->willReturn(
-                (new Envelope($command))->with(
-                    new HandledStamp('unexpected-result', 'handler')
-                )
-            );
-        $this->messageBusFactory->method('create')
-            ->willReturn($messageBus);
-        $commandBus = new InMemorySymfonyCommandBus(
-            $this->messageBusFactory,
-            $this->commandHandlers
-        );
+        $commandBus = $this->createCommandBusReturning($command, 'unexpected-result');
 
         $this->expectException(\LogicException::class);
         $this->expectExceptionMessage(sprintf(
@@ -183,5 +155,27 @@ final class InMemorySymfonyCommandBusTest extends UnitTestCase
         ));
 
         $commandBus->dispatch($command);
+    }
+
+    private function createCommandBusReturning(
+        CommandInterface $command,
+        CommandResponseInterface|string|null $result
+    ): InMemorySymfonyCommandBus {
+        $messageBus = $this->createMock(MessageBus::class);
+        $messageBus->expects($this->once())
+            ->method('dispatch')
+            ->with($command)
+            ->willReturn(
+                (new Envelope($command))->with(
+                    new HandledStamp($result, 'handler')
+                )
+            );
+        $this->messageBusFactory->method('create')
+            ->willReturn($messageBus);
+
+        return new InMemorySymfonyCommandBus(
+            $this->messageBusFactory,
+            $this->commandHandlers
+        );
     }
 }

--- a/tests/Unit/Shared/Infrastructure/Bus/Command/InMemorySymfonyCommandBusTest.php
+++ b/tests/Unit/Shared/Infrastructure/Bus/Command/InMemorySymfonyCommandBusTest.php
@@ -134,4 +134,54 @@ final class InMemorySymfonyCommandBusTest extends UnitTestCase
 
         $this->assertNull($commandBus->dispatch($command));
     }
+
+    public function testDispatchReturnsNullWhenHandlerReturnsNull(): void
+    {
+        $command = $this->createMock(CommandInterface::class);
+        $messageBus = $this->createMock(MessageBus::class);
+        $messageBus->expects($this->once())
+            ->method('dispatch')
+            ->with($command)
+            ->willReturn(
+                (new Envelope($command))->with(
+                    new HandledStamp(null, 'handler')
+                )
+            );
+        $this->messageBusFactory->method('create')
+            ->willReturn($messageBus);
+        $commandBus = new InMemorySymfonyCommandBus(
+            $this->messageBusFactory,
+            $this->commandHandlers
+        );
+
+        $this->assertNull($commandBus->dispatch($command));
+    }
+
+    public function testDispatchRejectsUnsupportedHandlerResult(): void
+    {
+        $command = $this->createMock(CommandInterface::class);
+        $messageBus = $this->createMock(MessageBus::class);
+        $messageBus->expects($this->once())
+            ->method('dispatch')
+            ->with($command)
+            ->willReturn(
+                (new Envelope($command))->with(
+                    new HandledStamp('unexpected-result', 'handler')
+                )
+            );
+        $this->messageBusFactory->method('create')
+            ->willReturn($messageBus);
+        $commandBus = new InMemorySymfonyCommandBus(
+            $this->messageBusFactory,
+            $this->commandHandlers
+        );
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage(sprintf(
+            'Command handler for %s returned unsupported result string.',
+            $command::class
+        ));
+
+        $commandBus->dispatch($command);
+    }
 }

--- a/tests/Unit/Shared/Infrastructure/Bus/Command/InMemorySymfonyCommandBusTest.php
+++ b/tests/Unit/Shared/Infrastructure/Bus/Command/InMemorySymfonyCommandBusTest.php
@@ -5,13 +5,16 @@ declare(strict_types=1);
 namespace App\Tests\Unit\Shared\Infrastructure\Bus\Command;
 
 use App\Shared\Domain\Bus\Command\CommandInterface;
+use App\Shared\Domain\Bus\Command\CommandResponseInterface;
 use App\Shared\Infrastructure\Bus\Command\CommandNotRegisteredException;
 use App\Shared\Infrastructure\Bus\Command\InMemorySymfonyCommandBus;
 use App\Shared\Infrastructure\Bus\MessageBusFactory;
 use App\Tests\Unit\UnitTestCase;
+use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\HandlerFailedException;
 use Symfony\Component\Messenger\Exception\NoHandlerForMessageException;
 use Symfony\Component\Messenger\MessageBus;
+use Symfony\Component\Messenger\Stamp\HandledStamp;
 
 final class InMemorySymfonyCommandBusTest extends UnitTestCase
 {
@@ -89,5 +92,46 @@ final class InMemorySymfonyCommandBusTest extends UnitTestCase
         $this->expectException(\RuntimeException::class);
 
         $commandBus->dispatch($command);
+    }
+
+    public function testDispatchReturnsHandledCommandResponse(): void
+    {
+        $command = $this->createMock(CommandInterface::class);
+        $response = $this->createMock(CommandResponseInterface::class);
+        $messageBus = $this->createMock(MessageBus::class);
+        $messageBus->expects($this->once())
+            ->method('dispatch')
+            ->with($command)
+            ->willReturn(
+                (new Envelope($command))->with(
+                    new HandledStamp($response, 'handler')
+                )
+            );
+        $this->messageBusFactory->method('create')
+            ->willReturn($messageBus);
+        $commandBus = new InMemorySymfonyCommandBus(
+            $this->messageBusFactory,
+            $this->commandHandlers
+        );
+
+        $this->assertSame($response, $commandBus->dispatch($command));
+    }
+
+    public function testDispatchReturnsNullWhenHandlerHasNoResponse(): void
+    {
+        $command = $this->createMock(CommandInterface::class);
+        $messageBus = $this->createMock(MessageBus::class);
+        $messageBus->expects($this->once())
+            ->method('dispatch')
+            ->with($command)
+            ->willReturn(new Envelope($command));
+        $this->messageBusFactory->method('create')
+            ->willReturn($messageBus);
+        $commandBus = new InMemorySymfonyCommandBus(
+            $this->messageBusFactory,
+            $this->commandHandlers
+        );
+
+        $this->assertNull($commandBus->dispatch($command));
     }
 }

--- a/tests/Unit/Shared/Infrastructure/Bus/Command/InMemorySymfonyCommandBusTest.php
+++ b/tests/Unit/Shared/Infrastructure/Bus/Command/InMemorySymfonyCommandBusTest.php
@@ -98,23 +98,29 @@ final class InMemorySymfonyCommandBusTest extends UnitTestCase
     {
         $command = $this->createMock(CommandInterface::class);
         $response = $this->createMock(CommandResponseInterface::class);
-        $messageBus = $this->createMock(MessageBus::class);
-        $messageBus->expects($this->once())
-            ->method('dispatch')
-            ->with($command)
-            ->willReturn(
-                (new Envelope($command))->with(
-                    new HandledStamp($response, 'handler')
-                )
-            );
-        $this->messageBusFactory->method('create')
-            ->willReturn($messageBus);
-        $commandBus = new InMemorySymfonyCommandBus(
-            $this->messageBusFactory,
-            $this->commandHandlers
-        );
+        $commandBus = $this->createCommandBusReturning($command, $response);
 
         $this->assertSame($response, $commandBus->dispatch($command));
+    }
+
+    public function testDispatchRejectsMultipleHandledResults(): void
+    {
+        $command = $this->createMock(CommandInterface::class);
+        $firstResponse = $this->createMock(CommandResponseInterface::class);
+        $secondResponse = $this->createMock(CommandResponseInterface::class);
+        $commandBus = $this->createCommandBusReturningMultipleResults(
+            $command,
+            $firstResponse,
+            $secondResponse
+        );
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage(sprintf(
+            'Command %s resolved to 2 handlers; exactly one is required.',
+            $command::class
+        ));
+
+        $commandBus->dispatch($command);
     }
 
     public function testDispatchReturnsNullWhenHandlerHasNoResponse(): void
@@ -157,19 +163,40 @@ final class InMemorySymfonyCommandBusTest extends UnitTestCase
         $commandBus->dispatch($command);
     }
 
+    private function createCommandBusReturningMultipleResults(
+        CommandInterface $command,
+        CommandResponseInterface $firstResponse,
+        CommandResponseInterface $secondResponse
+    ): InMemorySymfonyCommandBus {
+        return $this->createCommandBusDispatchingEnvelope(
+            $command,
+            (new Envelope($command))
+                ->with(new HandledStamp($firstResponse, 'first-handler'))
+                ->with(new HandledStamp($secondResponse, 'second-handler'))
+        );
+    }
+
     private function createCommandBusReturning(
         CommandInterface $command,
         CommandResponseInterface|string|null $result
+    ): InMemorySymfonyCommandBus {
+        return $this->createCommandBusDispatchingEnvelope(
+            $command,
+            (new Envelope($command))->with(
+                new HandledStamp($result, 'handler')
+            )
+        );
+    }
+
+    private function createCommandBusDispatchingEnvelope(
+        CommandInterface $command,
+        Envelope $envelope
     ): InMemorySymfonyCommandBus {
         $messageBus = $this->createMock(MessageBus::class);
         $messageBus->expects($this->once())
             ->method('dispatch')
             ->with($command)
-            ->willReturn(
-                (new Envelope($command))->with(
-                    new HandledStamp($result, 'handler')
-                )
-            );
+            ->willReturn($envelope);
         $this->messageBusFactory->method('create')
             ->willReturn($messageBus);
 

--- a/tests/Unit/User/Application/Command/ConfirmPasswordResetCommandTest.php
+++ b/tests/Unit/User/Application/Command/ConfirmPasswordResetCommandTest.php
@@ -6,7 +6,6 @@ namespace App\Tests\Unit\User\Application\Command;
 
 use App\Tests\Unit\UnitTestCase;
 use App\User\Application\Command\ConfirmPasswordResetCommand;
-use App\User\Application\DTO\ConfirmPasswordResetCommandResponse;
 
 final class ConfirmPasswordResetCommandTest extends UnitTestCase
 {
@@ -20,18 +19,5 @@ final class ConfirmPasswordResetCommandTest extends UnitTestCase
         $this->assertInstanceOf(ConfirmPasswordResetCommand::class, $command);
         $this->assertSame($token, $command->token);
         $this->assertSame($newPassword, $command->newPassword);
-    }
-
-    public function testSetAndGetResponse(): void
-    {
-        $token = $this->faker->sha256();
-        $newPassword = $this->faker->password();
-
-        $command = new ConfirmPasswordResetCommand($token, $newPassword);
-        $response = new ConfirmPasswordResetCommandResponse();
-
-        $command->setResponse($response);
-
-        $this->assertSame($response, $command->getResponse());
     }
 }

--- a/tests/Unit/User/Application/Command/RegisterUserBatchCommandTest.php
+++ b/tests/Unit/User/Application/Command/RegisterUserBatchCommandTest.php
@@ -8,7 +8,6 @@ use App\Shared\Infrastructure\Factory\UuidFactory;
 use App\Shared\Infrastructure\Transformer\UuidTransformer;
 use App\Tests\Unit\UnitTestCase;
 use App\User\Application\Command\RegisterUserBatchCommand;
-use App\User\Application\DTO\RegisterUserBatchCommandResponse;
 use App\User\Domain\Collection\UserCollection;
 use App\User\Domain\Factory\UserFactory;
 use App\User\Domain\Factory\UserFactoryInterface;
@@ -46,32 +45,6 @@ final class RegisterUserBatchCommandTest extends UnitTestCase
 
         $command = new RegisterUserBatchCommand(new UserCollection($users));
 
-        $this->assertEquals(new UserCollection($users), $command->users);
-    }
-
-    public function testGetResponse(): void
-    {
-        $users = [];
-        for ($i = 0; $i < self::BATCH_SIZE; $i++) {
-            $email = $this->faker->email();
-            $initials = $this->faker->name();
-            $password = $this->faker->password();
-
-            $users[] = $this->userFactory->create(
-                $email,
-                $initials,
-                $password,
-                $this->transformer->transformFromString($this->faker->uuid())
-            );
-        }
-
-        $command = new RegisterUserBatchCommand(new UserCollection($users));
-        $response =
-            new RegisterUserBatchCommandResponse(new UserCollection($users));
-
-        $command->setResponse($response);
-
-        $this->assertSame($response, $command->getResponse());
         $this->assertEquals(new UserCollection($users), $command->users);
     }
 }

--- a/tests/Unit/User/Application/Command/RequestPasswordResetCommandTest.php
+++ b/tests/Unit/User/Application/Command/RequestPasswordResetCommandTest.php
@@ -6,7 +6,6 @@ namespace App\Tests\Unit\User\Application\Command;
 
 use App\Tests\Unit\UnitTestCase;
 use App\User\Application\Command\RequestPasswordResetCommand;
-use App\User\Application\DTO\RequestPasswordResetCommandResponse;
 
 final class RequestPasswordResetCommandTest extends UnitTestCase
 {
@@ -18,17 +17,5 @@ final class RequestPasswordResetCommandTest extends UnitTestCase
 
         $this->assertInstanceOf(RequestPasswordResetCommand::class, $command);
         $this->assertSame($email, $command->email);
-    }
-
-    public function testSetAndGetResponse(): void
-    {
-        $email = $this->faker->safeEmail();
-
-        $command = new RequestPasswordResetCommand($email);
-        $response = new RequestPasswordResetCommandResponse();
-
-        $command->setResponse($response);
-
-        $this->assertSame($response, $command->getResponse());
     }
 }

--- a/tests/Unit/User/Application/Command/SignUpCommandTest.php
+++ b/tests/Unit/User/Application/Command/SignUpCommandTest.php
@@ -4,28 +4,11 @@ declare(strict_types=1);
 
 namespace App\Tests\Unit\User\Application\Command;
 
-use App\Shared\Infrastructure\Factory\UuidFactory;
-use App\Shared\Infrastructure\Transformer\UuidTransformer;
 use App\Tests\Unit\UnitTestCase;
 use App\User\Application\Command\RegisterUserCommand;
-use App\User\Application\DTO\RegisterUserCommandResponse;
-use App\User\Domain\Factory\UserFactory;
-use App\User\Domain\Factory\UserFactoryInterface;
 
 final class SignUpCommandTest extends UnitTestCase
 {
-    private UserFactoryInterface $userFactory;
-    private UuidTransformer $transformer;
-
-    #[\Override]
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        $this->userFactory = new UserFactory();
-        $this->transformer = new UuidTransformer(new UuidFactory());
-    }
-
     public function testConstructor(): void
     {
         $email = $this->faker->email();
@@ -38,27 +21,5 @@ final class SignUpCommandTest extends UnitTestCase
         $this->assertSame($email, $command->email);
         $this->assertSame($initials, $command->initials);
         $this->assertSame($password, $command->password);
-    }
-
-    public function testGetResponse(): void
-    {
-        $email = $this->faker->email();
-        $initials = $this->faker->name();
-        $password = $this->faker->password();
-
-        $user = $this->userFactory->create(
-            $email,
-            $initials,
-            $password,
-            $this->transformer->transformFromString($this->faker->uuid())
-        );
-
-        $command = new RegisterUserCommand($email, $initials, $password);
-        $response = new RegisterUserCommandResponse($user);
-
-        $command->setResponse($response);
-
-        $this->assertSame($response, $command->getResponse());
-        $this->assertSame($user, $command->getResponse()->createdUser);
     }
 }

--- a/tests/Unit/User/Application/CommandHandler/CompleteTwoFactorCommandHandlerSuccessPathTest.php
+++ b/tests/Unit/User/Application/CommandHandler/CompleteTwoFactorCommandHandlerSuccessPathTest.php
@@ -9,6 +9,7 @@ use App\Shared\Infrastructure\Transformer\UuidTransformer;
 use App\Tests\Unit\UnitTestCase;
 use App\User\Application\Command\CompleteTwoFactorCommand;
 use App\User\Application\CommandHandler\CompleteTwoFactorCommandHandler;
+use App\User\Application\DTO\CompleteTwoFactorCommandResponse;
 use App\User\Application\DTO\IssuedSession;
 use App\User\Application\Factory\IssuedSessionFactoryInterface;
 use App\User\Application\Validator\TwoFactorCodeValidatorInterface;
@@ -60,14 +61,14 @@ final class CompleteTwoFactorCommandHandlerSuccessPathTest extends UnitTestCase
         $this->expectIssuedSession('issued-access-token', 'issued-refresh-token');
         $this->expectPendingConsumeAndCompletion($pending);
 
-        $command = $this->invokeHandlerWith($pending->getId(), '123456', $ipAddress, $userAgent);
-        $this->assertSame('issued-access-token', $command->getResponse()->getAccessToken());
-        $this->assertNotEmpty($command->getResponse()->getRefreshToken());
+        $response = $this->invokeHandlerWith($pending->getId(), '123456', $ipAddress, $userAgent);
+        $this->assertSame('issued-access-token', $response->getAccessToken());
+        $this->assertNotEmpty($response->getRefreshToken());
         $this->assertNotSame(
-            $command->getResponse()->getAccessToken(),
-            $command->getResponse()->getRefreshToken()
+            $response->getAccessToken(),
+            $response->getRefreshToken()
         );
-        $this->assertFalse($command->getResponse()->isRememberMe());
+        $this->assertFalse($response->isRememberMe());
     }
 
     public function testInvokeCompletesTwoFactorWithRememberMeFromPendingSession(): void
@@ -86,13 +87,13 @@ final class CompleteTwoFactorCommandHandlerSuccessPathTest extends UnitTestCase
         $this->pendingTwoFactorRepository->method('consumeIfActive')->willReturn(true);
         $this->events->method('publishCompleted');
 
-        $command = $this->invokeHandlerWith(
+        $response = $this->invokeHandlerWith(
             $pending->getId(),
             '123456',
             $this->faker->ipv4(),
             $this->faker->userAgent()
         );
-        $this->assertTrue($command->getResponse()->isRememberMe());
+        $this->assertTrue($response->isRememberMe());
     }
 
     public function testInvokeCompletesTwoFactorWithRecoveryCodeAndIssuesTokens(): void
@@ -108,8 +109,8 @@ final class CompleteTwoFactorCommandHandlerSuccessPathTest extends UnitTestCase
         $this->expectPendingConsumeAndCompletion($pending);
         $this->events->expects($this->once())->method('publishRecoveryCodeUsed');
 
-        $command = $this->invokeHandlerWith($pending->getId(), 'AB12-CD34', $ip, $ua);
-        $this->assertZeroRemainingCodesResponse($command, 'issued-access-token');
+        $response = $this->invokeHandlerWith($pending->getId(), 'AB12-CD34', $ip, $ua);
+        $this->assertZeroRemainingCodesResponse($response, 'issued-access-token');
     }
 
     public function testInvokeUsesLaterUnusedRecoveryCodeWhenEarlierCodeIsUsed(): void
@@ -120,13 +121,13 @@ final class CompleteTwoFactorCommandHandlerSuccessPathTest extends UnitTestCase
         $this->expectRecoveryCodeVerification($user, 'CC33-DD44', 4);
         $this->expectIssuedSession('test-access-token', 'test-refresh-token');
         $this->expectPendingConsumeAndCompletion($pending);
-        $command = $this->invokeHandlerWith(
+        $response = $this->invokeHandlerWith(
             $pending->getId(),
             'CC33-DD44',
             $this->faker->ipv4(),
             $this->faker->userAgent()
         );
-        $this->assertSame('test-access-token', $command->getResponse()->getAccessToken());
+        $this->assertSame('test-access-token', $response->getAccessToken());
     }
 
     public function testRecoveryCodeSignInIncludesWarningWhenFewCodesRemain(): void
@@ -138,16 +139,16 @@ final class CompleteTwoFactorCommandHandlerSuccessPathTest extends UnitTestCase
         $this->expectIssuedSession('access-token', 'refresh-token');
         $this->expectPendingConsumeAndCompletion($pending);
         $this->events->expects($this->once())->method('publishRecoveryCodeUsed');
-        $command = $this->invokeHandlerWith(
+        $response = $this->invokeHandlerWith(
             $pending->getId(),
             'AB12-CD34',
             $this->faker->ipv4(),
             $this->faker->userAgent()
         );
-        $this->assertSame(2, $command->getResponse()->getRecoveryCodesRemaining());
+        $this->assertSame(2, $response->getRecoveryCodesRemaining());
         $this->assertStringContainsString(
             '2',
-            (string) $command->getResponse()->getWarningMessage()
+            (string) $response->getWarningMessage()
         );
     }
 
@@ -161,14 +162,14 @@ final class CompleteTwoFactorCommandHandlerSuccessPathTest extends UnitTestCase
         $this->expectIssuedSession('access-token', 'refresh-token');
         $this->expectPendingConsumeAndCompletion($pending);
 
-        $command = $this->invokeHandlerWith(
+        $response = $this->invokeHandlerWith(
             $pending->getId(),
             'AB12-CD34',
             $this->faker->ipv4(),
             $this->faker->userAgent()
         );
-        $this->assertNull($command->getResponse()->getRecoveryCodesRemaining());
-        $this->assertNull($command->getResponse()->getWarningMessage());
+        $this->assertNull($response->getRecoveryCodesRemaining());
+        $this->assertNull($response->getWarningMessage());
     }
 
     public function testTotpSignInDoesNotIncludeRecoveryCodeInfo(): void
@@ -191,14 +192,14 @@ final class CompleteTwoFactorCommandHandlerSuccessPathTest extends UnitTestCase
         $this->events->expects($this->once())->method('publishCompleted');
         $this->pendingTwoFactorRepository->method('consumeIfActive')->willReturn(true);
 
-        $command = $this->invokeHandlerWith(
+        $response = $this->invokeHandlerWith(
             $pending->getId(),
             '123456',
             $this->faker->ipv4(),
             $this->faker->userAgent()
         );
-        $this->assertNull($command->getResponse()->getRecoveryCodesRemaining());
-        $this->assertNull($command->getResponse()->getWarningMessage());
+        $this->assertNull($response->getRecoveryCodesRemaining());
+        $this->assertNull($response->getWarningMessage());
     }
 
     private function configureLookupsOnce(PendingTwoFactor $pending, User $user): void
@@ -263,23 +264,23 @@ final class CompleteTwoFactorCommandHandlerSuccessPathTest extends UnitTestCase
         string $code,
         string $ipAddress,
         string $userAgent
-    ): CompleteTwoFactorCommand {
+    ): CompleteTwoFactorCommandResponse {
         $handler = $this->createHandler();
         $command = new CompleteTwoFactorCommand($pendingId, $code, $ipAddress, $userAgent);
-        $handler->__invoke($command);
-        return $command;
+
+        return $handler->__invoke($command);
     }
 
     private function assertZeroRemainingCodesResponse(
-        CompleteTwoFactorCommand $command,
+        CompleteTwoFactorCommandResponse $response,
         string $expectedAccess
     ): void {
-        $this->assertSame($expectedAccess, $command->getResponse()->getAccessToken());
-        $this->assertNotEmpty($command->getResponse()->getRefreshToken());
-        $this->assertSame(0, $command->getResponse()->getRecoveryCodesRemaining());
+        $this->assertSame($expectedAccess, $response->getAccessToken());
+        $this->assertNotEmpty($response->getRefreshToken());
+        $this->assertSame(0, $response->getRecoveryCodesRemaining());
         $this->assertSame(
             'All recovery codes have been used. Regenerate immediately.',
-            $command->getResponse()->getWarningMessage()
+            $response->getWarningMessage()
         );
     }
 

--- a/tests/Unit/User/Application/CommandHandler/CompleteTwoFactorCommandHandlerTest.php
+++ b/tests/Unit/User/Application/CommandHandler/CompleteTwoFactorCommandHandlerTest.php
@@ -9,6 +9,7 @@ use App\Shared\Infrastructure\Transformer\UuidTransformer;
 use App\Tests\Unit\UnitTestCase;
 use App\User\Application\Command\CompleteTwoFactorCommand;
 use App\User\Application\CommandHandler\CompleteTwoFactorCommandHandler;
+use App\User\Application\DTO\CompleteTwoFactorCommandResponse;
 use App\User\Application\DTO\IssuedSession;
 use App\User\Application\Factory\IssuedSessionFactoryInterface;
 use App\User\Application\Validator\TwoFactorCodeValidatorInterface;
@@ -251,8 +252,8 @@ final class CompleteTwoFactorCommandHandlerTest extends UnitTestCase
             $this->faker->userAgent()
         );
 
-        $this->createHandler()->__invoke($command);
-        $this->assertResponseTokens($command, 'access-token', 'refresh-token');
+        $response = $this->createHandler()->__invoke($command);
+        $this->assertResponseTokens($response, 'access-token', 'refresh-token');
     }
 
     public function testInvokeThrowsUnauthorizedWhenPendingSessionConsumeFails(): void
@@ -322,11 +323,10 @@ final class CompleteTwoFactorCommandHandlerTest extends UnitTestCase
     }
 
     private function assertResponseTokens(
-        CompleteTwoFactorCommand $command,
+        CompleteTwoFactorCommandResponse $response,
         string $expectedAccessToken,
         string $expectedRefreshToken
     ): void {
-        $response = $command->getResponse();
         $this->assertSame($expectedAccessToken, $response->getAccessToken());
         $this->assertSame($expectedRefreshToken, $response->getRefreshToken());
     }

--- a/tests/Unit/User/Application/CommandHandler/ConfirmPasswordResetCommandHandlerTest.php
+++ b/tests/Unit/User/Application/CommandHandler/ConfirmPasswordResetCommandHandlerTest.php
@@ -11,6 +11,7 @@ use App\User\Application\Command\SignOutAllCommand;
 use App\User\Application\CommandHandler\ConfirmPasswordResetCommandHandler;
 use App\User\Application\DTO\ConfirmPasswordResetCommandResponse;
 use App\User\Application\Provider\AccountLockoutProviderInterface;
+use App\User\Application\Service\PasswordResetConfirmationService;
 use App\User\Application\Validator\PasswordResetTokenValidatorInterface;
 use App\User\Domain\Contract\PasswordHasherInterface;
 use App\User\Domain\Entity\PasswordResetTokenInterface;
@@ -48,11 +49,14 @@ final class ConfirmPasswordResetCommandHandlerTest extends UnitTestCase
         $this->commandBus = $this->createMock(CommandBusInterface::class);
         $this->publisher = $this->createMock(PasswordResetConfirmationPublisherInterface::class);
 
-        $this->handler = new ConfirmPasswordResetCommandHandler(
+        $confirmationService = new PasswordResetConfirmationService(
             $this->tokenRepository,
             $this->userRepository,
             $this->passwordHasher,
             $this->tokenValidator,
+        );
+        $this->handler = new ConfirmPasswordResetCommandHandler(
+            $confirmationService,
             $this->accountLockoutGuard,
             $this->commandBus,
             $this->publisher,

--- a/tests/Unit/User/Application/CommandHandler/ConfirmPasswordResetCommandHandlerTest.php
+++ b/tests/Unit/User/Application/CommandHandler/ConfirmPasswordResetCommandHandlerTest.php
@@ -9,6 +9,7 @@ use App\Tests\Unit\UnitTestCase;
 use App\User\Application\Command\ConfirmPasswordResetCommand;
 use App\User\Application\Command\SignOutAllCommand;
 use App\User\Application\CommandHandler\ConfirmPasswordResetCommandHandler;
+use App\User\Application\DTO\ConfirmPasswordResetCommandResponse;
 use App\User\Application\Provider\AccountLockoutProviderInterface;
 use App\User\Application\Validator\PasswordResetTokenValidatorInterface;
 use App\User\Domain\Contract\PasswordHasherInterface;
@@ -66,11 +67,11 @@ final class ConfirmPasswordResetCommandHandlerTest extends UnitTestCase
 
         $this->setupConfirmPasswordResetExpectations($testData, $mocks);
 
-        $this->handler->__invoke($command);
+        $response = $this->handler->__invoke($command);
 
         $this->assertInstanceOf(
-            \App\User\Application\DTO\ConfirmPasswordResetCommandResponse::class,
-            $command->getResponse()
+            ConfirmPasswordResetCommandResponse::class,
+            $response
         );
     }
 

--- a/tests/Unit/User/Application/CommandHandler/ConfirmTwoFactorCommandHandlerTest.php
+++ b/tests/Unit/User/Application/CommandHandler/ConfirmTwoFactorCommandHandlerTest.php
@@ -9,6 +9,7 @@ use App\Shared\Infrastructure\Transformer\UuidTransformer;
 use App\Tests\Unit\UnitTestCase;
 use App\User\Application\Command\ConfirmTwoFactorCommand;
 use App\User\Application\CommandHandler\ConfirmTwoFactorCommandHandler;
+use App\User\Application\DTO\ConfirmTwoFactorCommandResponse;
 use App\User\Application\Factory\RecoveryCodeBatchFactoryInterface;
 use App\User\Application\Validator\TwoFactorCodeValidatorInterface;
 use App\User\Domain\Entity\RecoveryCode;
@@ -64,8 +65,8 @@ final class ConfirmTwoFactorCommandHandlerTest extends UnitTestCase
         $this->expectBulkSessionRevocation($user, $sessionId, 0);
         $this->expectSuccessEvents();
 
-        $command = $this->invokeHandler($user->getEmail(), $code, $sessionId);
-        $codes = $command->getResponse()->getRecoveryCodes();
+        $response = $this->invokeHandler($user->getEmail(), $code, $sessionId);
+        $codes = $response->getRecoveryCodes();
         $this->assertCount(RecoveryCode::COUNT, $codes);
     }
 
@@ -269,11 +270,11 @@ final class ConfirmTwoFactorCommandHandlerTest extends UnitTestCase
         string $email,
         string $code,
         string $sessionId
-    ): ConfirmTwoFactorCommand {
+    ): ConfirmTwoFactorCommandResponse {
         $handler = $this->createHandler();
         $command = new ConfirmTwoFactorCommand($email, $code, $sessionId);
-        $handler->__invoke($command);
-        return $command;
+
+        return $handler->__invoke($command);
     }
 
     private function createHandler(): ConfirmTwoFactorCommandHandler

--- a/tests/Unit/User/Application/CommandHandler/RefreshTokenCommandHandlerTest.php
+++ b/tests/Unit/User/Application/CommandHandler/RefreshTokenCommandHandlerTest.php
@@ -36,7 +36,7 @@ final class RefreshTokenCommandHandlerTest extends RefreshTokenCommandHandlerTes
     {
         $this->refreshTokenRepository
             ->expects($this->once())
-            ->method('findByTokenHash')
+            ->method('findByPlainToken')
             ->willReturn(null);
 
         $this->authSessionRepository
@@ -203,7 +203,7 @@ final class RefreshTokenCommandHandlerTest extends RefreshTokenCommandHandlerTes
 
         $this->refreshTokenRepository
             ->expects($this->once())
-            ->method('findByTokenHash')
+            ->method('findByPlainToken')
             ->willReturn($token);
 
         $this->authSessionRepository

--- a/tests/Unit/User/Application/CommandHandler/RefreshTokenCommandHandlerTest.php
+++ b/tests/Unit/User/Application/CommandHandler/RefreshTokenCommandHandlerTest.php
@@ -21,12 +21,12 @@ final class RefreshTokenCommandHandlerTest extends RefreshTokenCommandHandlerTes
         $this->expectTokenLookup($oldToken, $plainToken);
         $this->expectSessionLookup($session);
         $this->expectUserLookup($user);
+        $accessToken = $this->faker->sha256();
         $capturedPayload = [];
-        $this->expectSuccessfulRotation($session, $user, 'new-access-token', $capturedPayload);
+        $this->expectSuccessfulRotation($session, $user, $accessToken, $capturedPayload);
         $response = $this->invokeHandler($plainToken);
-        $this->assertSame('new-access-token', $response->getAccessToken());
-        $expectedRefresh = 'test-opaque-token-1234567890-abcdefghijklmn';
-        $this->assertSame($expectedRefresh, $response->getRefreshToken());
+        $this->assertSame($accessToken, $response->getAccessToken());
+        $this->assertSame($this->generatedRefreshToken, $response->getRefreshToken());
         $this->assertOpaqueTokenFormat($response->getRefreshToken());
         $this->assertTrue($oldToken->isRotated());
         $this->assertJwtPayloadContents($capturedPayload, $user->getId(), $session->getId());
@@ -95,9 +95,10 @@ final class RefreshTokenCommandHandlerTest extends RefreshTokenCommandHandlerTes
         $this->expectTokenLookup($token, $plainToken);
         $this->expectSessionLookup($session);
         $this->expectUserLookup($user);
-        $this->expectSuccessfulGraceReuse($session, $user, 'grace-access-token');
+        $accessToken = $this->faker->sha256();
+        $this->expectSuccessfulGraceReuse($session, $user, $accessToken);
         $response = $this->invokeHandler($plainToken);
-        $this->assertSame('grace-access-token', $response->getAccessToken());
+        $this->assertSame($accessToken, $response->getAccessToken());
         $this->assertOpaqueTokenFormat($response->getRefreshToken());
         $this->assertTrue($token->isGraceUsed());
     }
@@ -114,9 +115,10 @@ final class RefreshTokenCommandHandlerTest extends RefreshTokenCommandHandlerTes
         $this->expectFailedAtomicRotation();
         $this->expectSessionLookup($session);
         $this->expectUserLookup($user);
-        $this->expectSuccessfulGraceReuse($session, $user, 'concurrent-access-token');
+        $accessToken = $this->faker->sha256();
+        $this->expectSuccessfulGraceReuse($session, $user, $accessToken);
         $response = $this->invokeHandler($plainToken);
-        $this->assertSame('concurrent-access-token', $response->getAccessToken());
+        $this->assertSame($accessToken, $response->getAccessToken());
         $this->assertOpaqueTokenFormat($response->getRefreshToken());
         $this->assertTrue($latestToken->isGraceUsed());
     }

--- a/tests/Unit/User/Application/CommandHandler/RefreshTokenCommandHandlerTest.php
+++ b/tests/Unit/User/Application/CommandHandler/RefreshTokenCommandHandlerTest.php
@@ -23,8 +23,7 @@ final class RefreshTokenCommandHandlerTest extends RefreshTokenCommandHandlerTes
         $this->expectUserLookup($user);
         $capturedPayload = [];
         $this->expectSuccessfulRotation($session, $user, 'new-access-token', $capturedPayload);
-        $command = $this->invokeHandler($plainToken);
-        $response = $command->getResponse();
+        $response = $this->invokeHandler($plainToken);
         $this->assertSame('new-access-token', $response->getAccessToken());
         $expectedRefresh = 'test-opaque-token-1234567890-abcdefghijklmn';
         $this->assertSame($expectedRefresh, $response->getRefreshToken());
@@ -97,9 +96,9 @@ final class RefreshTokenCommandHandlerTest extends RefreshTokenCommandHandlerTes
         $this->expectSessionLookup($session);
         $this->expectUserLookup($user);
         $this->expectSuccessfulGraceReuse($session, $user, 'grace-access-token');
-        $command = $this->invokeHandler($plainToken);
-        $this->assertSame('grace-access-token', $command->getResponse()->getAccessToken());
-        $this->assertOpaqueTokenFormat($command->getResponse()->getRefreshToken());
+        $response = $this->invokeHandler($plainToken);
+        $this->assertSame('grace-access-token', $response->getAccessToken());
+        $this->assertOpaqueTokenFormat($response->getRefreshToken());
         $this->assertTrue($token->isGraceUsed());
     }
 
@@ -116,9 +115,9 @@ final class RefreshTokenCommandHandlerTest extends RefreshTokenCommandHandlerTes
         $this->expectSessionLookup($session);
         $this->expectUserLookup($user);
         $this->expectSuccessfulGraceReuse($session, $user, 'concurrent-access-token');
-        $command = $this->invokeHandler($plainToken);
-        $this->assertSame('concurrent-access-token', $command->getResponse()->getAccessToken());
-        $this->assertOpaqueTokenFormat($command->getResponse()->getRefreshToken());
+        $response = $this->invokeHandler($plainToken);
+        $this->assertSame('concurrent-access-token', $response->getAccessToken());
+        $this->assertOpaqueTokenFormat($response->getRefreshToken());
         $this->assertTrue($latestToken->isGraceUsed());
     }
 
@@ -296,10 +295,10 @@ final class RefreshTokenCommandHandlerTest extends RefreshTokenCommandHandlerTes
             ->willReturn($candidateTokens);
         $this->expectSuccessfulGraceReuse($session, $user, $expectedAccessToken);
 
-        $command = $this->invokeHandler($plainToken);
+        $response = $this->invokeHandler($plainToken);
 
-        $this->assertSame($expectedAccessToken, $command->getResponse()->getAccessToken());
-        $this->assertOpaqueTokenFormat($command->getResponse()->getRefreshToken());
+        $this->assertSame($expectedAccessToken, $response->getAccessToken());
+        $this->assertOpaqueTokenFormat($response->getRefreshToken());
         $this->assertTrue($oldToken->isGraceUsed());
     }
 

--- a/tests/Unit/User/Application/CommandHandler/RefreshTokenCommandHandlerTestCase.php
+++ b/tests/Unit/User/Application/CommandHandler/RefreshTokenCommandHandlerTestCase.php
@@ -63,8 +63,8 @@ abstract class RefreshTokenCommandHandlerTestCase extends UnitTestCase
     ): void {
         $this->refreshTokenRepository
             ->expects($this->once())
-            ->method('findByTokenHash')
-            ->with(hash('sha256', $plainToken))
+            ->method('findByPlainToken')
+            ->with($plainToken)
             ->willReturn($token);
     }
 
@@ -75,8 +75,8 @@ abstract class RefreshTokenCommandHandlerTestCase extends UnitTestCase
     ): void {
         $this->refreshTokenRepository
             ->expects($this->exactly(2))
-            ->method('findByTokenHash')
-            ->with(hash('sha256', $plainToken))
+            ->method('findByPlainToken')
+            ->with($plainToken)
             ->willReturnOnConsecutiveCalls($first, $second);
     }
 

--- a/tests/Unit/User/Application/CommandHandler/RefreshTokenCommandHandlerTestCase.php
+++ b/tests/Unit/User/Application/CommandHandler/RefreshTokenCommandHandlerTestCase.php
@@ -299,7 +299,11 @@ abstract class RefreshTokenCommandHandlerTestCase extends UnitTestCase
     ): RefreshTokenCommandHandler {
         return new RefreshTokenCommandHandler(
             $this->refreshTokenRepository,
-            $this->createContextResolver(),
+            new RefreshTokenContextResolver(
+                $this->refreshTokenRepository,
+                $this->authSessionRepository,
+                $this->userRepository,
+            ),
             $this->createTokenIssuer(),
             $this->createTheftDetector(),
             $refreshTokenGraceWindowSeconds,
@@ -383,15 +387,6 @@ abstract class RefreshTokenCommandHandlerTestCase extends UnitTestCase
             $this->refreshTokenRepository,
             $this->authSessionRepository,
             $this->publisher,
-        );
-    }
-
-    private function createContextResolver(): RefreshTokenContextResolver
-    {
-        return new RefreshTokenContextResolver(
-            $this->refreshTokenRepository,
-            $this->authSessionRepository,
-            $this->userRepository,
         );
     }
 }

--- a/tests/Unit/User/Application/CommandHandler/RefreshTokenCommandHandlerTestCase.php
+++ b/tests/Unit/User/Application/CommandHandler/RefreshTokenCommandHandlerTestCase.php
@@ -12,6 +12,7 @@ use App\User\Application\CommandHandler\RefreshTokenCommandHandler;
 use App\User\Application\DTO\RefreshTokenCommandResponse;
 use App\User\Application\Factory\AccessTokenFactoryInterface;
 use App\User\Application\Factory\AuthTokenFactoryInterface;
+use App\User\Application\Service\RefreshTokenContextResolver;
 use App\User\Application\Service\RefreshTokenIssuer;
 use App\User\Application\Service\RefreshTokenTheftDetector;
 use App\User\Domain\Entity\AuthRefreshToken;
@@ -296,24 +297,11 @@ abstract class RefreshTokenCommandHandlerTestCase extends UnitTestCase
     protected function createHandler(
         int $refreshTokenGraceWindowSeconds = 60
     ): RefreshTokenCommandHandler {
-        $tokenIssuer = new RefreshTokenIssuer(
-            $this->refreshTokenRepository,
-            $this->accessTokenFactory,
-            $this->authTokenFactory,
-            $this->publisher,
-        );
-        $theftDetector = new RefreshTokenTheftDetector(
-            $this->refreshTokenRepository,
-            $this->authSessionRepository,
-            $this->publisher,
-        );
-
         return new RefreshTokenCommandHandler(
             $this->refreshTokenRepository,
-            $this->authSessionRepository,
-            $this->userRepository,
-            $tokenIssuer,
-            $theftDetector,
+            $this->createContextResolver(),
+            $this->createTokenIssuer(),
+            $this->createTheftDetector(),
             $refreshTokenGraceWindowSeconds,
         );
     }
@@ -376,6 +364,34 @@ abstract class RefreshTokenCommandHandlerTestCase extends UnitTestCase
             $this->uuidTransformer->transformFromString(
                 $this->faker->uuid()
             )
+        );
+    }
+
+    private function createTokenIssuer(): RefreshTokenIssuer
+    {
+        return new RefreshTokenIssuer(
+            $this->refreshTokenRepository,
+            $this->accessTokenFactory,
+            $this->authTokenFactory,
+            $this->publisher,
+        );
+    }
+
+    private function createTheftDetector(): RefreshTokenTheftDetector
+    {
+        return new RefreshTokenTheftDetector(
+            $this->refreshTokenRepository,
+            $this->authSessionRepository,
+            $this->publisher,
+        );
+    }
+
+    private function createContextResolver(): RefreshTokenContextResolver
+    {
+        return new RefreshTokenContextResolver(
+            $this->refreshTokenRepository,
+            $this->authSessionRepository,
+            $this->userRepository,
         );
     }
 }

--- a/tests/Unit/User/Application/CommandHandler/RefreshTokenCommandHandlerTestCase.php
+++ b/tests/Unit/User/Application/CommandHandler/RefreshTokenCommandHandlerTestCase.php
@@ -9,6 +9,7 @@ use App\Shared\Infrastructure\Transformer\UuidTransformer;
 use App\Tests\Unit\UnitTestCase;
 use App\User\Application\Command\RefreshTokenCommand;
 use App\User\Application\CommandHandler\RefreshTokenCommandHandler;
+use App\User\Application\DTO\RefreshTokenCommandResponse;
 use App\User\Application\Factory\AccessTokenFactoryInterface;
 use App\User\Application\Factory\AuthTokenFactoryInterface;
 use App\User\Domain\Entity\AuthRefreshToken;
@@ -243,11 +244,11 @@ abstract class RefreshTokenCommandHandlerTestCase extends UnitTestCase
 
     protected function invokeHandler(
         string $plainToken
-    ): RefreshTokenCommand {
+    ): RefreshTokenCommandResponse {
         $handler = $this->createHandler();
         $command = new RefreshTokenCommand($plainToken);
-        $handler->__invoke($command);
-        return $command;
+
+        return $handler->__invoke($command);
     }
 
     /**

--- a/tests/Unit/User/Application/CommandHandler/RefreshTokenCommandHandlerTestCase.php
+++ b/tests/Unit/User/Application/CommandHandler/RefreshTokenCommandHandlerTestCase.php
@@ -12,6 +12,8 @@ use App\User\Application\CommandHandler\RefreshTokenCommandHandler;
 use App\User\Application\DTO\RefreshTokenCommandResponse;
 use App\User\Application\Factory\AccessTokenFactoryInterface;
 use App\User\Application\Factory\AuthTokenFactoryInterface;
+use App\User\Application\Service\RefreshTokenIssuer;
+use App\User\Application\Service\RefreshTokenTheftDetector;
 use App\User\Domain\Entity\AuthRefreshToken;
 use App\User\Domain\Entity\AuthSession;
 use App\User\Domain\Entity\User;
@@ -35,6 +37,7 @@ abstract class RefreshTokenCommandHandlerTestCase extends UnitTestCase
     protected AuthTokenFactoryInterface&MockObject $authTokenFactory;
     protected UserFactory $userFactory;
     protected UuidTransformer $uuidTransformer;
+    protected string $generatedRefreshToken;
 
     #[\Override]
     protected function setUp(): void
@@ -50,6 +53,7 @@ abstract class RefreshTokenCommandHandlerTestCase extends UnitTestCase
         $this->authTokenFactory = $this->createMock(AuthTokenFactoryInterface::class);
         $this->userFactory = new UserFactory();
         $this->uuidTransformer = new UuidTransformer(new SharedUuidFactory());
+        $this->generatedRefreshToken = $this->faker->regexify('[A-Za-z0-9_-]{43}');
     }
 
     protected function expectTokenLookup(
@@ -192,9 +196,7 @@ abstract class RefreshTokenCommandHandlerTestCase extends UnitTestCase
     {
         $this->authTokenFactory
             ->method('generateOpaqueToken')
-            ->willReturn(
-                'test-opaque-token-1234567890-abcdefghijklmn'
-            );
+            ->willReturn($this->generatedRefreshToken);
         $this->configureCreateRefreshTokenCallback();
         $this->configureJwtPayloadFactory();
     }
@@ -294,13 +296,24 @@ abstract class RefreshTokenCommandHandlerTestCase extends UnitTestCase
     protected function createHandler(
         int $refreshTokenGraceWindowSeconds = 60
     ): RefreshTokenCommandHandler {
+        $tokenIssuer = new RefreshTokenIssuer(
+            $this->refreshTokenRepository,
+            $this->accessTokenFactory,
+            $this->authTokenFactory,
+            $this->publisher,
+        );
+        $theftDetector = new RefreshTokenTheftDetector(
+            $this->refreshTokenRepository,
+            $this->authSessionRepository,
+            $this->publisher,
+        );
+
         return new RefreshTokenCommandHandler(
             $this->refreshTokenRepository,
             $this->authSessionRepository,
             $this->userRepository,
-            $this->accessTokenFactory,
-            $this->authTokenFactory,
-            $this->publisher,
+            $tokenIssuer,
+            $theftDetector,
             $refreshTokenGraceWindowSeconds,
         );
     }

--- a/tests/Unit/User/Application/CommandHandler/RefreshTokenTheftDetectionTest.php
+++ b/tests/Unit/User/Application/CommandHandler/RefreshTokenTheftDetectionTest.php
@@ -9,8 +9,10 @@ use App\User\Domain\Entity\AuthRefreshToken;
 use App\User\Domain\Entity\AuthSession;
 use App\User\Domain\Entity\User;
 use DateTimeImmutable;
+use RuntimeException;
 use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
 use Symfony\Component\Uid\Ulid;
+use Throwable;
 
 final class RefreshTokenTheftDetectionTest extends RefreshTokenCommandHandlerTestCase
 {
@@ -60,8 +62,14 @@ final class RefreshTokenTheftDetectionTest extends RefreshTokenCommandHandlerTes
         $this->expectSessionLookup($session);
         $this->expectUserLookup($user);
         $this->expectTokenRevocationSave();
-        $this->expectTheftDetectionResponse($session, $user, 'grace_period_expired', [$token]);
-        $this->expectException(UnauthorizedHttpException::class);
+        $this->expectTheftDetectionResponse(
+            $session,
+            $user,
+            'grace_period_expired',
+            [$token],
+            new RuntimeException('Publisher unavailable.')
+        );
+        $this->expectInvalidTokenException();
         $this->createHandler()->__invoke(new RefreshTokenCommand($plainToken));
     }
 
@@ -324,13 +332,14 @@ final class RefreshTokenTheftDetectionTest extends RefreshTokenCommandHandlerTes
         AuthSession $session,
         User $user,
         string $reason,
-        array $sessionTokens
+        array $sessionTokens,
+        ?Throwable $publishingFailure = null
     ): void {
         $this->refreshTokenRepository->expects($this->once())
             ->method('findBySessionId')->with($session->getId())
             ->willReturn($sessionTokens);
         $this->expectSessionRevoked();
-        $this->expectTheftEvent($session, $user, $reason);
+        $this->expectTheftEvent($session, $user, $reason, $publishingFailure);
     }
 
     private function expectSessionRevoked(): void
@@ -346,9 +355,10 @@ final class RefreshTokenTheftDetectionTest extends RefreshTokenCommandHandlerTes
     private function expectTheftEvent(
         AuthSession $session,
         User $user,
-        string $reason
+        string $reason,
+        ?Throwable $publishingFailure = null
     ): void {
-        $this->publisher
+        $expectation = $this->publisher
             ->expects($this->once())
             ->method('publishTheftDetected')
             ->with(
@@ -357,6 +367,9 @@ final class RefreshTokenTheftDetectionTest extends RefreshTokenCommandHandlerTes
                 $session->getIpAddress(),
                 $reason
             );
+        if ($publishingFailure instanceof Throwable) {
+            $expectation->willThrowException($publishingFailure);
+        }
     }
 
     private function createRevokedToken(

--- a/tests/Unit/User/Application/CommandHandler/RegenerateRecoveryCodesCommandHandlerTest.php
+++ b/tests/Unit/User/Application/CommandHandler/RegenerateRecoveryCodesCommandHandlerTest.php
@@ -77,8 +77,8 @@ final class RegenerateRecoveryCodesCommandHandlerTest extends UnitTestCase
             ->willReturn($generatedCodes);
 
         $command = new RegenerateRecoveryCodesCommand($user->getEmail(), $sessionId);
-        $this->createHandler()->__invoke($command);
-        $codes = $command->getResponse()->getRecoveryCodes();
+        $response = $this->createHandler()->__invoke($command);
+        $codes = $response->getRecoveryCodes();
         $this->assertCount(RecoveryCode::COUNT, $codes);
     }
 
@@ -254,10 +254,10 @@ final class RegenerateRecoveryCodesCommandHandlerTest extends UnitTestCase
             ->willReturn($this->generatedCodes());
 
         $command = new RegenerateRecoveryCodesCommand($user->getEmail(), $sessionId);
-        $this->createHandler()->__invoke($command);
+        $response = $this->createHandler()->__invoke($command);
         $this->assertCount(
             RecoveryCode::COUNT,
-            $command->getResponse()->getRecoveryCodes()
+            $response->getRecoveryCodes()
         );
     }
 

--- a/tests/Unit/User/Application/CommandHandler/RegisterUserBatchCommandHandlerTest.php
+++ b/tests/Unit/User/Application/CommandHandler/RegisterUserBatchCommandHandlerTest.php
@@ -69,9 +69,9 @@ final class RegisterUserBatchCommandHandlerTest extends UnitTestCase
 
         $this->expectSuccessfulBatchRegistration($testData);
 
-        $this->handler->__invoke($command);
+        $response = $this->handler->__invoke($command);
 
-        $this->assertCreatedUsersResponse($command, $testData['users']);
+        $this->assertCreatedUsersResponse($response, $testData['users']);
     }
 
     public function testInvokeReturnsEmptyResponseForEmptyBatch(): void
@@ -93,9 +93,8 @@ final class RegisterUserBatchCommandHandlerTest extends UnitTestCase
         $this->eventBus->expects($this->never())
             ->method('publish');
 
-        $this->handler->__invoke($command);
+        $response = $this->handler->__invoke($command);
 
-        $response = $command->getResponse();
         $this->assertInstanceOf(RegisterUserBatchCommandResponse::class, $response);
         $this->assertCount(0, $response->users);
     }
@@ -110,9 +109,9 @@ final class RegisterUserBatchCommandHandlerTest extends UnitTestCase
         $this->setupExistingUserBatchExpectations($email, $existingUser);
         $this->setupNeverCalledForBatchRegistration();
 
-        $this->handler->__invoke($command);
+        $response = $this->handler->__invoke($command);
 
-        $this->assertBatchResponse($command, $existingUser);
+        $this->assertBatchResponse($response, $existingUser);
     }
 
     public function testInvokeDeduplicatesNewUsersWithinSameBatch(): void
@@ -124,9 +123,9 @@ final class RegisterUserBatchCommandHandlerTest extends UnitTestCase
 
         $this->expectDuplicateBatchRegistration($testData);
 
-        $this->handler->__invoke($command);
+        $response = $this->handler->__invoke($command);
 
-        $this->assertDuplicateBatchResponse($command);
+        $this->assertDuplicateBatchResponse($response);
     }
 
     public function testInvokeDeduplicatesNewUsersWithSparseKnownUserKeys(): void
@@ -144,9 +143,9 @@ final class RegisterUserBatchCommandHandlerTest extends UnitTestCase
 
         $this->expectSparseKnownUserBatchRegistration($testData, $knownUser);
 
-        $this->handler->__invoke($command);
+        $response = $this->handler->__invoke($command);
 
-        $this->assertDuplicateBatchResponse($command);
+        $this->assertDuplicateBatchResponse($response);
     }
 
     private function setHandler(): void
@@ -253,10 +252,9 @@ final class RegisterUserBatchCommandHandlerTest extends UnitTestCase
      * @param list<UserInterface> $users
      */
     private function assertCreatedUsersResponse(
-        RegisterUserBatchCommand $command,
+        RegisterUserBatchCommandResponse $response,
         array $users
     ): void {
-        $response = $command->getResponse();
         $this->assertInstanceOf(
             RegisterUserBatchCommandResponse::class,
             $response
@@ -462,9 +460,8 @@ final class RegisterUserBatchCommandHandlerTest extends UnitTestCase
     }
 
     private function assertDuplicateBatchResponse(
-        RegisterUserBatchCommand $command
+        RegisterUserBatchCommandResponse $response
     ): void {
-        $response = $command->getResponse();
         $this->assertInstanceOf(RegisterUserBatchCommandResponse::class, $response);
         $users = iterator_to_array($response->users);
         $this->assertCount(2, $users);
@@ -570,10 +567,9 @@ final class RegisterUserBatchCommandHandlerTest extends UnitTestCase
     }
 
     private function assertBatchResponse(
-        RegisterUserBatchCommand $command,
+        RegisterUserBatchCommandResponse $response,
         UserInterface $existingUser
     ): void {
-        $response = $command->getResponse();
         $this->assertInstanceOf(RegisterUserBatchCommandResponse::class, $response);
         $users = iterator_to_array($response->users);
         $this->assertCount(1, $users);

--- a/tests/Unit/User/Application/CommandHandler/RequestPasswordResetCommandHandlerTest.php
+++ b/tests/Unit/User/Application/CommandHandler/RequestPasswordResetCommandHandlerTest.php
@@ -65,9 +65,9 @@ final class RequestPasswordResetCommandHandlerTest extends UnitTestCase
         $this->setupPasswordResetExpectations($testData, $mocks);
 
         $command = new RequestPasswordResetCommand($testData['email']);
-        $this->handler->__invoke($command);
+        $response = $this->handler->__invoke($command);
 
-        $this->assertPasswordResetResponse($command);
+        $this->assertPasswordResetResponse($response);
     }
 
     public function testRequestPasswordResetForNonExistingUser(): void
@@ -78,12 +78,9 @@ final class RequestPasswordResetCommandHandlerTest extends UnitTestCase
         $this->setupNeverCalledExpectations();
 
         $command = new RequestPasswordResetCommand($email);
-        $this->handler->__invoke($command);
+        $response = $this->handler->__invoke($command);
 
-        $this->assertInstanceOf(
-            RequestPasswordResetCommandResponse::class,
-            $command->getResponse()
-        );
+        $this->assertPasswordResetResponse($response);
     }
 
     private function setupUserNotFoundExpectations(string $email): void
@@ -208,11 +205,12 @@ final class RequestPasswordResetCommandHandlerTest extends UnitTestCase
             ->with($mocks['event']);
     }
 
-    private function assertPasswordResetResponse(RequestPasswordResetCommand $command): void
-    {
+    private function assertPasswordResetResponse(
+        RequestPasswordResetCommandResponse $response
+    ): void {
         $this->assertInstanceOf(
             RequestPasswordResetCommandResponse::class,
-            $command->getResponse()
+            $response
         );
     }
 }

--- a/tests/Unit/User/Application/CommandHandler/SetupTwoFactorCommandHandlerTest.php
+++ b/tests/Unit/User/Application/CommandHandler/SetupTwoFactorCommandHandlerTest.php
@@ -9,6 +9,7 @@ use App\Shared\Infrastructure\Transformer\UuidTransformer;
 use App\Tests\Unit\UnitTestCase;
 use App\User\Application\Command\SetupTwoFactorCommand;
 use App\User\Application\CommandHandler\SetupTwoFactorCommandHandler;
+use App\User\Application\DTO\SetupTwoFactorCommandResponse;
 use App\User\Application\Factory\TOTPSecretFactoryInterface;
 use App\User\Domain\Contract\TwoFactorSecretEncryptorInterface;
 use App\User\Domain\Entity\User;
@@ -49,8 +50,8 @@ final class SetupTwoFactorCommandHandlerTest extends UnitTestCase
         $this->expectSecretEncryption($secret);
         $this->expectUserSaveWithEncryptedSecret($user);
         $command = new SetupTwoFactorCommand($user->getEmail());
-        $this->createHandler()->__invoke($command);
-        $this->assertSetupTwoFactorResponse($command, $secret, $otpauthUri, $user->getEmail());
+        $response = $this->createHandler()->__invoke($command);
+        $this->assertSetupTwoFactorResponse($response, $secret, $otpauthUri, $user->getEmail());
     }
 
     public function testInvokeThrowsUnauthorizedWhenAuthenticatedUserIsMissing(): void
@@ -155,12 +156,11 @@ final class SetupTwoFactorCommandHandlerTest extends UnitTestCase
     }
 
     private function assertSetupTwoFactorResponse(
-        SetupTwoFactorCommand $command,
+        SetupTwoFactorCommandResponse $response,
         string $secret,
         string $otpauthUri,
         string $email
     ): void {
-        $response = $command->getResponse();
         $this->assertSame($secret, $response->getSecret());
         $this->assertSame($otpauthUri, $response->getOtpauthUri());
         $this->assertStringContainsString(rawurlencode($email), $response->getOtpauthUri());

--- a/tests/Unit/User/Application/CommandHandler/SignInCommandHandlerBasicTest.php
+++ b/tests/Unit/User/Application/CommandHandler/SignInCommandHandlerBasicTest.php
@@ -16,8 +16,7 @@ final class SignInCommandHandlerBasicTest extends SignInCommandHandlerTestCase
         $this->expectSignedInEvent($user, $ip, $ua, false);
 
         $command = new SignInCommand($email, $pw, false, $ip, $ua);
-        $this->createHandler()->__invoke($command);
-        $response = $command->getResponse();
+        $response = $this->createHandler()->__invoke($command);
 
         $this->assertFalse($response->isTwoFactorEnabled());
         $this->assertNotEmpty($response->getAccessToken());
@@ -33,8 +32,8 @@ final class SignInCommandHandlerBasicTest extends SignInCommandHandlerTestCase
             ->willReturn($user);
 
         $command = new SignInCommand($email, $pw, true, $ip, $ua);
-        $this->createHandler()->__invoke($command);
+        $response = $this->createHandler()->__invoke($command);
 
-        $this->assertNotEmpty($command->getResponse()->getAccessToken());
+        $this->assertNotEmpty($response->getAccessToken());
     }
 }

--- a/tests/Unit/User/Application/CommandHandler/SignInCommandHandlerTwoFactorTest.php
+++ b/tests/Unit/User/Application/CommandHandler/SignInCommandHandlerTwoFactorTest.php
@@ -25,13 +25,13 @@ final class SignInCommandHandlerTwoFactorTest extends SignInCommandHandlerTestCa
         $this->signInPublisher->expects($this->never())->method('publishSignedIn');
 
         $command = new SignInCommand($email, $pw, false, $ip, $ua);
-        $this->createHandler()->__invoke($command);
+        $response = $this->createHandler()->__invoke($command);
 
         $this->assertPendingTwoFactor($pendingSid, $user->getId(), 300, false);
-        $this->assertTrue($command->getResponse()->isTwoFactorEnabled());
-        $this->assertSame($pendingSid, $command->getResponse()->getPendingSessionId());
-        $this->assertNull($command->getResponse()->getAccessToken());
-        $this->assertNull($command->getResponse()->getRefreshToken());
+        $this->assertTrue($response->isTwoFactorEnabled());
+        $this->assertSame($pendingSid, $response->getPendingSessionId());
+        $this->assertNull($response->getAccessToken());
+        $this->assertNull($response->getRefreshToken());
     }
 
     public function testInvokeStoresRememberMeInPendingTwoFactorWhenTwoFactorIsEnabled(): void
@@ -47,12 +47,12 @@ final class SignInCommandHandlerTwoFactorTest extends SignInCommandHandlerTestCa
         $this->idFactory->method('create')->willReturn($pendingSid);
 
         $command = new SignInCommand($email, $pw, true, $ip, $ua);
-        $this->createHandler()->__invoke($command);
+        $response = $this->createHandler()->__invoke($command);
 
         $saved = $this->pendingTwoFactorRepository->saved();
         $this->assertNotNull($saved);
         $this->assertTrue($saved->isRememberMe());
-        $this->assertTrue($command->getResponse()->isTwoFactorEnabled());
+        $this->assertTrue($response->isTwoFactorEnabled());
     }
 
     public function testDefaultTtlIsThreeHundredSeconds(): void

--- a/tests/Unit/User/Application/CommandHandler/SignUpCommandHandlerTest.php
+++ b/tests/Unit/User/Application/CommandHandler/SignUpCommandHandlerTest.php
@@ -10,6 +10,7 @@ use App\Shared\Infrastructure\Transformer\UuidTransformer;
 use App\Tests\Unit\UnitTestCase;
 use App\User\Application\Command\RegisterUserCommand;
 use App\User\Application\CommandHandler\RegisterUserCommandHandler;
+use App\User\Application\DTO\RegisterUserCommandResponse;
 use App\User\Application\Factory\SignUpCommandFactory;
 use App\User\Application\Factory\SignUpCommandFactoryInterface;
 use App\User\Application\Transformer\SignUpTransformer;
@@ -76,7 +77,10 @@ final class SignUpCommandHandlerTest extends UnitTestCase
 
         $this->setExpectations($user);
 
-        $this->handler->__invoke($command);
+        $response = $this->handler->__invoke($command);
+
+        $this->assertInstanceOf(RegisterUserCommandResponse::class, $response);
+        $this->assertSame($user, $response->createdUser);
     }
 
     public function testInvokeReturnsExistingUserWhenEmailAlreadyRegistered(): void
@@ -89,9 +93,9 @@ final class SignUpCommandHandlerTest extends UnitTestCase
         $this->setupExistingUserExpectations($email, $existingUser);
         $this->setupNeverCalledForSignup();
 
-        $this->handler->__invoke($command);
+        $response = $this->handler->__invoke($command);
 
-        $this->assertSame($existingUser, $command->getResponse()->createdUser);
+        $this->assertSame($existingUser, $response->createdUser);
     }
 
     private function setExpectations(

--- a/tests/Unit/User/Application/Controller/ConfirmPasswordResetControllerTest.php
+++ b/tests/Unit/User/Application/Controller/ConfirmPasswordResetControllerTest.php
@@ -9,6 +9,7 @@ use App\Shared\Domain\Bus\Command\CommandBusInterface;
 use App\Tests\Unit\UnitTestCase;
 use App\User\Application\Command\ConfirmPasswordResetCommand;
 use App\User\Application\Controller\ConfirmPasswordResetController;
+use App\User\Application\DTO\ConfirmPasswordResetCommandResponse;
 use App\User\Application\DTO\ConfirmPasswordResetDto;
 use Symfony\Component\HttpFoundation\JsonResponse;
 
@@ -80,7 +81,7 @@ final class ConfirmPasswordResetControllerTest extends UnitTestCase
                     $testData['newPassword']
                 )
             ))
-            ->willReturn($commandResponse);
+            ->willReturn(new ConfirmPasswordResetCommandResponse());
     }
 
     private function validateCommand(

--- a/tests/Unit/User/Application/Controller/ConfirmPasswordResetControllerTest.php
+++ b/tests/Unit/User/Application/Controller/ConfirmPasswordResetControllerTest.php
@@ -74,21 +74,19 @@ final class ConfirmPasswordResetControllerTest extends UnitTestCase
                 fn (ConfirmPasswordResetCommand $cmd) => $this->validateCommand(
                     $cmd,
                     $testData['token'],
-                    $testData['newPassword'],
-                    $commandResponse
+                    $testData['newPassword']
                 )
-            ));
+            ))
+            ->willReturn($commandResponse);
     }
 
     private function validateCommand(
         ConfirmPasswordResetCommand $command,
         string $token,
-        string $newPassword,
-        ConfirmPasswordResetCommandResponse $commandResponse
+        string $newPassword
     ): bool {
         $this->assertEquals($token, $command->token);
         $this->assertEquals($newPassword, $command->newPassword);
-        $command->setResponse($commandResponse);
 
         return true;
     }

--- a/tests/Unit/User/Application/Controller/ConfirmPasswordResetControllerTest.php
+++ b/tests/Unit/User/Application/Controller/ConfirmPasswordResetControllerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Unit\User\Application\Controller;
 
+use App\Shared\Application\Bus\Guard\CommandResponseTypeGuard;
 use App\Shared\Domain\Bus\Command\CommandBusInterface;
 use App\Tests\Unit\UnitTestCase;
 use App\User\Application\Command\ConfirmPasswordResetCommand;
@@ -23,7 +24,10 @@ final class ConfirmPasswordResetControllerTest extends UnitTestCase
         parent::setUp();
 
         $this->commandBus = $this->createMock(CommandBusInterface::class);
-        $this->controller = new ConfirmPasswordResetController($this->commandBus);
+        $this->controller = new ConfirmPasswordResetController(
+            $this->commandBus,
+            new CommandResponseTypeGuard()
+        );
     }
 
     public function testInvokeDispatchesCommandAndReturnsResponse(): void
@@ -43,7 +47,10 @@ final class ConfirmPasswordResetControllerTest extends UnitTestCase
     public function testConstructorSetsCommandBus(): void
     {
         $commandBus = $this->createMock(CommandBusInterface::class);
-        $controller = new ConfirmPasswordResetController($commandBus);
+        $controller = new ConfirmPasswordResetController(
+            $commandBus,
+            new CommandResponseTypeGuard()
+        );
 
         $this->assertInstanceOf(ConfirmPasswordResetController::class, $controller);
     }

--- a/tests/Unit/User/Application/Controller/RequestPasswordResetControllerTest.php
+++ b/tests/Unit/User/Application/Controller/RequestPasswordResetControllerTest.php
@@ -32,22 +32,16 @@ final class RequestPasswordResetControllerTest extends UnitTestCase
 
         $dto = new RequestPasswordResetDto($email);
 
-        $commandResponse = new RequestPasswordResetCommandResponse();
-
         $this->commandBus->expects($this->once())
             ->method('dispatch')
             ->with($this->callback(
-                function (RequestPasswordResetCommand $command) use (
-                    $email,
-                    $commandResponse
-                ) {
+                function (RequestPasswordResetCommand $command) use ($email) {
                     $this->assertEquals($email, $command->email);
-
-                    $command->setResponse($commandResponse);
 
                     return true;
                 }
-            ));
+            ))
+            ->willReturn(new RequestPasswordResetCommandResponse());
 
         $response = ($this->controller)($dto);
 

--- a/tests/Unit/User/Application/Processor/AuthProcessorTestCase.php
+++ b/tests/Unit/User/Application/Processor/AuthProcessorTestCase.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\User\Application\Processor;
+
+use App\Shared\Domain\Bus\Command\CommandBusInterface;
+use App\Shared\Domain\Bus\Command\CommandInterface;
+use App\Shared\Domain\Bus\Command\CommandResponseInterface;
+use App\Tests\Unit\UnitTestCase;
+use PHPUnit\Framework\MockObject\MockObject;
+
+abstract class AuthProcessorTestCase extends UnitTestCase
+{
+    /**
+     * @template TCommand of CommandInterface
+     *
+     * @param class-string<TCommand> $commandClass
+     * @param callable(TCommand): void $assertCommand
+     */
+    protected function expectDispatchMatchingCommand(
+        CommandBusInterface&MockObject $commandBus,
+        string $commandClass,
+        CommandResponseInterface $response,
+        callable $assertCommand,
+    ): void {
+        $commandBus->expects($this->once())->method('dispatch')
+            ->with($this->callback(
+                function (CommandInterface $command) use (
+                    $commandClass,
+                    $assertCommand,
+                ): bool {
+                    self::assertInstanceOf($commandClass, $command);
+                    $assertCommand($command);
+
+                    return true;
+                }
+            ))
+            ->willReturn($response);
+    }
+}

--- a/tests/Unit/User/Application/Processor/AuthProcessorTestCase.php
+++ b/tests/Unit/User/Application/Processor/AuthProcessorTestCase.php
@@ -8,7 +8,9 @@ use App\Shared\Domain\Bus\Command\CommandBusInterface;
 use App\Shared\Domain\Bus\Command\CommandInterface;
 use App\Shared\Domain\Bus\Command\CommandResponseInterface;
 use App\Tests\Unit\UnitTestCase;
+use App\User\Application\Resolver\HttpRequestContextResolverInterface;
 use PHPUnit\Framework\MockObject\MockObject;
+use Symfony\Component\HttpFoundation\Request;
 
 abstract class AuthProcessorTestCase extends UnitTestCase
 {
@@ -37,5 +39,72 @@ abstract class AuthProcessorTestCase extends UnitTestCase
                 }
             ))
             ->willReturn($response);
+    }
+
+    /**
+     * @param class-string $commandClass
+     */
+    protected function expectDispatchWithRequestMetadata(
+        CommandBusInterface&MockObject $commandBus,
+        string $commandClass,
+        CommandResponseInterface $response,
+        string $expectedIpAddress,
+        string $expectedUserAgent,
+    ): void {
+        $this->expectDispatchMatchingCommand(
+            $commandBus,
+            $commandClass,
+            $response,
+            function (CommandInterface $cmd) use (
+                $expectedIpAddress,
+                $expectedUserAgent,
+            ): void {
+                $this->assertSame(
+                    $expectedIpAddress,
+                    $this->readStringProperty($cmd, 'ipAddress')
+                );
+                $this->assertSame(
+                    $expectedUserAgent,
+                    $this->readStringProperty($cmd, 'userAgent')
+                );
+            }
+        );
+    }
+
+    protected function stubRequestContextResolver(
+        HttpRequestContextResolverInterface&MockObject $resolver,
+        ?Request $request,
+        string $ipAddress,
+        string $userAgent,
+    ): void {
+        $resolver->method('resolveRequest')->willReturn($request);
+        $this->stubRequestContextMetadata(
+            $resolver,
+            $request,
+            $ipAddress,
+            $userAgent
+        );
+    }
+
+    protected function stubRequestContextMetadata(
+        HttpRequestContextResolverInterface&MockObject $resolver,
+        ?Request $request,
+        string $ipAddress,
+        string $userAgent,
+    ): void {
+        $resolver->method('resolveIpAddress')
+            ->with($request)->willReturn($ipAddress);
+        $resolver->method('resolveUserAgent')
+            ->with($request)->willReturn($userAgent);
+    }
+
+    private function readStringProperty(object $object, string $property): string
+    {
+        $reflectionProperty = new \ReflectionProperty($object, $property);
+        $value = $reflectionProperty->getValue($object);
+
+        self::assertIsString($value);
+
+        return $value;
     }
 }

--- a/tests/Unit/User/Application/Processor/AuthProcessorTestCase.php
+++ b/tests/Unit/User/Application/Processor/AuthProcessorTestCase.php
@@ -28,7 +28,7 @@ abstract class AuthProcessorTestCase extends UnitTestCase
     ): void {
         $commandBus->expects($this->once())->method('dispatch')
             ->with($this->callback(
-                function (CommandInterface $command) use (
+                static function (CommandInterface $command) use (
                     $commandClass,
                     $assertCommand,
                 ): bool {
@@ -84,6 +84,39 @@ abstract class AuthProcessorTestCase extends UnitTestCase
             $ipAddress,
             $userAgent
         );
+    }
+
+    protected function stubRandomRequestContext(
+        HttpRequestContextResolverInterface&MockObject $resolver,
+        ?Request $request = null,
+    ): Request {
+        $request ??= $this->createMock(Request::class);
+        $this->stubRequestContextResolver(
+            $resolver,
+            $request,
+            $this->faker->ipv4(),
+            $this->faker->userAgent()
+        );
+
+        return $request;
+    }
+
+    /**
+     * @return array{string, string}
+     */
+    protected function expectResolvedRequestContext(
+        HttpRequestContextResolverInterface&MockObject $resolver,
+        ?Request $expectedRequest,
+        Request $resolvedRequest,
+    ): array {
+        $ipAddress = $this->faker->ipv4();
+        $userAgent = $this->faker->userAgent();
+        $resolver->expects($this->once())
+            ->method('resolveRequest')->with($expectedRequest)
+            ->willReturn($resolvedRequest);
+        $this->stubRequestContextMetadata($resolver, $resolvedRequest, $ipAddress, $userAgent);
+
+        return [$ipAddress, $userAgent];
     }
 
     protected function stubRequestContextMetadata(

--- a/tests/Unit/User/Application/Processor/AuthProcessorTestCase.php
+++ b/tests/Unit/User/Application/Processor/AuthProcessorTestCase.php
@@ -100,8 +100,11 @@ abstract class AuthProcessorTestCase extends UnitTestCase
 
     private function readStringProperty(object $object, string $property): string
     {
-        $reflectionProperty = new \ReflectionProperty($object, $property);
-        $value = $reflectionProperty->getValue($object);
+        if (!property_exists($object, $property)) {
+            self::fail(sprintf('Expected %s to expose property "%s".', $object::class, $property));
+        }
+
+        $value = $object->{$property};
 
         self::assertIsString($value);
 

--- a/tests/Unit/User/Application/Processor/CompleteTwoFactorProcessorTest.php
+++ b/tests/Unit/User/Application/Processor/CompleteTwoFactorProcessorTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Unit\User\Application\Processor;
 
 use ApiPlatform\Metadata\Operation;
+use App\Shared\Application\Bus\Guard\CommandResponseTypeGuard;
 use App\Shared\Domain\Bus\Command\CommandBusInterface;
 use App\User\Application\Command\CompleteTwoFactorCommand;
 use App\User\Application\DTO\CompleteTwoFactorCommandResponse;
@@ -183,22 +184,22 @@ final class CompleteTwoFactorProcessorTest extends AuthProcessorTestCase
         string $refreshToken
     ): void {
         $response = new CompleteTwoFactorCommandResponse($accessToken, $refreshToken);
-        $this->commandBus->expects($this->once())->method('dispatch')
-            ->with($this->callback(
-                function (CompleteTwoFactorCommand $cmd) use (
-                    $pendingSessionId,
-                    $totpCode,
-                    $ipAddress,
-                    $userAgent,
-                ): bool {
-                    $this->assertSame($pendingSessionId, $cmd->pendingSessionId);
-                    $this->assertSame($totpCode, $cmd->twoFactorCode);
-                    $this->assertSame($ipAddress, $cmd->ipAddress);
-                    $this->assertSame($userAgent, $cmd->userAgent);
-                    return true;
-                }
-            ))
-            ->willReturn($response);
+        $this->expectDispatchMatchingCommand(
+            $this->commandBus,
+            CompleteTwoFactorCommand::class,
+            $response,
+            function (CompleteTwoFactorCommand $cmd) use (
+                $pendingSessionId,
+                $totpCode,
+                $ipAddress,
+                $userAgent,
+            ): void {
+                $this->assertSame($pendingSessionId, $cmd->pendingSessionId);
+                $this->assertSame($totpCode, $cmd->twoFactorCode);
+                $this->assertSame($ipAddress, $cmd->ipAddress);
+                $this->assertSame($userAgent, $cmd->userAgent);
+            }
+        );
     }
 
     /**
@@ -220,13 +221,14 @@ final class CompleteTwoFactorProcessorTest extends AuthProcessorTestCase
     private function expectDispatchSetsResponse(
         CompleteTwoFactorCommandResponse $response
     ): void {
-        $this->commandBus->expects($this->once())->method('dispatch')
-            ->with($this->callback(
-                static function (CompleteTwoFactorCommand $cmd): bool {
-                    return $cmd->pendingSessionId !== '';
-                }
-            ))
-            ->willReturn($response);
+        $this->expectDispatchMatchingCommand(
+            $this->commandBus,
+            CompleteTwoFactorCommand::class,
+            $response,
+            static function (CompleteTwoFactorCommand $cmd): void {
+                self::assertNotSame('', $cmd->pendingSessionId);
+            }
+        );
     }
 
     private function processDto(
@@ -235,6 +237,7 @@ final class CompleteTwoFactorProcessorTest extends AuthProcessorTestCase
     ): mixed {
         $processor = new CompleteTwoFactorProcessor(
             $this->commandBus,
+            new CommandResponseTypeGuard(),
             new CompleteTwoFactorCommandFactory(),
             $this->requestContextResolver,
             $this->cookieFactory,

--- a/tests/Unit/User/Application/Processor/CompleteTwoFactorProcessorTest.php
+++ b/tests/Unit/User/Application/Processor/CompleteTwoFactorProcessorTest.php
@@ -228,16 +228,15 @@ final class CompleteTwoFactorProcessorTest extends UnitTestCase
                     $totpCode,
                     $ipAddress,
                     $userAgent,
-                    $response
                 ): bool {
                     $this->assertSame($pendingSessionId, $cmd->pendingSessionId);
                     $this->assertSame($totpCode, $cmd->twoFactorCode);
                     $this->assertSame($ipAddress, $cmd->ipAddress);
                     $this->assertSame($userAgent, $cmd->userAgent);
-                    $cmd->setResponse($response);
                     return true;
                 }
-            ));
+            ))
+            ->willReturn($response);
     }
 
     private function expectDispatchSetsResponse(
@@ -245,11 +244,11 @@ final class CompleteTwoFactorProcessorTest extends UnitTestCase
     ): void {
         $this->commandBus->expects($this->once())->method('dispatch')
             ->with($this->callback(
-                static function (CompleteTwoFactorCommand $cmd) use ($response): bool {
-                    $cmd->setResponse($response);
-                    return true;
+                static function (CompleteTwoFactorCommand $cmd): bool {
+                    return $cmd->pendingSessionId !== '';
                 }
-            ));
+            ))
+            ->willReturn($response);
     }
 
     private function expectDispatchAssertingRequestMetadata(
@@ -262,14 +261,13 @@ final class CompleteTwoFactorProcessorTest extends UnitTestCase
                 function (CompleteTwoFactorCommand $cmd) use (
                     $ipAddress,
                     $userAgent,
-                    $response
                 ): bool {
                     $this->assertSame($ipAddress, $cmd->ipAddress);
                     $this->assertSame($userAgent, $cmd->userAgent);
-                    $cmd->setResponse($response);
                     return true;
                 }
-            ));
+            ))
+            ->willReturn($response);
     }
 
     private function processDto(

--- a/tests/Unit/User/Application/Processor/CompleteTwoFactorProcessorTest.php
+++ b/tests/Unit/User/Application/Processor/CompleteTwoFactorProcessorTest.php
@@ -42,16 +42,14 @@ final class CompleteTwoFactorProcessorTest extends AuthProcessorTestCase
         $data = $this->makeTokenScenarioData();
         [$ipAddress, $userAgent, $pendingSessionId, $totpCode, $accessToken, $refreshToken] = $data;
         $request = $this->createMock(Request::class);
-        $this->stubRequestContextResolver($this->requestContextResolver, $request, $ipAddress, $userAgent);
-        $dto = new CompleteTwoFactorDto($pendingSessionId, $totpCode);
-        $this->expectDispatchValidatingMetadata(
-            $pendingSessionId,
-            $totpCode,
+        $this->stubRequestContextResolver(
+            $this->requestContextResolver,
+            $request,
             $ipAddress,
-            $userAgent,
-            $accessToken,
-            $refreshToken
+            $userAgent
         );
+        $dto = new CompleteTwoFactorDto($pendingSessionId, $totpCode);
+        $this->expectDispatchForTokenScenario($data);
         $this->cookieFactory->expects($this->once())->method('create')
             ->with($accessToken, false)
             ->willReturn(Cookie::create('__Host-auth_token', $accessToken));
@@ -62,18 +60,9 @@ final class CompleteTwoFactorProcessorTest extends AuthProcessorTestCase
 
     public function testProcessAttachesCookieWithRememberMe(): void
     {
-        $request = $this->createMock(Request::class);
-        $this->stubRequestContextResolver(
-            $this->requestContextResolver,
-            $request,
-            $this->faker->ipv4(),
-            $this->faker->userAgent()
-        );
+        $request = $this->stubRandomRequestContext($this->requestContextResolver);
         $accessToken = $this->faker->sha256();
-        $dto = new CompleteTwoFactorDto(
-            $this->faker->lexify('??????????????????????????'),
-            (string) $this->faker->numberBetween(100000, 999999)
-        );
+        $dto = $this->makeRandomDto();
         $commandResponse = (new CompleteTwoFactorCommandResponse(
             $accessToken,
             $this->faker->sha256()
@@ -88,17 +77,8 @@ final class CompleteTwoFactorProcessorTest extends AuthProcessorTestCase
 
     public function testProcessDoesNotCreateCookieWhenAccessTokenIsEmpty(): void
     {
-        $request = $this->createMock(Request::class);
-        $this->stubRequestContextResolver(
-            $this->requestContextResolver,
-            $request,
-            $this->faker->ipv4(),
-            $this->faker->userAgent()
-        );
-        $dto = new CompleteTwoFactorDto(
-            $this->faker->lexify('??????????????????????????'),
-            (string) $this->faker->numberBetween(100000, 999999)
-        );
+        $request = $this->stubRandomRequestContext($this->requestContextResolver);
+        $dto = $this->makeRandomDto();
         $this->expectDispatchSetsResponse(
             new CompleteTwoFactorCommandResponse(
                 '',
@@ -112,12 +92,12 @@ final class CompleteTwoFactorProcessorTest extends AuthProcessorTestCase
 
     public function testProcessDelegatesContextRequestToResolver(): void
     {
-        $ipAddress = $this->faker->ipv4();
-        $userAgent = $this->faker->userAgent();
         $request = $this->createMock(Request::class);
-        $this->requestContextResolver->expects($this->once())->method('resolveRequest')
-            ->with($request)->willReturn($request);
-        $this->stubRequestContextMetadata($this->requestContextResolver, $request, $ipAddress, $userAgent);
+        [$ipAddress, $userAgent] = $this->expectResolvedRequestContext(
+            $this->requestContextResolver,
+            $request,
+            $request
+        );
         $dto = $this->makeRandomDto();
         $accessToken = $this->faker->sha256();
         $this->expectDispatchWithRequestMetadata(
@@ -136,21 +116,13 @@ final class CompleteTwoFactorProcessorTest extends AuthProcessorTestCase
 
     public function testProcessPassesNullToResolverWhenContextRequestIsMissing(): void
     {
-        $ipAddress = $this->faker->ipv4();
-        $userAgent = $this->faker->userAgent();
         $resolvedRequest = $this->createMock(Request::class);
-        $this->requestContextResolver->expects($this->once())->method('resolveRequest')
-            ->with(null)->willReturn($resolvedRequest);
-        $this->stubRequestContextMetadata(
+        [$ipAddress, $userAgent] = $this->expectResolvedRequestContext(
             $this->requestContextResolver,
-            $resolvedRequest,
-            $ipAddress,
-            $userAgent
+            null,
+            $resolvedRequest
         );
-        $dto = new CompleteTwoFactorDto(
-            $this->faker->lexify('??????????????????????????'),
-            (string) $this->faker->numberBetween(100000, 999999)
-        );
+        $dto = $this->makeRandomDto();
         $this->expectDispatchWithRequestMetadata(
             $this->commandBus,
             CompleteTwoFactorCommand::class,
@@ -167,18 +139,9 @@ final class CompleteTwoFactorProcessorTest extends AuthProcessorTestCase
 
     public function testProcessIncludesRecoveryCodeWarningFieldsInResponse(): void
     {
-        $request = $this->createMock(Request::class);
-        $this->stubRequestContextResolver(
-            $this->requestContextResolver,
-            $request,
-            $this->faker->ipv4(),
-            $this->faker->userAgent()
-        );
+        $request = $this->stubRandomRequestContext($this->requestContextResolver);
         $recoveryCode = $this->faker->regexify('[A-Z0-9]{4}-[A-Z0-9]{4}');
-        $dto = new CompleteTwoFactorDto(
-            $this->faker->lexify('??????????????????????????'),
-            $recoveryCode
-        );
+        $dto = $this->makeDtoWithCode($recoveryCode);
         $remainingCodes = $this->faker->numberBetween(1, 3);
         $warningMessage = $this->faker->sentence();
         $this->expectDispatchSetsResponse(new CompleteTwoFactorCommandResponse(
@@ -196,17 +159,8 @@ final class CompleteTwoFactorProcessorTest extends AuthProcessorTestCase
 
     public function testProcessOmitsRecoveryCodeFieldsWhenNull(): void
     {
-        $request = $this->createMock(Request::class);
-        $this->stubRequestContextResolver(
-            $this->requestContextResolver,
-            $request,
-            $this->faker->ipv4(),
-            $this->faker->userAgent()
-        );
-        $dto = new CompleteTwoFactorDto(
-            $this->faker->lexify('??????????????????????????'),
-            (string) $this->faker->numberBetween(100000, 999999)
-        );
+        $request = $this->stubRandomRequestContext($this->requestContextResolver);
+        $dto = $this->makeRandomDto();
         $this->expectDispatchSetsResponse(
             new CompleteTwoFactorCommandResponse(
                 $this->faker->sha256(),
@@ -245,6 +199,22 @@ final class CompleteTwoFactorProcessorTest extends AuthProcessorTestCase
                 }
             ))
             ->willReturn($response);
+    }
+
+    /**
+     * @param array{string, string, string, string, string, string} $data
+     */
+    private function expectDispatchForTokenScenario(array $data): void
+    {
+        [$ipAddress, $userAgent, $pendingSessionId, $totpCode, $accessToken, $refreshToken] = $data;
+        $this->expectDispatchValidatingMetadata(
+            $pendingSessionId,
+            $totpCode,
+            $ipAddress,
+            $userAgent,
+            $accessToken,
+            $refreshToken
+        );
     }
 
     private function expectDispatchSetsResponse(
@@ -307,9 +277,16 @@ final class CompleteTwoFactorProcessorTest extends AuthProcessorTestCase
 
     private function makeRandomDto(): CompleteTwoFactorDto
     {
+        return $this->makeDtoWithCode(
+            (string) $this->faker->numberBetween(100000, 999999)
+        );
+    }
+
+    private function makeDtoWithCode(string $code): CompleteTwoFactorDto
+    {
         return new CompleteTwoFactorDto(
             $this->faker->lexify('??????????????????????????'),
-            (string) $this->faker->numberBetween(100000, 999999)
+            $code
         );
     }
 }

--- a/tests/Unit/User/Application/Processor/CompleteTwoFactorProcessorTest.php
+++ b/tests/Unit/User/Application/Processor/CompleteTwoFactorProcessorTest.php
@@ -6,7 +6,6 @@ namespace App\Tests\Unit\User\Application\Processor;
 
 use ApiPlatform\Metadata\Operation;
 use App\Shared\Domain\Bus\Command\CommandBusInterface;
-use App\Tests\Unit\UnitTestCase;
 use App\User\Application\Command\CompleteTwoFactorCommand;
 use App\User\Application\DTO\CompleteTwoFactorCommandResponse;
 use App\User\Application\DTO\CompleteTwoFactorDto;
@@ -18,7 +17,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\Request;
 
-final class CompleteTwoFactorProcessorTest extends UnitTestCase
+final class CompleteTwoFactorProcessorTest extends AuthProcessorTestCase
 {
     private CommandBusInterface&MockObject $commandBus;
     private HttpRequestContextResolverInterface&MockObject $requestContextResolver;
@@ -256,18 +255,15 @@ final class CompleteTwoFactorProcessorTest extends UnitTestCase
         string $userAgent,
         CompleteTwoFactorCommandResponse $response
     ): void {
-        $this->commandBus->expects($this->once())->method('dispatch')
-            ->with($this->callback(
-                function (CompleteTwoFactorCommand $cmd) use (
-                    $ipAddress,
-                    $userAgent,
-                ): bool {
-                    $this->assertSame($ipAddress, $cmd->ipAddress);
-                    $this->assertSame($userAgent, $cmd->userAgent);
-                    return true;
-                }
-            ))
-            ->willReturn($response);
+        $this->expectDispatchMatchingCommand(
+            $this->commandBus,
+            CompleteTwoFactorCommand::class,
+            $response,
+            function (CompleteTwoFactorCommand $cmd) use ($ipAddress, $userAgent): void {
+                $this->assertSame($ipAddress, $cmd->ipAddress);
+                $this->assertSame($userAgent, $cmd->userAgent);
+            }
+        );
     }
 
     private function processDto(

--- a/tests/Unit/User/Application/Processor/CompleteTwoFactorProcessorTest.php
+++ b/tests/Unit/User/Application/Processor/CompleteTwoFactorProcessorTest.php
@@ -42,7 +42,7 @@ final class CompleteTwoFactorProcessorTest extends AuthProcessorTestCase
         $data = $this->makeTokenScenarioData();
         [$ipAddress, $userAgent, $pendingSessionId, $totpCode, $accessToken, $refreshToken] = $data;
         $request = $this->createMock(Request::class);
-        $this->stubResolver($request, $ipAddress, $userAgent);
+        $this->stubRequestContextResolver($this->requestContextResolver, $request, $ipAddress, $userAgent);
         $dto = new CompleteTwoFactorDto($pendingSessionId, $totpCode);
         $this->expectDispatchValidatingMetadata(
             $pendingSessionId,
@@ -63,7 +63,12 @@ final class CompleteTwoFactorProcessorTest extends AuthProcessorTestCase
     public function testProcessAttachesCookieWithRememberMe(): void
     {
         $request = $this->createMock(Request::class);
-        $this->stubResolver($request, $this->faker->ipv4(), $this->faker->userAgent());
+        $this->stubRequestContextResolver(
+            $this->requestContextResolver,
+            $request,
+            $this->faker->ipv4(),
+            $this->faker->userAgent()
+        );
         $accessToken = $this->faker->sha256();
         $dto = new CompleteTwoFactorDto(
             $this->faker->lexify('??????????????????????????'),
@@ -84,7 +89,12 @@ final class CompleteTwoFactorProcessorTest extends AuthProcessorTestCase
     public function testProcessDoesNotCreateCookieWhenAccessTokenIsEmpty(): void
     {
         $request = $this->createMock(Request::class);
-        $this->stubResolver($request, $this->faker->ipv4(), $this->faker->userAgent());
+        $this->stubRequestContextResolver(
+            $this->requestContextResolver,
+            $request,
+            $this->faker->ipv4(),
+            $this->faker->userAgent()
+        );
         $dto = new CompleteTwoFactorDto(
             $this->faker->lexify('??????????????????????????'),
             (string) $this->faker->numberBetween(100000, 999999)
@@ -107,16 +117,18 @@ final class CompleteTwoFactorProcessorTest extends AuthProcessorTestCase
         $request = $this->createMock(Request::class);
         $this->requestContextResolver->expects($this->once())->method('resolveRequest')
             ->with($request)->willReturn($request);
-        $this->stubResolverMetadata($request, $ipAddress, $userAgent);
+        $this->stubRequestContextMetadata($this->requestContextResolver, $request, $ipAddress, $userAgent);
         $dto = $this->makeRandomDto();
         $accessToken = $this->faker->sha256();
-        $this->expectDispatchAssertingRequestMetadata(
-            $ipAddress,
-            $userAgent,
+        $this->expectDispatchWithRequestMetadata(
+            $this->commandBus,
+            CompleteTwoFactorCommand::class,
             new CompleteTwoFactorCommandResponse(
                 $accessToken,
                 $this->faker->sha256()
-            )
+            ),
+            $ipAddress,
+            $userAgent
         );
         $response = $this->processDto($dto, $request);
         $this->assertSame(200, $response->getStatusCode());
@@ -129,18 +141,25 @@ final class CompleteTwoFactorProcessorTest extends AuthProcessorTestCase
         $resolvedRequest = $this->createMock(Request::class);
         $this->requestContextResolver->expects($this->once())->method('resolveRequest')
             ->with(null)->willReturn($resolvedRequest);
-        $this->stubResolverMetadata($resolvedRequest, $ipAddress, $userAgent);
+        $this->stubRequestContextMetadata(
+            $this->requestContextResolver,
+            $resolvedRequest,
+            $ipAddress,
+            $userAgent
+        );
         $dto = new CompleteTwoFactorDto(
             $this->faker->lexify('??????????????????????????'),
             (string) $this->faker->numberBetween(100000, 999999)
         );
-        $this->expectDispatchAssertingRequestMetadata(
-            $ipAddress,
-            $userAgent,
+        $this->expectDispatchWithRequestMetadata(
+            $this->commandBus,
+            CompleteTwoFactorCommand::class,
             new CompleteTwoFactorCommandResponse(
                 $this->faker->sha256(),
                 $this->faker->sha256()
-            )
+            ),
+            $ipAddress,
+            $userAgent
         );
         $response = $this->processDto($dto);
         $this->assertSame(200, $response->getStatusCode());
@@ -149,7 +168,12 @@ final class CompleteTwoFactorProcessorTest extends AuthProcessorTestCase
     public function testProcessIncludesRecoveryCodeWarningFieldsInResponse(): void
     {
         $request = $this->createMock(Request::class);
-        $this->stubResolver($request, $this->faker->ipv4(), $this->faker->userAgent());
+        $this->stubRequestContextResolver(
+            $this->requestContextResolver,
+            $request,
+            $this->faker->ipv4(),
+            $this->faker->userAgent()
+        );
         $recoveryCode = $this->faker->regexify('[A-Z0-9]{4}-[A-Z0-9]{4}');
         $dto = new CompleteTwoFactorDto(
             $this->faker->lexify('??????????????????????????'),
@@ -173,7 +197,12 @@ final class CompleteTwoFactorProcessorTest extends AuthProcessorTestCase
     public function testProcessOmitsRecoveryCodeFieldsWhenNull(): void
     {
         $request = $this->createMock(Request::class);
-        $this->stubResolver($request, $this->faker->ipv4(), $this->faker->userAgent());
+        $this->stubRequestContextResolver(
+            $this->requestContextResolver,
+            $request,
+            $this->faker->ipv4(),
+            $this->faker->userAgent()
+        );
         $dto = new CompleteTwoFactorDto(
             $this->faker->lexify('??????????????????????????'),
             (string) $this->faker->numberBetween(100000, 999999)
@@ -189,26 +218,6 @@ final class CompleteTwoFactorProcessorTest extends AuthProcessorTestCase
         $this->assertSame(200, $response->getStatusCode());
         $this->assertArrayNotHasKey('recovery_codes_remaining', $body);
         $this->assertArrayNotHasKey('warning', $body);
-    }
-
-    private function stubResolver(
-        ?Request $request,
-        string $ipAddress,
-        string $userAgent
-    ): void {
-        $this->requestContextResolver->method('resolveRequest')->willReturn($request);
-        $this->stubResolverMetadata($request, $ipAddress, $userAgent);
-    }
-
-    private function stubResolverMetadata(
-        ?Request $request,
-        string $ipAddress,
-        string $userAgent
-    ): void {
-        $this->requestContextResolver->method('resolveIpAddress')
-            ->with($request)->willReturn($ipAddress);
-        $this->requestContextResolver->method('resolveUserAgent')
-            ->with($request)->willReturn($userAgent);
     }
 
     private function expectDispatchValidatingMetadata(
@@ -248,22 +257,6 @@ final class CompleteTwoFactorProcessorTest extends AuthProcessorTestCase
                 }
             ))
             ->willReturn($response);
-    }
-
-    private function expectDispatchAssertingRequestMetadata(
-        string $ipAddress,
-        string $userAgent,
-        CompleteTwoFactorCommandResponse $response
-    ): void {
-        $this->expectDispatchMatchingCommand(
-            $this->commandBus,
-            CompleteTwoFactorCommand::class,
-            $response,
-            function (CompleteTwoFactorCommand $cmd) use ($ipAddress, $userAgent): void {
-                $this->assertSame($ipAddress, $cmd->ipAddress);
-                $this->assertSame($userAgent, $cmd->userAgent);
-            }
-        );
     }
 
     private function processDto(

--- a/tests/Unit/User/Application/Processor/CompleteTwoFactorProcessorTest.php
+++ b/tests/Unit/User/Application/Processor/CompleteTwoFactorProcessorTest.php
@@ -14,6 +14,7 @@ use App\User\Application\Factory\AuthCookieFactoryInterface;
 use App\User\Application\Factory\CompleteTwoFactorCommandFactory;
 use App\User\Application\Processor\CompleteTwoFactorProcessor;
 use App\User\Application\Resolver\HttpRequestContextResolverInterface;
+use App\User\Application\Service\CompleteTwoFactorCommandDispatcher;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\Request;
@@ -236,10 +237,12 @@ final class CompleteTwoFactorProcessorTest extends AuthProcessorTestCase
         ?Request $request = null
     ): mixed {
         $processor = new CompleteTwoFactorProcessor(
-            $this->commandBus,
-            new CommandResponseTypeGuard(),
-            new CompleteTwoFactorCommandFactory(),
-            $this->requestContextResolver,
+            new CompleteTwoFactorCommandDispatcher(
+                $this->commandBus,
+                new CommandResponseTypeGuard(),
+                new CompleteTwoFactorCommandFactory(),
+                $this->requestContextResolver
+            ),
             $this->cookieFactory,
         );
         if ($request !== null) {

--- a/tests/Unit/User/Application/Processor/ConfirmTwoFactorProcessorTest.php
+++ b/tests/Unit/User/Application/Processor/ConfirmTwoFactorProcessorTest.php
@@ -14,6 +14,7 @@ use App\User\Application\DTO\ConfirmTwoFactorDto;
 use App\User\Application\Factory\ConfirmTwoFactorCommandFactory;
 use App\User\Application\Processor\ConfirmTwoFactorProcessor;
 use App\User\Application\Resolver\CurrentUserIdentityResolver;
+use App\User\Application\Service\ConfirmTwoFactorCommandDispatcher;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -94,10 +95,12 @@ final class ConfirmTwoFactorProcessorTest extends UnitTestCase
     private function createProcessor(): ConfirmTwoFactorProcessor
     {
         return new ConfirmTwoFactorProcessor(
-            $this->commandBus,
-            new CommandResponseTypeGuard(),
-            new CurrentUserIdentityResolver($this->security),
-            new ConfirmTwoFactorCommandFactory(),
+            new ConfirmTwoFactorCommandDispatcher(
+                $this->commandBus,
+                new CommandResponseTypeGuard(),
+                new CurrentUserIdentityResolver($this->security),
+                new ConfirmTwoFactorCommandFactory()
+            ),
         );
     }
 

--- a/tests/Unit/User/Application/Processor/ConfirmTwoFactorProcessorTest.php
+++ b/tests/Unit/User/Application/Processor/ConfirmTwoFactorProcessorTest.php
@@ -161,14 +161,11 @@ final class ConfirmTwoFactorProcessorTest extends UnitTestCase
                     $email,
                     $code,
                     $recoveryCodes
-                ): void {
+                ): ConfirmTwoFactorCommandResponse {
                     $this->assertSame($email, $cmd->userEmail);
                     $this->assertSame($code, $cmd->twoFactorCode);
-                    $cmd->setResponse(
-                        new ConfirmTwoFactorCommandResponse(
-                            $recoveryCodes
-                        )
-                    );
+
+                    return new ConfirmTwoFactorCommandResponse($recoveryCodes);
                 }
             );
     }
@@ -208,14 +205,13 @@ final class ConfirmTwoFactorProcessorTest extends UnitTestCase
             ->willReturnCallback(
                 function (ConfirmTwoFactorCommand $cmd) use (
                     $sessionId
-                ): void {
+                ): ConfirmTwoFactorCommandResponse {
                     $this->assertSame(
                         $sessionId,
                         $cmd->currentSessionId
                     );
-                    $cmd->setResponse(
-                        new ConfirmTwoFactorCommandResponse([])
-                    );
+
+                    return new ConfirmTwoFactorCommandResponse([]);
                 }
             );
     }
@@ -226,11 +222,10 @@ final class ConfirmTwoFactorProcessorTest extends UnitTestCase
             ->expects($this->once())
             ->method('dispatch')
             ->willReturnCallback(
-                function (ConfirmTwoFactorCommand $cmd): void {
+                function (ConfirmTwoFactorCommand $cmd): ConfirmTwoFactorCommandResponse {
                     $this->assertSame('', $cmd->currentSessionId);
-                    $cmd->setResponse(
-                        new ConfirmTwoFactorCommandResponse([])
-                    );
+
+                    return new ConfirmTwoFactorCommandResponse([]);
                 }
             );
     }

--- a/tests/Unit/User/Application/Processor/ConfirmTwoFactorProcessorTest.php
+++ b/tests/Unit/User/Application/Processor/ConfirmTwoFactorProcessorTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Unit\User\Application\Processor;
 
 use ApiPlatform\Metadata\Post;
+use App\Shared\Application\Bus\Guard\CommandResponseTypeGuard;
 use App\Shared\Domain\Bus\Command\CommandBusInterface;
 use App\Tests\Unit\UnitTestCase;
 use App\User\Application\Command\ConfirmTwoFactorCommand;
@@ -94,6 +95,7 @@ final class ConfirmTwoFactorProcessorTest extends UnitTestCase
     {
         return new ConfirmTwoFactorProcessor(
             $this->commandBus,
+            new CommandResponseTypeGuard(),
             new CurrentUserIdentityResolver($this->security),
             new ConfirmTwoFactorCommandFactory(),
         );

--- a/tests/Unit/User/Application/Processor/RefreshTokenProcessorTest.php
+++ b/tests/Unit/User/Application/Processor/RefreshTokenProcessorTest.php
@@ -62,15 +62,13 @@ final class RefreshTokenProcessorTest extends UnitTestCase
              */
                 function (RefreshTokenCommand $command): bool {
                     $this->assertSame('old-refresh-token', $command->refreshToken);
-                    $command->setResponse(
-                        new RefreshTokenCommandResponse(
-                            'new-access-token',
-                            'new-refresh-token'
-                        )
-                    );
 
                     return true;
                 }
+            ))
+            ->willReturn(new RefreshTokenCommandResponse(
+                'new-access-token',
+                'new-refresh-token'
             ));
     }
 
@@ -83,15 +81,12 @@ final class RefreshTokenProcessorTest extends UnitTestCase
              * @return true
              */
                 static function (RefreshTokenCommand $command): bool {
-                    $command->setResponse(
-                        new RefreshTokenCommandResponse(
-                            '',
-                            'new-refresh-token'
-                        )
-                    );
-
-                    return true;
+                    return $command->refreshToken === 'old-refresh-token';
                 }
+            ))
+            ->willReturn(new RefreshTokenCommandResponse(
+                '',
+                'new-refresh-token'
             ));
     }
 

--- a/tests/Unit/User/Application/Processor/RefreshTokenProcessorTest.php
+++ b/tests/Unit/User/Application/Processor/RefreshTokenProcessorTest.php
@@ -33,8 +33,10 @@ final class RefreshTokenProcessorTest extends UnitTestCase
     public function testProcessReturnsNewTokensAndSetsCookie(): void
     {
         $refreshToken = $this->faker->sha256();
+        $accessToken = $this->faker->sha256();
+        $newRefreshToken = $this->faker->sha256();
         $dto = new RefreshTokenDto($refreshToken);
-        $this->expectRefreshDispatch($refreshToken);
+        $this->expectRefreshDispatch($refreshToken, $accessToken, $newRefreshToken);
 
         $processor = new RefreshTokenProcessor(
             $this->commandBus,
@@ -43,14 +45,15 @@ final class RefreshTokenProcessorTest extends UnitTestCase
         );
         $response = $processor->process($dto, $this->operation);
 
-        $this->assertRefreshResponse($response);
+        $this->assertRefreshResponse($response, $accessToken, $newRefreshToken);
     }
 
     public function testProcessDoesNotSetCookieWhenAccessTokenIsEmpty(): void
     {
         $refreshToken = $this->faker->sha256();
+        $newRefreshToken = $this->faker->sha256();
         $dto = new RefreshTokenDto($refreshToken);
-        $this->expectEmptyAccessTokenDispatch($refreshToken);
+        $this->expectEmptyAccessTokenDispatch($refreshToken, $newRefreshToken);
 
         $processor = new RefreshTokenProcessor(
             $this->commandBus,
@@ -63,8 +66,26 @@ final class RefreshTokenProcessorTest extends UnitTestCase
         $this->assertCount(0, $response->headers->getCookies());
     }
 
-    private function expectRefreshDispatch(string $refreshToken): void
-    {
+    private function expectRefreshDispatch(
+        string $refreshToken,
+        string $accessToken,
+        string $newRefreshToken
+    ): void {
+        $this->expectDispatchResponse($refreshToken, $accessToken, $newRefreshToken);
+    }
+
+    private function expectEmptyAccessTokenDispatch(
+        string $refreshToken,
+        string $newRefreshToken
+    ): void {
+        $this->expectDispatchResponse($refreshToken, '', $newRefreshToken);
+    }
+
+    private function expectDispatchResponse(
+        string $refreshToken,
+        string $accessToken,
+        string $newRefreshToken
+    ): void {
         $this->commandBus
             ->expects($this->once())
             ->method('dispatch')
@@ -78,36 +99,19 @@ final class RefreshTokenProcessorTest extends UnitTestCase
                 }
             ))
             ->willReturn(new RefreshTokenCommandResponse(
-                'new-access-token',
-                'new-refresh-token'
+                $accessToken,
+                $newRefreshToken
             ));
     }
 
-    private function expectEmptyAccessTokenDispatch(string $refreshToken): void
-    {
-        $this->commandBus
-            ->expects($this->once())
-            ->method('dispatch')
-            ->with($this->callback(/**
-             * @return true
-             */
-                function (RefreshTokenCommand $command) use ($refreshToken): bool {
-                    $this->assertSame($refreshToken, $command->refreshToken);
-
-                    return true;
-                }
-            ))
-            ->willReturn(new RefreshTokenCommandResponse(
-                '',
-                'new-refresh-token'
-            ));
-    }
-
-    private function assertRefreshResponse(Response $response): void
-    {
+    private function assertRefreshResponse(
+        Response $response,
+        string $accessToken,
+        string $refreshToken
+    ): void {
         $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
         $body = json_decode((string) $response->getContent(), true);
-        $this->assertSame('new-access-token', $body['access_token']);
-        $this->assertSame('new-refresh-token', $body['refresh_token']);
+        $this->assertSame($accessToken, $body['access_token']);
+        $this->assertSame($refreshToken, $body['refresh_token']);
     }
 }

--- a/tests/Unit/User/Application/Processor/RefreshTokenProcessorTest.php
+++ b/tests/Unit/User/Application/Processor/RefreshTokenProcessorTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Unit\User\Application\Processor;
 
 use ApiPlatform\Metadata\Operation;
+use App\Shared\Application\Bus\Guard\CommandResponseTypeGuard;
 use App\Shared\Domain\Bus\Command\CommandBusInterface;
 use App\Tests\Unit\UnitTestCase;
 use App\User\Application\Command\RefreshTokenCommand;
@@ -31,10 +32,15 @@ final class RefreshTokenProcessorTest extends UnitTestCase
 
     public function testProcessReturnsNewTokensAndSetsCookie(): void
     {
-        $dto = new RefreshTokenDto('old-refresh-token');
-        $this->expectRefreshDispatch();
+        $refreshToken = $this->faker->sha256();
+        $dto = new RefreshTokenDto($refreshToken);
+        $this->expectRefreshDispatch($refreshToken);
 
-        $processor = new RefreshTokenProcessor($this->commandBus, new RefreshTokenCommandFactory());
+        $processor = new RefreshTokenProcessor(
+            $this->commandBus,
+            new CommandResponseTypeGuard(),
+            new RefreshTokenCommandFactory()
+        );
         $response = $processor->process($dto, $this->operation);
 
         $this->assertRefreshResponse($response);
@@ -42,17 +48,22 @@ final class RefreshTokenProcessorTest extends UnitTestCase
 
     public function testProcessDoesNotSetCookieWhenAccessTokenIsEmpty(): void
     {
-        $dto = new RefreshTokenDto('old-refresh-token');
-        $this->expectEmptyAccessTokenDispatch();
+        $refreshToken = $this->faker->sha256();
+        $dto = new RefreshTokenDto($refreshToken);
+        $this->expectEmptyAccessTokenDispatch($refreshToken);
 
-        $processor = new RefreshTokenProcessor($this->commandBus, new RefreshTokenCommandFactory());
+        $processor = new RefreshTokenProcessor(
+            $this->commandBus,
+            new CommandResponseTypeGuard(),
+            new RefreshTokenCommandFactory()
+        );
         $response = $processor->process($dto, $this->operation);
 
         $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
         $this->assertCount(0, $response->headers->getCookies());
     }
 
-    private function expectRefreshDispatch(): void
+    private function expectRefreshDispatch(string $refreshToken): void
     {
         $this->commandBus
             ->expects($this->once())
@@ -60,8 +71,8 @@ final class RefreshTokenProcessorTest extends UnitTestCase
             ->with($this->callback(/**
              * @return true
              */
-                function (RefreshTokenCommand $command): bool {
-                    $this->assertSame('old-refresh-token', $command->refreshToken);
+                function (RefreshTokenCommand $command) use ($refreshToken): bool {
+                    $this->assertSame($refreshToken, $command->refreshToken);
 
                     return true;
                 }
@@ -72,7 +83,7 @@ final class RefreshTokenProcessorTest extends UnitTestCase
             ));
     }
 
-    private function expectEmptyAccessTokenDispatch(): void
+    private function expectEmptyAccessTokenDispatch(string $refreshToken): void
     {
         $this->commandBus
             ->expects($this->once())
@@ -80,8 +91,10 @@ final class RefreshTokenProcessorTest extends UnitTestCase
             ->with($this->callback(/**
              * @return true
              */
-                static function (RefreshTokenCommand $command): bool {
-                    return $command->refreshToken === 'old-refresh-token';
+                function (RefreshTokenCommand $command) use ($refreshToken): bool {
+                    $this->assertSame($refreshToken, $command->refreshToken);
+
+                    return true;
                 }
             ))
             ->willReturn(new RefreshTokenCommandResponse(

--- a/tests/Unit/User/Application/Processor/RegenerateRecoveryCodesProcessorTest.php
+++ b/tests/Unit/User/Application/Processor/RegenerateRecoveryCodesProcessorTest.php
@@ -126,15 +126,15 @@ final class RegenerateRecoveryCodesProcessorTest extends UnitTestCase
             ->with($this->callback(
                 function (RegenerateRecoveryCodesCommand $cmd) use (
                     $email,
-                    $sessionId,
-                    $codes
+                    $sessionId
                 ): bool {
                     $this->assertSame($email, $cmd->userEmail);
                     $this->assertSame($sessionId, $cmd->currentSessionId);
-                    $cmd->setResponse(new RegenerateRecoveryCodesCommandResponse($codes));
+
                     return true;
                 }
-            ));
+            ))
+            ->willReturn(new RegenerateRecoveryCodesCommandResponse($codes));
     }
 
     private function expectDispatchWithEmptySessionResponse(): void
@@ -143,10 +143,11 @@ final class RegenerateRecoveryCodesProcessorTest extends UnitTestCase
             ->with($this->callback(
                 function (RegenerateRecoveryCodesCommand $cmd): bool {
                     $this->assertSame('', $cmd->currentSessionId);
-                    $cmd->setResponse(new RegenerateRecoveryCodesCommandResponse([]));
+
                     return true;
                 }
-            ));
+            ))
+            ->willReturn(new RegenerateRecoveryCodesCommandResponse([]));
     }
 
     private function processRecoveryCodes(): mixed

--- a/tests/Unit/User/Application/Processor/RegenerateRecoveryCodesProcessorTest.php
+++ b/tests/Unit/User/Application/Processor/RegenerateRecoveryCodesProcessorTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Unit\User\Application\Processor;
 
 use ApiPlatform\Metadata\Operation;
+use App\Shared\Application\Bus\Guard\CommandResponseTypeGuard;
 use App\Shared\Domain\Bus\Command\CommandBusInterface;
 use App\Tests\Unit\UnitTestCase;
 use App\User\Application\Command\RegenerateRecoveryCodesCommand;
@@ -75,6 +76,7 @@ final class RegenerateRecoveryCodesProcessorTest extends UnitTestCase
 
         $processor = new RegenerateRecoveryCodesProcessor(
             $this->commandBus,
+            new CommandResponseTypeGuard(),
             new CurrentUserIdentityResolver($this->security),
             new RegenerateRecoveryCodesCommandFactory(),
         );
@@ -154,6 +156,7 @@ final class RegenerateRecoveryCodesProcessorTest extends UnitTestCase
     {
         $processor = new RegenerateRecoveryCodesProcessor(
             $this->commandBus,
+            new CommandResponseTypeGuard(),
             new CurrentUserIdentityResolver($this->security),
             new RegenerateRecoveryCodesCommandFactory()
         );

--- a/tests/Unit/User/Application/Processor/RegisterUserBatchProcessorTest.php
+++ b/tests/Unit/User/Application/Processor/RegisterUserBatchProcessorTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Unit\User\Application\Processor;
 
 use ApiPlatform\Metadata\Operation;
+use App\Shared\Application\Bus\Guard\CommandResponseTypeGuard;
 use App\Shared\Domain\Bus\Command\CommandBusInterface;
 use App\Shared\Infrastructure\Factory\UuidFactory;
 use App\Shared\Infrastructure\Transformer\UuidTransformer;
@@ -45,6 +46,7 @@ final class RegisterUserBatchProcessorTest extends UnitTestCase
         $this->processor = new RegisterUserBatchProcessor(
             $this->serializer,
             $this->commandBus,
+            new CommandResponseTypeGuard(),
             $this->commandFactory
         );
         $this->userFactory = new UserFactory();

--- a/tests/Unit/User/Application/Processor/RegisterUserBatchProcessorTest.php
+++ b/tests/Unit/User/Application/Processor/RegisterUserBatchProcessorTest.php
@@ -89,10 +89,6 @@ final class RegisterUserBatchProcessorTest extends UnitTestCase
         $command = $this->createMock(RegisterUserBatchCommand::class);
         $commandResponse =
             new RegisterUserBatchCommandResponse($userCollection);
-        $command->expects($this->once())
-            ->method('getResponse')
-            ->willReturn($commandResponse);
-
         $this->commandFactory->expects($this->once())
             ->method('create')
             ->with($userCollection)
@@ -100,7 +96,8 @@ final class RegisterUserBatchProcessorTest extends UnitTestCase
 
         $this->commandBus->expects($this->once())
             ->method('dispatch')
-            ->with($command);
+            ->with($command)
+            ->willReturn($commandResponse);
 
         $this->setExpectationsForSerializer($commandResponse, $users);
     }

--- a/tests/Unit/User/Application/Processor/RegisterUserProcessorTest.php
+++ b/tests/Unit/User/Application/Processor/RegisterUserProcessorTest.php
@@ -62,11 +62,8 @@ final class RegisterUserProcessorTest extends UnitTestCase
         $signUpCommand =
             $this->signUpCommandFactory->create($email, $initials, $password);
         $user = $this->userFactory->create($email, $initials, $password, $uuid);
-        $signUpCommand->setResponse(
-            new RegisterUserCommandResponse($user)
-        );
 
-        $this->setExpectations($userRegisterDto, $signUpCommand);
+        $this->setExpectations($userRegisterDto, $signUpCommand, $user);
 
         $returnedUser =
             $this->processor->process($userRegisterDto, $this->mockOperation);
@@ -80,6 +77,7 @@ final class RegisterUserProcessorTest extends UnitTestCase
     private function setExpectations(
         UserRegisterDto $userRegisterDto,
         RegisterUserCommand $signUpCommand,
+        User $user,
     ): void {
         $this->mockSignUpCommandFactory->expects($this->once())
             ->method('create')
@@ -92,6 +90,7 @@ final class RegisterUserProcessorTest extends UnitTestCase
 
         $this->commandBus->expects($this->once())
             ->method('dispatch')
-            ->with($signUpCommand);
+            ->with($signUpCommand)
+            ->willReturn(new RegisterUserCommandResponse($user));
     }
 }

--- a/tests/Unit/User/Application/Processor/RegisterUserProcessorTest.php
+++ b/tests/Unit/User/Application/Processor/RegisterUserProcessorTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Unit\User\Application\Processor;
 
 use ApiPlatform\Metadata\Operation;
+use App\Shared\Application\Bus\Guard\CommandResponseTypeGuard;
 use App\Shared\Domain\Bus\Command\CommandBusInterface;
 use App\Shared\Infrastructure\Factory\UuidFactory;
 use App\Shared\Infrastructure\Transformer\UuidTransformer;
@@ -45,6 +46,7 @@ final class RegisterUserProcessorTest extends UnitTestCase
         );
         $this->processor = new RegisterUserProcessor(
             $this->commandBus,
+            new CommandResponseTypeGuard(),
             $this->mockSignUpCommandFactory
         );
     }

--- a/tests/Unit/User/Application/Processor/SetupTwoFactorProcessorTest.php
+++ b/tests/Unit/User/Application/Processor/SetupTwoFactorProcessorTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Unit\User\Application\Processor;
 
 use ApiPlatform\Metadata\Post;
+use App\Shared\Application\Bus\Guard\CommandResponseTypeGuard;
 use App\Shared\Application\Validator\Http\EmptyJsonObjectRequestValidator;
 use App\Shared\Domain\Bus\Command\CommandBusInterface;
 use App\Tests\Unit\UnitTestCase;
@@ -159,6 +160,7 @@ final class SetupTwoFactorProcessorTest extends UnitTestCase
 
         return new SetupTwoFactorProcessor(
             $this->commandBus,
+            new CommandResponseTypeGuard(),
             new CurrentUserIdentityResolver($this->security),
             new SetupTwoFactorCommandFactory(),
             new HttpRequestContextResolver($requestStack),

--- a/tests/Unit/User/Application/Processor/SetupTwoFactorProcessorTest.php
+++ b/tests/Unit/User/Application/Processor/SetupTwoFactorProcessorTest.php
@@ -221,14 +221,11 @@ final class SetupTwoFactorProcessorTest extends UnitTestCase
         $this->commandBus->expects($this->once())
             ->method('dispatch')
             ->with($this->callback(
-                static function (SetupTwoFactorCommand $cmd) use ($email, $uri, $secret): bool {
-                    $cmd->setResponse(
-                        new SetupTwoFactorCommandResponse($uri, $secret)
-                    );
-
+                static function (SetupTwoFactorCommand $cmd) use ($email): bool {
                     return $cmd->userEmail === $email;
                 }
-            ));
+            ))
+            ->willReturn(new SetupTwoFactorCommandResponse($uri, $secret));
     }
 
     private function assertSetupResponse(

--- a/tests/Unit/User/Application/Processor/SignInProcessorTest.php
+++ b/tests/Unit/User/Application/Processor/SignInProcessorTest.php
@@ -57,13 +57,7 @@ final class SignInProcessorTest extends AuthProcessorTestCase
 
     public function testProcessAttachesCookieWithRememberMe(): void
     {
-        $request = $this->createMock(Request::class);
-        $this->stubRequestContextResolver(
-            $this->requestContextResolver,
-            $request,
-            $this->faker->ipv4(),
-            $this->faker->userAgent()
-        );
+        $request = $this->stubRandomRequestContext($this->requestContextResolver);
         $dto = new SignInDto($this->faker->email(), $this->faker->password());
         $dto->setRememberMe(true);
         $accessToken = $this->faker->sha256();
@@ -78,24 +72,13 @@ final class SignInProcessorTest extends AuthProcessorTestCase
 
     public function testProcessReturnsTwoFactorBodyWithoutAttachingCookie(): void
     {
-        $request = $this->createMock(Request::class);
-        $this->stubRequestContextResolver(
-            $this->requestContextResolver,
-            $request,
-            $this->faker->ipv4(),
-            $this->faker->userAgent()
-        );
+        $request = $this->stubRandomRequestContext($this->requestContextResolver);
         $dto = new SignInDto($this->faker->email(), $this->faker->password());
         $pendingSessionId = $this->faker->uuid();
         $cmdResponse = new SignInCommandResponse(true, null, null, $pendingSessionId);
         $this->expectDispatchWithResponse($cmdResponse);
         $this->cookieFactory->expects($this->never())->method('create');
-        $response = $this->createProcessor()->process(
-            $dto,
-            $this->operation,
-            [],
-            ['request' => $request]
-        );
+        $response = $this->processWithRequest($dto, $request);
         $this->assertSame(200, $response->getStatusCode());
         $this->assertTwoFactorResponseBody(
             $response,
@@ -105,13 +88,7 @@ final class SignInProcessorTest extends AuthProcessorTestCase
 
     public function testProcessDoesNotAttachCookieForTwoFactorEvenWithTokenValue(): void
     {
-        $request = $this->createMock(Request::class);
-        $this->stubRequestContextResolver(
-            $this->requestContextResolver,
-            $request,
-            $this->faker->ipv4(),
-            $this->faker->userAgent()
-        );
+        $request = $this->stubRandomRequestContext($this->requestContextResolver);
         $dto = new SignInDto($this->faker->email(), $this->faker->password());
         $cmdResponse = new SignInCommandResponse(
             true,
@@ -121,33 +98,17 @@ final class SignInProcessorTest extends AuthProcessorTestCase
         );
         $this->expectDispatchWithResponse($cmdResponse);
         $this->cookieFactory->expects($this->never())->method('create');
-        $this->createProcessor()->process(
-            $dto,
-            $this->operation,
-            [],
-            ['request' => $request]
-        );
+        $this->processWithRequest($dto, $request);
     }
 
     public function testProcessDoesNotAttachCookieWhenAccessTokenIsMissing(): void
     {
-        $request = $this->createMock(Request::class);
-        $this->stubRequestContextResolver(
-            $this->requestContextResolver,
-            $request,
-            $this->faker->ipv4(),
-            $this->faker->userAgent()
-        );
+        $request = $this->stubRandomRequestContext($this->requestContextResolver);
         $dto = new SignInDto($this->faker->email(), $this->faker->password());
         $refreshToken = $this->faker->sha256();
         $this->expectDispatchWithResponse(new SignInCommandResponse(false, null, $refreshToken));
         $this->cookieFactory->expects($this->never())->method('create');
-        $response = $this->createProcessor()->process(
-            $dto,
-            $this->operation,
-            [],
-            ['request' => $request]
-        );
+        $response = $this->processWithRequest($dto, $request);
         $this->assertSame(200, $response->getStatusCode());
         $this->assertTokenResponseBody(
             $response,
@@ -201,12 +162,12 @@ final class SignInProcessorTest extends AuthProcessorTestCase
 
     public function testProcessDelegatesContextRequestToResolver(): void
     {
-        $ipAddress = $this->faker->ipv4();
-        $userAgent = $this->faker->userAgent();
         $request = $this->createMock(Request::class);
-        $this->requestContextResolver->expects($this->once())
-            ->method('resolveRequest')->with($request)->willReturn($request);
-        $this->stubRequestContextMetadata($this->requestContextResolver, $request, $ipAddress, $userAgent);
+        [$ipAddress, $userAgent] = $this->expectResolvedRequestContext(
+            $this->requestContextResolver,
+            $request,
+            $request
+        );
         $cmdResponse = $this->createCommandResponse();
         $this->expectDispatchWithRequestMetadata(
             $this->commandBus,
@@ -215,27 +176,20 @@ final class SignInProcessorTest extends AuthProcessorTestCase
             $ipAddress,
             $userAgent
         );
-        $response = $this->createProcessor()->process(
+        $response = $this->processWithRequest(
             new SignInDto($this->faker->email(), $this->faker->password()),
-            $this->operation,
-            [],
-            ['request' => $request]
+            $request
         );
         $this->assertSame(200, $response->getStatusCode());
     }
 
     public function testProcessPassesNullToResolverWhenContextRequestIsMissing(): void
     {
-        $ipAddress = $this->faker->ipv4();
-        $userAgent = $this->faker->userAgent();
         $resolvedRequest = $this->createMock(Request::class);
-        $this->requestContextResolver->expects($this->once())
-            ->method('resolveRequest')->with(null)->willReturn($resolvedRequest);
-        $this->stubRequestContextMetadata(
+        [$ipAddress, $userAgent] = $this->expectResolvedRequestContext(
             $this->requestContextResolver,
-            $resolvedRequest,
-            $ipAddress,
-            $userAgent
+            null,
+            $resolvedRequest
         );
         $cmdResponse = $this->createCommandResponse();
         $this->expectDispatchWithRequestMetadata(
@@ -245,9 +199,8 @@ final class SignInProcessorTest extends AuthProcessorTestCase
             $ipAddress,
             $userAgent
         );
-        $response = $this->createProcessor()->process(
-            new SignInDto($this->faker->email(), $this->faker->password()),
-            $this->operation
+        $response = $this->processWithRequest(
+            new SignInDto($this->faker->email(), $this->faker->password())
         );
         $this->assertSame(200, $response->getStatusCode());
     }
@@ -350,8 +303,12 @@ final class SignInProcessorTest extends AuthProcessorTestCase
         ];
     }
 
-    private function processWithRequest(SignInDto $dto, Request $request): mixed
+    private function processWithRequest(SignInDto $dto, ?Request $request = null): mixed
     {
+        if ($request === null) {
+            return $this->createProcessor()->process($dto, $this->operation);
+        }
+
         return $this->createProcessor()->process(
             $dto,
             $this->operation,

--- a/tests/Unit/User/Application/Processor/SignInProcessorTest.php
+++ b/tests/Unit/User/Application/Processor/SignInProcessorTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Unit\User\Application\Processor;
 
 use ApiPlatform\Metadata\Operation;
+use App\Shared\Application\Bus\Guard\CommandResponseTypeGuard;
 use App\Shared\Domain\Bus\Command\CommandBusInterface;
 use App\User\Application\Command\SignInCommand;
 use App\User\Application\DTO\SignInCommandResponse;
@@ -13,6 +14,7 @@ use App\User\Application\Factory\AuthCookieFactoryInterface;
 use App\User\Application\Factory\SignInCommandFactory;
 use App\User\Application\Processor\SignInProcessor;
 use App\User\Application\Resolver\HttpRequestContextResolverInterface;
+use App\User\Application\Service\SignInCommandDispatcher;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\Request;
@@ -221,46 +223,47 @@ final class SignInProcessorTest extends AuthProcessorTestCase
         string $userAgent,
         SignInCommandResponse $response
     ): void {
-        $this->commandBus->expects($this->once())->method('dispatch')
-            ->with($this->callback(
-                function (SignInCommand $cmd) use (
-                    $email,
-                    $password,
-                    $ipAddress,
-                    $userAgent,
-                ): bool {
-                    $this->assertSame($email, $cmd->email);
-                    $this->assertSame($password, $cmd->password);
-                    $this->assertFalse($cmd->rememberMe);
-                    $this->assertSame($ipAddress, $cmd->ipAddress);
-                    $this->assertSame($userAgent, $cmd->userAgent);
-                    return true;
-                }
-            ))
-            ->willReturn($response);
+        $this->expectDispatchMatchingCommand(
+            $this->commandBus,
+            SignInCommand::class,
+            $response,
+            function (SignInCommand $cmd) use (
+                $email,
+                $password,
+                $ipAddress,
+                $userAgent,
+            ): void {
+                $this->assertSame($email, $cmd->email);
+                $this->assertSame($password, $cmd->password);
+                $this->assertFalse($cmd->rememberMe);
+                $this->assertSame($ipAddress, $cmd->ipAddress);
+                $this->assertSame($userAgent, $cmd->userAgent);
+            }
+        );
     }
 
     private function expectDispatchWithResponse(SignInCommandResponse $response): void
     {
-        $this->commandBus->expects($this->once())->method('dispatch')
-            ->with($this->callback(
-                static function (SignInCommand $cmd): bool {
-                    return $cmd->email !== '';
-                }
-            ))
-            ->willReturn($response);
+        $this->expectDispatchMatchingCommand(
+            $this->commandBus,
+            SignInCommand::class,
+            $response,
+            static function (SignInCommand $cmd): void {
+                self::assertNotSame('', $cmd->email);
+            }
+        );
     }
 
     private function expectDispatchWithRememberMe(SignInCommandResponse $response): void
     {
-        $this->commandBus->expects($this->once())->method('dispatch')
-            ->with($this->callback(
-                function (SignInCommand $cmd): bool {
-                    $this->assertTrue($cmd->rememberMe);
-                    return true;
-                }
-            ))
-            ->willReturn($response);
+        $this->expectDispatchMatchingCommand(
+            $this->commandBus,
+            SignInCommand::class,
+            $response,
+            function (SignInCommand $cmd): void {
+                $this->assertTrue($cmd->rememberMe);
+            }
+        );
     }
 
     private function assertTokenResponseBody(
@@ -320,9 +323,12 @@ final class SignInProcessorTest extends AuthProcessorTestCase
     private function createProcessor(): SignInProcessor
     {
         return new SignInProcessor(
-            $this->commandBus,
-            new SignInCommandFactory(),
-            $this->requestContextResolver,
+            new SignInCommandDispatcher(
+                $this->commandBus,
+                new CommandResponseTypeGuard(),
+                new SignInCommandFactory(),
+                $this->requestContextResolver
+            ),
             $this->cookieFactory,
         );
     }

--- a/tests/Unit/User/Application/Processor/SignInProcessorTest.php
+++ b/tests/Unit/User/Application/Processor/SignInProcessorTest.php
@@ -6,7 +6,6 @@ namespace App\Tests\Unit\User\Application\Processor;
 
 use ApiPlatform\Metadata\Operation;
 use App\Shared\Domain\Bus\Command\CommandBusInterface;
-use App\Tests\Unit\UnitTestCase;
 use App\User\Application\Command\SignInCommand;
 use App\User\Application\DTO\SignInCommandResponse;
 use App\User\Application\DTO\SignInDto;
@@ -19,7 +18,7 @@ use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
 
-final class SignInProcessorTest extends UnitTestCase
+final class SignInProcessorTest extends AuthProcessorTestCase
 {
     private CommandBusInterface&MockObject $commandBus;
     private HttpRequestContextResolverInterface&MockObject $requestContextResolver;
@@ -289,15 +288,15 @@ final class SignInProcessorTest extends UnitTestCase
         string $expectedAgent,
         SignInCommandResponse $response
     ): void {
-        $this->commandBus->expects($this->once())->method('dispatch')
-            ->with($this->callback(
-                function (SignInCommand $cmd) use ($expectedIp, $expectedAgent): bool {
-                    $this->assertSame($expectedIp, $cmd->ipAddress);
-                    $this->assertSame($expectedAgent, $cmd->userAgent);
-                    return true;
-                }
-            ))
-            ->willReturn($response);
+        $this->expectDispatchMatchingCommand(
+            $this->commandBus,
+            SignInCommand::class,
+            $response,
+            function (SignInCommand $cmd) use ($expectedIp, $expectedAgent): void {
+                $this->assertSame($expectedIp, $cmd->ipAddress);
+                $this->assertSame($expectedAgent, $cmd->userAgent);
+            }
+        );
     }
 
     private function assertTokenResponseBody(

--- a/tests/Unit/User/Application/Processor/SignInProcessorTest.php
+++ b/tests/Unit/User/Application/Processor/SignInProcessorTest.php
@@ -249,40 +249,39 @@ final class SignInProcessorTest extends UnitTestCase
                     $password,
                     $ipAddress,
                     $userAgent,
-                    $response
                 ): bool {
                     $this->assertSame($email, $cmd->email);
                     $this->assertSame($password, $cmd->password);
                     $this->assertFalse($cmd->rememberMe);
                     $this->assertSame($ipAddress, $cmd->ipAddress);
                     $this->assertSame($userAgent, $cmd->userAgent);
-                    $cmd->setResponse($response);
                     return true;
                 }
-            ));
+            ))
+            ->willReturn($response);
     }
 
     private function expectDispatchWithResponse(SignInCommandResponse $response): void
     {
         $this->commandBus->expects($this->once())->method('dispatch')
             ->with($this->callback(
-                static function (SignInCommand $cmd) use ($response): bool {
-                    $cmd->setResponse($response);
-                    return true;
+                static function (SignInCommand $cmd): bool {
+                    return $cmd->email !== '';
                 }
-            ));
+            ))
+            ->willReturn($response);
     }
 
     private function expectDispatchWithRememberMe(SignInCommandResponse $response): void
     {
         $this->commandBus->expects($this->once())->method('dispatch')
             ->with($this->callback(
-                function (SignInCommand $cmd) use ($response): bool {
+                function (SignInCommand $cmd): bool {
                     $this->assertTrue($cmd->rememberMe);
-                    $cmd->setResponse($response);
                     return true;
                 }
-            ));
+            ))
+            ->willReturn($response);
     }
 
     private function expectDispatchValidatingRequestMetadata(
@@ -292,13 +291,13 @@ final class SignInProcessorTest extends UnitTestCase
     ): void {
         $this->commandBus->expects($this->once())->method('dispatch')
             ->with($this->callback(
-                function (SignInCommand $cmd) use ($expectedIp, $expectedAgent, $response): bool {
+                function (SignInCommand $cmd) use ($expectedIp, $expectedAgent): bool {
                     $this->assertSame($expectedIp, $cmd->ipAddress);
                     $this->assertSame($expectedAgent, $cmd->userAgent);
-                    $cmd->setResponse($response);
                     return true;
                 }
-            ));
+            ))
+            ->willReturn($response);
     }
 
     private function assertTokenResponseBody(

--- a/tests/Unit/User/Application/Processor/SignInProcessorTest.php
+++ b/tests/Unit/User/Application/Processor/SignInProcessorTest.php
@@ -44,7 +44,7 @@ final class SignInProcessorTest extends AuthProcessorTestCase
         $access = $this->faker->sha256();
         $refresh = $this->faker->sha256();
         $request = $this->createMock(Request::class);
-        $this->stubResolver($request, $ip, $ua);
+        $this->stubRequestContextResolver($this->requestContextResolver, $request, $ip, $ua);
         $cmdResponse = new SignInCommandResponse(false, $access, $refresh);
         $this->expectDispatchValidatingCommand($email, $password, $ip, $ua, $cmdResponse);
         $this->cookieFactory->expects($this->once())->method('create')
@@ -58,7 +58,12 @@ final class SignInProcessorTest extends AuthProcessorTestCase
     public function testProcessAttachesCookieWithRememberMe(): void
     {
         $request = $this->createMock(Request::class);
-        $this->stubResolver($request, $this->faker->ipv4(), $this->faker->userAgent());
+        $this->stubRequestContextResolver(
+            $this->requestContextResolver,
+            $request,
+            $this->faker->ipv4(),
+            $this->faker->userAgent()
+        );
         $dto = new SignInDto($this->faker->email(), $this->faker->password());
         $dto->setRememberMe(true);
         $accessToken = $this->faker->sha256();
@@ -74,7 +79,12 @@ final class SignInProcessorTest extends AuthProcessorTestCase
     public function testProcessReturnsTwoFactorBodyWithoutAttachingCookie(): void
     {
         $request = $this->createMock(Request::class);
-        $this->stubResolver($request, $this->faker->ipv4(), $this->faker->userAgent());
+        $this->stubRequestContextResolver(
+            $this->requestContextResolver,
+            $request,
+            $this->faker->ipv4(),
+            $this->faker->userAgent()
+        );
         $dto = new SignInDto($this->faker->email(), $this->faker->password());
         $pendingSessionId = $this->faker->uuid();
         $cmdResponse = new SignInCommandResponse(true, null, null, $pendingSessionId);
@@ -96,7 +106,12 @@ final class SignInProcessorTest extends AuthProcessorTestCase
     public function testProcessDoesNotAttachCookieForTwoFactorEvenWithTokenValue(): void
     {
         $request = $this->createMock(Request::class);
-        $this->stubResolver($request, $this->faker->ipv4(), $this->faker->userAgent());
+        $this->stubRequestContextResolver(
+            $this->requestContextResolver,
+            $request,
+            $this->faker->ipv4(),
+            $this->faker->userAgent()
+        );
         $dto = new SignInDto($this->faker->email(), $this->faker->password());
         $cmdResponse = new SignInCommandResponse(
             true,
@@ -117,7 +132,12 @@ final class SignInProcessorTest extends AuthProcessorTestCase
     public function testProcessDoesNotAttachCookieWhenAccessTokenIsMissing(): void
     {
         $request = $this->createMock(Request::class);
-        $this->stubResolver($request, $this->faker->ipv4(), $this->faker->userAgent());
+        $this->stubRequestContextResolver(
+            $this->requestContextResolver,
+            $request,
+            $this->faker->ipv4(),
+            $this->faker->userAgent()
+        );
         $dto = new SignInDto($this->faker->email(), $this->faker->password());
         $refreshToken = $this->faker->sha256();
         $this->expectDispatchWithResponse(new SignInCommandResponse(false, null, $refreshToken));
@@ -140,7 +160,12 @@ final class SignInProcessorTest extends AuthProcessorTestCase
     public function testProcessCastsMissingRefreshTokenToEmptyStringInResponseBody(): void
     {
         $request = $this->createMock(Request::class);
-        $this->stubResolver($request, $this->faker->ipv4(), $this->faker->userAgent());
+        $this->stubRequestContextResolver(
+            $this->requestContextResolver,
+            $request,
+            $this->faker->ipv4(),
+            $this->faker->userAgent()
+        );
         $dto = new SignInDto($this->faker->email(), $this->faker->password());
         $accessToken = $this->faker->sha256();
         $this->expectDispatchWithResponse(new SignInCommandResponse(false, $accessToken, null));
@@ -159,7 +184,12 @@ final class SignInProcessorTest extends AuthProcessorTestCase
     public function testProcessPropagatesUnauthorizedExceptionWithBearerHeader(): void
     {
         $request = $this->createMock(Request::class);
-        $this->stubResolver($request, $this->faker->ipv4(), $this->faker->userAgent());
+        $this->stubRequestContextResolver(
+            $this->requestContextResolver,
+            $request,
+            $this->faker->ipv4(),
+            $this->faker->userAgent()
+        );
         $dto = new SignInDto($this->faker->email(), $this->faker->password());
         $this->commandBus->expects($this->once())
             ->method('dispatch')
@@ -176,9 +206,15 @@ final class SignInProcessorTest extends AuthProcessorTestCase
         $request = $this->createMock(Request::class);
         $this->requestContextResolver->expects($this->once())
             ->method('resolveRequest')->with($request)->willReturn($request);
-        $this->stubResolverMetadata($request, $ipAddress, $userAgent);
+        $this->stubRequestContextMetadata($this->requestContextResolver, $request, $ipAddress, $userAgent);
         $cmdResponse = $this->createCommandResponse();
-        $this->expectDispatchValidatingRequestMetadata($ipAddress, $userAgent, $cmdResponse);
+        $this->expectDispatchWithRequestMetadata(
+            $this->commandBus,
+            SignInCommand::class,
+            $cmdResponse,
+            $ipAddress,
+            $userAgent
+        );
         $response = $this->createProcessor()->process(
             new SignInDto($this->faker->email(), $this->faker->password()),
             $this->operation,
@@ -195,34 +231,25 @@ final class SignInProcessorTest extends AuthProcessorTestCase
         $resolvedRequest = $this->createMock(Request::class);
         $this->requestContextResolver->expects($this->once())
             ->method('resolveRequest')->with(null)->willReturn($resolvedRequest);
-        $this->stubResolverMetadata($resolvedRequest, $ipAddress, $userAgent);
+        $this->stubRequestContextMetadata(
+            $this->requestContextResolver,
+            $resolvedRequest,
+            $ipAddress,
+            $userAgent
+        );
         $cmdResponse = $this->createCommandResponse();
-        $this->expectDispatchValidatingRequestMetadata($ipAddress, $userAgent, $cmdResponse);
+        $this->expectDispatchWithRequestMetadata(
+            $this->commandBus,
+            SignInCommand::class,
+            $cmdResponse,
+            $ipAddress,
+            $userAgent
+        );
         $response = $this->createProcessor()->process(
             new SignInDto($this->faker->email(), $this->faker->password()),
             $this->operation
         );
         $this->assertSame(200, $response->getStatusCode());
-    }
-
-    private function stubResolver(
-        ?Request $request,
-        string $ipAddress,
-        string $userAgent
-    ): void {
-        $this->requestContextResolver->method('resolveRequest')->willReturn($request);
-        $this->stubResolverMetadata($request, $ipAddress, $userAgent);
-    }
-
-    private function stubResolverMetadata(
-        ?Request $request,
-        string $ipAddress,
-        string $userAgent
-    ): void {
-        $this->requestContextResolver->method('resolveIpAddress')
-            ->with($request)->willReturn($ipAddress);
-        $this->requestContextResolver->method('resolveUserAgent')
-            ->with($request)->willReturn($userAgent);
     }
 
     private function createCommandResponse(): SignInCommandResponse
@@ -281,22 +308,6 @@ final class SignInProcessorTest extends AuthProcessorTestCase
                 }
             ))
             ->willReturn($response);
-    }
-
-    private function expectDispatchValidatingRequestMetadata(
-        string $expectedIp,
-        string $expectedAgent,
-        SignInCommandResponse $response
-    ): void {
-        $this->expectDispatchMatchingCommand(
-            $this->commandBus,
-            SignInCommand::class,
-            $response,
-            function (SignInCommand $cmd) use ($expectedIp, $expectedAgent): void {
-                $this->assertSame($expectedIp, $cmd->ipAddress);
-                $this->assertSame($expectedAgent, $cmd->userAgent);
-            }
-        );
     }
 
     private function assertTokenResponseBody(

--- a/tests/Unit/User/Application/Resolver/AuthMutationResolverConstructionTest.php
+++ b/tests/Unit/User/Application/Resolver/AuthMutationResolverConstructionTest.php
@@ -29,6 +29,8 @@ use App\User\Application\Resolver\SetupTwoFactorAuthMutationResolver;
 use App\User\Application\Resolver\SignInAuthMutationResolver;
 use App\User\Application\Resolver\SignOutAllAuthMutationResolver;
 use App\User\Application\Resolver\SignOutAuthMutationResolver;
+use App\User\Application\Service\CompleteTwoFactorCommandDispatcher;
+use App\User\Application\Service\ConfirmTwoFactorCommandDispatcher;
 use App\User\Application\Service\SignInCommandDispatcher;
 use App\User\Application\Validator\MutationInputValidator;
 use Symfony\Bundle\SecurityBundle\Security;
@@ -80,11 +82,8 @@ final class AuthMutationResolverConstructionTest extends UnitTestCase
     {
         return new CompleteTwoFactorAuthMutationResolver(
             $this->createValidator(),
-            $this->createCommandBus(),
-            $this->createCommandResponseTypeGuard(),
             $this->createAuthPayloadFactory(),
-            $this->createMock(CompleteTwoFactorCommandFactoryInterface::class),
-            $this->createMock(HttpRequestContextResolverInterface::class)
+            $this->createCompleteTwoFactorCommandDispatcher()
         );
     }
 
@@ -92,11 +91,8 @@ final class AuthMutationResolverConstructionTest extends UnitTestCase
     {
         return new ConfirmTwoFactorAuthMutationResolver(
             $this->createValidator(),
-            $this->createCommandBus(),
-            $this->createCommandResponseTypeGuard(),
             $this->createAuthPayloadFactory(),
-            $this->createCurrentUserIdentityResolver(),
-            $this->createMock(ConfirmTwoFactorCommandFactoryInterface::class)
+            $this->createConfirmTwoFactorCommandDispatcher()
         );
     }
 
@@ -181,6 +177,26 @@ final class AuthMutationResolverConstructionTest extends UnitTestCase
             $this->createCommandResponseTypeGuard(),
             $this->createMock(SignInCommandFactoryInterface::class),
             $this->createMock(HttpRequestContextResolverInterface::class)
+        );
+    }
+
+    private function createCompleteTwoFactorCommandDispatcher(): CompleteTwoFactorCommandDispatcher
+    {
+        return new CompleteTwoFactorCommandDispatcher(
+            $this->createCommandBus(),
+            $this->createCommandResponseTypeGuard(),
+            $this->createMock(CompleteTwoFactorCommandFactoryInterface::class),
+            $this->createMock(HttpRequestContextResolverInterface::class)
+        );
+    }
+
+    private function createConfirmTwoFactorCommandDispatcher(): ConfirmTwoFactorCommandDispatcher
+    {
+        return new ConfirmTwoFactorCommandDispatcher(
+            $this->createCommandBus(),
+            $this->createCommandResponseTypeGuard(),
+            $this->createCurrentUserIdentityResolver(),
+            $this->createMock(ConfirmTwoFactorCommandFactoryInterface::class)
         );
     }
 

--- a/tests/Unit/User/Application/Resolver/AuthMutationResolverConstructionTest.php
+++ b/tests/Unit/User/Application/Resolver/AuthMutationResolverConstructionTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Unit\User\Application\Resolver;
 
 use ApiPlatform\GraphQl\Resolver\MutationResolverInterface;
+use App\Shared\Application\Bus\Guard\CommandResponseTypeGuard;
 use App\Shared\Domain\Bus\Command\CommandBusInterface;
 use App\Tests\Unit\UnitTestCase;
 use App\User\Application\Factory\AuthPayloadFactory;
@@ -28,6 +29,7 @@ use App\User\Application\Resolver\SetupTwoFactorAuthMutationResolver;
 use App\User\Application\Resolver\SignInAuthMutationResolver;
 use App\User\Application\Resolver\SignOutAllAuthMutationResolver;
 use App\User\Application\Resolver\SignOutAuthMutationResolver;
+use App\User\Application\Service\SignInCommandDispatcher;
 use App\User\Application\Validator\MutationInputValidator;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
@@ -69,10 +71,8 @@ final class AuthMutationResolverConstructionTest extends UnitTestCase
     {
         return new SignInAuthMutationResolver(
             $this->createValidator(),
-            $this->createCommandBus(),
             $this->createAuthPayloadFactory(),
-            $this->createMock(SignInCommandFactoryInterface::class),
-            $this->createMock(HttpRequestContextResolverInterface::class)
+            $this->createSignInCommandDispatcher()
         );
     }
 
@@ -81,6 +81,7 @@ final class AuthMutationResolverConstructionTest extends UnitTestCase
         return new CompleteTwoFactorAuthMutationResolver(
             $this->createValidator(),
             $this->createCommandBus(),
+            $this->createCommandResponseTypeGuard(),
             $this->createAuthPayloadFactory(),
             $this->createMock(CompleteTwoFactorCommandFactoryInterface::class),
             $this->createMock(HttpRequestContextResolverInterface::class)
@@ -92,6 +93,7 @@ final class AuthMutationResolverConstructionTest extends UnitTestCase
         return new ConfirmTwoFactorAuthMutationResolver(
             $this->createValidator(),
             $this->createCommandBus(),
+            $this->createCommandResponseTypeGuard(),
             $this->createAuthPayloadFactory(),
             $this->createCurrentUserIdentityResolver(),
             $this->createMock(ConfirmTwoFactorCommandFactoryInterface::class)
@@ -114,6 +116,7 @@ final class AuthMutationResolverConstructionTest extends UnitTestCase
         return new RefreshTokenAuthMutationResolver(
             $this->createValidator(),
             $this->createCommandBus(),
+            $this->createCommandResponseTypeGuard(),
             $this->createAuthPayloadFactory(),
             $this->createMock(RefreshTokenCommandFactoryInterface::class)
         );
@@ -123,6 +126,7 @@ final class AuthMutationResolverConstructionTest extends UnitTestCase
     {
         return new RegenerateRecoveryCodesAuthMutationResolver(
             $this->createCommandBus(),
+            $this->createCommandResponseTypeGuard(),
             $this->createAuthPayloadFactory(),
             $this->createCurrentUserIdentityResolver(),
             $this->createMock(RegenerateRecoveryCodesCommandFactoryInterface::class)
@@ -133,6 +137,7 @@ final class AuthMutationResolverConstructionTest extends UnitTestCase
     {
         return new SetupTwoFactorAuthMutationResolver(
             $this->createCommandBus(),
+            $this->createCommandResponseTypeGuard(),
             $this->createAuthPayloadFactory(),
             $this->createCurrentUserIdentityResolver(),
             $this->createMock(SetupTwoFactorCommandFactoryInterface::class)
@@ -162,6 +167,21 @@ final class AuthMutationResolverConstructionTest extends UnitTestCase
     private function createCommandBus(): CommandBusInterface
     {
         return $this->createMock(CommandBusInterface::class);
+    }
+
+    private function createCommandResponseTypeGuard(): CommandResponseTypeGuard
+    {
+        return new CommandResponseTypeGuard();
+    }
+
+    private function createSignInCommandDispatcher(): SignInCommandDispatcher
+    {
+        return new SignInCommandDispatcher(
+            $this->createCommandBus(),
+            $this->createCommandResponseTypeGuard(),
+            $this->createMock(SignInCommandFactoryInterface::class),
+            $this->createMock(HttpRequestContextResolverInterface::class)
+        );
     }
 
     private function createAuthPayloadFactory(): AuthPayloadFactory

--- a/tests/Unit/User/Application/Resolver/CompleteTwoFactorAuthMutationResolverTest.php
+++ b/tests/Unit/User/Application/Resolver/CompleteTwoFactorAuthMutationResolverTest.php
@@ -13,6 +13,7 @@ use App\User\Application\DTO\CompleteTwoFactorDto;
 use App\User\Application\Factory\CompleteTwoFactorCommandFactoryInterface;
 use App\User\Application\Resolver\CompleteTwoFactorAuthMutationResolver;
 use App\User\Application\Resolver\HttpRequestContextResolverInterface;
+use App\User\Application\Service\CompleteTwoFactorCommandDispatcher;
 use App\User\Application\Validator\MutationInputValidator;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -39,11 +40,13 @@ final class CompleteTwoFactorAuthMutationResolverTest extends AuthMutationResolv
         $this->setUpScenario();
         $this->resolver = new CompleteTwoFactorAuthMutationResolver(
             $this->validator,
-            $this->commandBus,
-            new CommandResponseTypeGuard(),
             $this->authPayloadFactory(),
-            $this->commandFactory,
-            $this->requestContextResolver
+            new CompleteTwoFactorCommandDispatcher(
+                $this->commandBus,
+                new CommandResponseTypeGuard(),
+                $this->commandFactory,
+                $this->requestContextResolver
+            )
         );
     }
 

--- a/tests/Unit/User/Application/Resolver/CompleteTwoFactorAuthMutationResolverTest.php
+++ b/tests/Unit/User/Application/Resolver/CompleteTwoFactorAuthMutationResolverTest.php
@@ -23,6 +23,7 @@ final class CompleteTwoFactorAuthMutationResolverTest extends AuthMutationResolv
     private HttpRequestContextResolverInterface $requestContextResolver;
     private CompleteTwoFactorAuthMutationResolver $resolver;
     private CompleteTwoFactorCommand $command;
+    private CompleteTwoFactorCommandResponse $commandResponse;
     private Request $request;
     private string $pendingSessionId;
     private string $twoFactorCode;
@@ -80,7 +81,7 @@ final class CompleteTwoFactorAuthMutationResolverTest extends AuthMutationResolv
             $this->ipAddress,
             $this->userAgent
         );
-        $this->command->setResponse($this->response());
+        $this->commandResponse = $this->response();
     }
 
     private function expectValidation(): void
@@ -121,7 +122,8 @@ final class CompleteTwoFactorAuthMutationResolverTest extends AuthMutationResolv
             ->willReturn($this->command);
         $this->commandBus->expects($this->once())
             ->method('dispatch')
-            ->with($this->command);
+            ->with($this->command)
+            ->willReturn($this->commandResponse);
     }
 
     /**
@@ -152,11 +154,10 @@ final class CompleteTwoFactorAuthMutationResolverTest extends AuthMutationResolv
 
     private function assertPayload(AuthPayload $payload): void
     {
-        $response = $this->command->getResponse();
         $this->assertSame('auth-complete-two-factor', $payload->getId());
         $this->assertTrue($payload->isTwoFactorEnabled());
-        $this->assertSame($response->getAccessToken(), $payload->getAccessToken());
-        $this->assertSame($response->getRefreshToken(), $payload->getRefreshToken());
+        $this->assertSame($this->commandResponse->getAccessToken(), $payload->getAccessToken());
+        $this->assertSame($this->commandResponse->getRefreshToken(), $payload->getRefreshToken());
         $this->assertSame(2, $payload->getRecoveryCodesRemaining());
         $this->assertSame('Use recovery codes soon.', $payload->getWarning());
     }

--- a/tests/Unit/User/Application/Resolver/CompleteTwoFactorAuthMutationResolverTest.php
+++ b/tests/Unit/User/Application/Resolver/CompleteTwoFactorAuthMutationResolverTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Unit\User\Application\Resolver;
 
+use App\Shared\Application\Bus\Guard\CommandResponseTypeGuard;
 use App\Shared\Domain\Bus\Command\CommandBusInterface;
 use App\User\Application\Command\CompleteTwoFactorCommand;
 use App\User\Application\DTO\AuthPayload;
@@ -39,6 +40,7 @@ final class CompleteTwoFactorAuthMutationResolverTest extends AuthMutationResolv
         $this->resolver = new CompleteTwoFactorAuthMutationResolver(
             $this->validator,
             $this->commandBus,
+            new CommandResponseTypeGuard(),
             $this->authPayloadFactory(),
             $this->commandFactory,
             $this->requestContextResolver

--- a/tests/Unit/User/Application/Resolver/ConfirmPasswordResetMutationResolverTest.php
+++ b/tests/Unit/User/Application/Resolver/ConfirmPasswordResetMutationResolverTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Unit\User\Application\Resolver;
 
+use App\Shared\Application\Bus\Guard\CommandResponseTypeGuard;
 use App\Shared\Domain\Bus\Command\CommandBusInterface;
 use App\Tests\Unit\UnitTestCase;
 use App\User\Application\Command\ConfirmPasswordResetCommand;
@@ -27,6 +28,7 @@ final class ConfirmPasswordResetMutationResolverTest extends UnitTestCase
 
         $this->resolver = new ConfirmPasswordResetMutationResolver(
             $this->commandBus,
+            new CommandResponseTypeGuard(),
             $this->validator
         );
     }

--- a/tests/Unit/User/Application/Resolver/ConfirmPasswordResetMutationResolverTest.php
+++ b/tests/Unit/User/Application/Resolver/ConfirmPasswordResetMutationResolverTest.php
@@ -63,11 +63,10 @@ final class ConfirmPasswordResetMutationResolverTest extends UnitTestCase
         $this->commandBus->expects($this->once())
             ->method('dispatch')
             ->with($this->callback(static function (ConfirmPasswordResetCommand $command) {
-                $response = new ConfirmPasswordResetCommandResponse();
-                $command->setResponse($response);
-
-                return true;
-            }));
+                return $command->token === ''
+                    && $command->newPassword === '';
+            }))
+            ->willReturn(new ConfirmPasswordResetCommandResponse());
 
         $result = $this->resolver->__invoke(null, $context);
 
@@ -106,11 +105,9 @@ final class ConfirmPasswordResetMutationResolverTest extends UnitTestCase
                     $this->assertSame($token, $command->token);
                     $this->assertSame($newPassword, $command->newPassword);
 
-                    $response = new ConfirmPasswordResetCommandResponse();
-                    $command->setResponse($response);
-
                     return true;
                 }
-            ));
+            ))
+            ->willReturn(new ConfirmPasswordResetCommandResponse());
     }
 }

--- a/tests/Unit/User/Application/Resolver/ConfirmTwoFactorAuthMutationResolverTest.php
+++ b/tests/Unit/User/Application/Resolver/ConfirmTwoFactorAuthMutationResolverTest.php
@@ -19,6 +19,7 @@ final class ConfirmTwoFactorAuthMutationResolverTest extends AuthMutationResolve
     private ConfirmTwoFactorCommandFactoryInterface $commandFactory;
     private ConfirmTwoFactorAuthMutationResolver $resolver;
     private ConfirmTwoFactorCommand $command;
+    private ConfirmTwoFactorCommandResponse $commandResponse;
     private string $email;
     private string $sessionId;
     private string $twoFactorCode;
@@ -50,7 +51,7 @@ final class ConfirmTwoFactorAuthMutationResolverTest extends AuthMutationResolve
 
         $this->assertSame('auth-confirm-two-factor', $result->getId());
         $this->assertSame(
-            $this->command->getResponse()->getRecoveryCodes(),
+            $this->commandResponse->getRecoveryCodes(),
             $result->getRecoveryCodes()
         );
     }
@@ -74,10 +75,8 @@ final class ConfirmTwoFactorAuthMutationResolverTest extends AuthMutationResolve
             $this->twoFactorCode,
             $this->sessionId
         );
-        $this->command->setResponse(
-            new ConfirmTwoFactorCommandResponse(
-                [$this->faker->sha1(), $this->faker->sha1()]
-            )
+        $this->commandResponse = new ConfirmTwoFactorCommandResponse(
+            [$this->faker->sha1(), $this->faker->sha1()]
         );
     }
 
@@ -98,7 +97,8 @@ final class ConfirmTwoFactorAuthMutationResolverTest extends AuthMutationResolve
             ->willReturn($this->command);
         $this->commandBus->expects($this->once())
             ->method('dispatch')
-            ->with($this->command);
+            ->with($this->command)
+            ->willReturn($this->commandResponse);
     }
 
     /**

--- a/tests/Unit/User/Application/Resolver/ConfirmTwoFactorAuthMutationResolverTest.php
+++ b/tests/Unit/User/Application/Resolver/ConfirmTwoFactorAuthMutationResolverTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Unit\User\Application\Resolver;
 
+use App\Shared\Application\Bus\Guard\CommandResponseTypeGuard;
 use App\Shared\Domain\Bus\Command\CommandBusInterface;
 use App\User\Application\Command\ConfirmTwoFactorCommand;
 use App\User\Application\DTO\ConfirmTwoFactorCommandResponse;
@@ -33,6 +34,7 @@ final class ConfirmTwoFactorAuthMutationResolverTest extends AuthMutationResolve
         $this->resolver = new ConfirmTwoFactorAuthMutationResolver(
             $this->validator,
             $this->commandBus,
+            new CommandResponseTypeGuard(),
             $this->authPayloadFactory(),
             $this->currentUserIdentityResolver(
                 $this->email,

--- a/tests/Unit/User/Application/Resolver/ConfirmTwoFactorAuthMutationResolverTest.php
+++ b/tests/Unit/User/Application/Resolver/ConfirmTwoFactorAuthMutationResolverTest.php
@@ -11,6 +11,7 @@ use App\User\Application\DTO\ConfirmTwoFactorCommandResponse;
 use App\User\Application\DTO\ConfirmTwoFactorDto;
 use App\User\Application\Factory\ConfirmTwoFactorCommandFactoryInterface;
 use App\User\Application\Resolver\ConfirmTwoFactorAuthMutationResolver;
+use App\User\Application\Service\ConfirmTwoFactorCommandDispatcher;
 use App\User\Application\Validator\MutationInputValidator;
 
 final class ConfirmTwoFactorAuthMutationResolverTest extends AuthMutationResolverTestCase
@@ -33,15 +34,17 @@ final class ConfirmTwoFactorAuthMutationResolverTest extends AuthMutationResolve
         $this->setUpScenario();
         $this->resolver = new ConfirmTwoFactorAuthMutationResolver(
             $this->validator,
-            $this->commandBus,
-            new CommandResponseTypeGuard(),
             $this->authPayloadFactory(),
-            $this->currentUserIdentityResolver(
-                $this->email,
-                $this->sessionId,
-                $this->faker->uuid()
+            new ConfirmTwoFactorCommandDispatcher(
+                $this->commandBus,
+                new CommandResponseTypeGuard(),
+                $this->currentUserIdentityResolver(
+                    $this->email,
+                    $this->sessionId,
+                    $this->faker->uuid()
+                ),
+                $this->commandFactory
             ),
-            $this->commandFactory
         );
     }
 

--- a/tests/Unit/User/Application/Resolver/RefreshTokenAuthMutationResolverTest.php
+++ b/tests/Unit/User/Application/Resolver/RefreshTokenAuthMutationResolverTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Unit\User\Application\Resolver;
 
+use App\Shared\Application\Bus\Guard\CommandResponseTypeGuard;
 use App\Shared\Domain\Bus\Command\CommandBusInterface;
 use App\User\Application\Command\RefreshTokenCommand;
 use App\User\Application\DTO\AuthPayload;
@@ -28,6 +29,7 @@ final class RefreshTokenAuthMutationResolverTest extends AuthMutationResolverTes
         $resolver = new RefreshTokenAuthMutationResolver(
             $validator,
             $commandBus,
+            new CommandResponseTypeGuard(),
             $this->authPayloadFactory(),
             $commandFactory
         );

--- a/tests/Unit/User/Application/Resolver/RefreshTokenAuthMutationResolverTest.php
+++ b/tests/Unit/User/Application/Resolver/RefreshTokenAuthMutationResolverTest.php
@@ -32,7 +32,7 @@ final class RefreshTokenAuthMutationResolverTest extends AuthMutationResolverTes
             $commandFactory
         );
 
-        $this->expectResolver($validator, $commandBus, $commandFactory, $command, $refreshToken, $commandResponse);
+        $this->expectResolver($validator, $commandBus, $commandFactory, $command, $commandResponse);
         $result = $resolver->__invoke(null, $this->context($refreshToken));
 
         $this->assertPayload($result, $commandResponse);
@@ -43,16 +43,15 @@ final class RefreshTokenAuthMutationResolverTest extends AuthMutationResolverTes
         CommandBusInterface $commandBus,
         RefreshTokenCommandFactoryInterface $commandFactory,
         RefreshTokenCommand $command,
-        string $refreshToken,
         RefreshTokenCommandResponse $response,
     ): void {
         $validator->expects($this->once())
             ->method('validate')
             ->with($this->callback(static fn (object $dto): bool => $dto instanceof RefreshTokenDto
-                && $dto->refreshTokenValue() === $refreshToken));
+                && $dto->refreshTokenValue() === $command->refreshToken));
         $commandFactory->expects($this->once())
             ->method('create')
-            ->with($refreshToken)
+            ->with($command->refreshToken)
             ->willReturn($command);
         $commandBus->expects($this->once())
             ->method('dispatch')

--- a/tests/Unit/User/Application/Resolver/RefreshTokenAuthMutationResolverTest.php
+++ b/tests/Unit/User/Application/Resolver/RefreshTokenAuthMutationResolverTest.php
@@ -19,7 +19,7 @@ final class RefreshTokenAuthMutationResolverTest extends AuthMutationResolverTes
     {
         $refreshToken = $this->faker->sha256();
         $command = new RefreshTokenCommand($refreshToken);
-        $command->setResponse($this->response());
+        $commandResponse = $this->response();
         $validator = $this->createMock(MutationInputValidator::class);
         $commandBus = $this->createMock(CommandBusInterface::class);
         $commandFactory = $this->createMock(
@@ -32,10 +32,10 @@ final class RefreshTokenAuthMutationResolverTest extends AuthMutationResolverTes
             $commandFactory
         );
 
-        $this->expectResolver($validator, $commandBus, $commandFactory, $command, $refreshToken);
+        $this->expectResolver($validator, $commandBus, $commandFactory, $command, $refreshToken, $commandResponse);
         $result = $resolver->__invoke(null, $this->context($refreshToken));
 
-        $this->assertPayload($result, $command->getResponse());
+        $this->assertPayload($result, $commandResponse);
     }
 
     private function expectResolver(
@@ -44,6 +44,7 @@ final class RefreshTokenAuthMutationResolverTest extends AuthMutationResolverTes
         RefreshTokenCommandFactoryInterface $commandFactory,
         RefreshTokenCommand $command,
         string $refreshToken,
+        RefreshTokenCommandResponse $response,
     ): void {
         $validator->expects($this->once())
             ->method('validate')
@@ -55,7 +56,8 @@ final class RefreshTokenAuthMutationResolverTest extends AuthMutationResolverTes
             ->willReturn($command);
         $commandBus->expects($this->once())
             ->method('dispatch')
-            ->with($command);
+            ->with($command)
+            ->willReturn($response);
     }
 
     /**

--- a/tests/Unit/User/Application/Resolver/RegisterUserMutationResolverTest.php
+++ b/tests/Unit/User/Application/Resolver/RegisterUserMutationResolverTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Unit\User\Application\Resolver;
 
+use App\Shared\Application\Bus\Guard\CommandResponseTypeGuard;
 use App\Shared\Domain\Bus\Command\CommandBusInterface;
 use App\Shared\Infrastructure\Factory\UuidFactory;
 use App\Shared\Infrastructure\Transformer\UuidTransformer;
@@ -45,6 +46,7 @@ final class RegisterUserMutationResolverTest extends UnitTestCase
             $this->createMock(CreateUserMutationInputTransformer::class);
         $this->resolver = new RegisterUserMutationResolver(
             $this->commandBus,
+            new CommandResponseTypeGuard(),
             $this->validator,
             $this->transformer,
             $this->mockSignUpCommandFactory

--- a/tests/Unit/User/Application/Resolver/RegisterUserMutationResolverTest.php
+++ b/tests/Unit/User/Application/Resolver/RegisterUserMutationResolverTest.php
@@ -85,7 +85,6 @@ final class RegisterUserMutationResolverTest extends UnitTestCase
         );
         $command =
             $this->signUpCommandFactory->create($email, $initials, $password);
-        $command->setResponse(new RegisterUserCommandResponse($user));
 
         $this->transformer->expects($this->once())
             ->method('transform');
@@ -100,6 +99,7 @@ final class RegisterUserMutationResolverTest extends UnitTestCase
 
         $this->commandBus->expects($this->once())
             ->method('dispatch')
-            ->with($command);
+            ->with($command)
+            ->willReturn(new RegisterUserCommandResponse($user));
     }
 }

--- a/tests/Unit/User/Application/Resolver/RequestPasswordResetMutationResolverTest.php
+++ b/tests/Unit/User/Application/Resolver/RequestPasswordResetMutationResolverTest.php
@@ -62,11 +62,9 @@ final class RequestPasswordResetMutationResolverTest extends UnitTestCase
         $this->commandBus->expects($this->once())
             ->method('dispatch')
             ->with($this->callback(static function (RequestPasswordResetCommand $command) {
-                $response = new RequestPasswordResetCommandResponse();
-                $command->setResponse($response);
-
-                return true;
-            }));
+                return $command->email === '';
+            }))
+            ->willReturn(new RequestPasswordResetCommandResponse());
 
         $result = $this->resolver->__invoke(null, $context);
 
@@ -96,10 +94,8 @@ final class RequestPasswordResetMutationResolverTest extends UnitTestCase
             ->with($this->callback(function (RequestPasswordResetCommand $command) use ($email) {
                 $this->assertSame($email, $command->email);
 
-                $response = new RequestPasswordResetCommandResponse();
-                $command->setResponse($response);
-
                 return true;
-            }));
+            }))
+            ->willReturn(new RequestPasswordResetCommandResponse());
     }
 }

--- a/tests/Unit/User/Application/Resolver/SetupAndRecoveryCodesAuthMutationResolverTest.php
+++ b/tests/Unit/User/Application/Resolver/SetupAndRecoveryCodesAuthMutationResolverTest.php
@@ -21,7 +21,7 @@ final class SetupAndRecoveryCodesAuthMutationResolverTest extends AuthMutationRe
     {
         $email = $this->faker->email();
         $command = new SetupTwoFactorCommand($email);
-        $command->setResponse($this->setupResponse());
+        $commandResponse = $this->setupResponse();
         $commandBus = $this->createMock(CommandBusInterface::class);
         $commandFactory = $this->createMock(
             SetupTwoFactorCommandFactoryInterface::class
@@ -33,10 +33,10 @@ final class SetupAndRecoveryCodesAuthMutationResolverTest extends AuthMutationRe
             $commandFactory
         );
 
-        $this->expectSetupResolver($commandBus, $commandFactory, $command, $email);
+        $this->expectSetupResolver($commandBus, $commandFactory, $command, $email, $commandResponse);
         $result = $resolver->__invoke(null, []);
 
-        $this->assertSetupPayload($result, $command->getResponse());
+        $this->assertSetupPayload($result, $commandResponse);
     }
 
     public function testRecoveryCodesResolverDispatchesCommandAndBuildsPayload(): void
@@ -44,7 +44,7 @@ final class SetupAndRecoveryCodesAuthMutationResolverTest extends AuthMutationRe
         $email = $this->faker->email();
         $sessionId = $this->faker->uuid();
         $command = new RegenerateRecoveryCodesCommand($email, $sessionId);
-        $command->setResponse($this->recoveryCodesResponse());
+        $commandResponse = $this->recoveryCodesResponse();
         $commandBus = $this->createMock(CommandBusInterface::class);
         $commandFactory = $this->createMock(
             RegenerateRecoveryCodesCommandFactoryInterface::class
@@ -56,10 +56,10 @@ final class SetupAndRecoveryCodesAuthMutationResolverTest extends AuthMutationRe
             $commandFactory
         );
 
-        $this->expectRecoveryResolver($commandBus, $commandFactory, $command, $email, $sessionId);
+        $this->expectRecoveryResolver($commandBus, $commandFactory, $command, $email, $sessionId, $commandResponse);
         $result = $resolver->__invoke(null, []);
 
-        $this->assertRecoveryCodesPayload($result, $command->getResponse());
+        $this->assertRecoveryCodesPayload($result, $commandResponse);
     }
 
     private function expectSetupResolver(
@@ -67,6 +67,7 @@ final class SetupAndRecoveryCodesAuthMutationResolverTest extends AuthMutationRe
         SetupTwoFactorCommandFactoryInterface $commandFactory,
         SetupTwoFactorCommand $command,
         string $email,
+        SetupTwoFactorCommandResponse $response,
     ): void {
         $commandFactory->expects($this->once())
             ->method('create')
@@ -74,7 +75,8 @@ final class SetupAndRecoveryCodesAuthMutationResolverTest extends AuthMutationRe
             ->willReturn($command);
         $commandBus->expects($this->once())
             ->method('dispatch')
-            ->with($command);
+            ->with($command)
+            ->willReturn($response);
     }
 
     private function expectRecoveryResolver(
@@ -83,6 +85,7 @@ final class SetupAndRecoveryCodesAuthMutationResolverTest extends AuthMutationRe
         RegenerateRecoveryCodesCommand $command,
         string $email,
         string $sessionId,
+        RegenerateRecoveryCodesCommandResponse $response,
     ): void {
         $commandFactory->expects($this->once())
             ->method('create')
@@ -90,7 +93,8 @@ final class SetupAndRecoveryCodesAuthMutationResolverTest extends AuthMutationRe
             ->willReturn($command);
         $commandBus->expects($this->once())
             ->method('dispatch')
-            ->with($command);
+            ->with($command)
+            ->willReturn($response);
     }
 
     private function setupResponse(): SetupTwoFactorCommandResponse

--- a/tests/Unit/User/Application/Resolver/SetupAndRecoveryCodesAuthMutationResolverTest.php
+++ b/tests/Unit/User/Application/Resolver/SetupAndRecoveryCodesAuthMutationResolverTest.php
@@ -56,7 +56,7 @@ final class SetupAndRecoveryCodesAuthMutationResolverTest extends AuthMutationRe
             $commandFactory
         );
 
-        $this->expectRecoveryResolver($commandBus, $commandFactory, $command, $email, $sessionId, $commandResponse);
+        $this->expectRecoveryResolver($commandBus, $commandFactory, $command, $commandResponse);
         $result = $resolver->__invoke(null, []);
 
         $this->assertRecoveryCodesPayload($result, $commandResponse);
@@ -83,13 +83,11 @@ final class SetupAndRecoveryCodesAuthMutationResolverTest extends AuthMutationRe
         CommandBusInterface $commandBus,
         RegenerateRecoveryCodesCommandFactoryInterface $commandFactory,
         RegenerateRecoveryCodesCommand $command,
-        string $email,
-        string $sessionId,
         RegenerateRecoveryCodesCommandResponse $response,
     ): void {
         $commandFactory->expects($this->once())
             ->method('create')
-            ->with($email, $sessionId)
+            ->with($command->userEmail, $command->currentSessionId)
             ->willReturn($command);
         $commandBus->expects($this->once())
             ->method('dispatch')

--- a/tests/Unit/User/Application/Resolver/SetupAndRecoveryCodesAuthMutationResolverTest.php
+++ b/tests/Unit/User/Application/Resolver/SetupAndRecoveryCodesAuthMutationResolverTest.php
@@ -26,14 +26,15 @@ final class SetupAndRecoveryCodesAuthMutationResolverTest extends AuthMutationRe
         $commandFactory = $this->createMock(
             SetupTwoFactorCommandFactoryInterface::class
         );
-        $resolver = new SetupTwoFactorAuthMutationResolver(
-            $commandBus,
-            $this->authPayloadFactory(),
-            $this->currentUserIdentityResolver($email, '', $this->faker->uuid()),
-            $commandFactory
-        );
+        $resolver = $this->setupResolver($commandBus, $commandFactory, $email);
 
-        $this->expectSetupResolver($commandBus, $commandFactory, $command, $email, $commandResponse);
+        $this->expectSetupResolver(
+            $commandBus,
+            $commandFactory,
+            $command,
+            $email,
+            $commandResponse
+        );
         $result = $resolver->__invoke(null, []);
 
         $this->assertSetupPayload($result, $commandResponse);
@@ -77,6 +78,19 @@ final class SetupAndRecoveryCodesAuthMutationResolverTest extends AuthMutationRe
             ->method('dispatch')
             ->with($command)
             ->willReturn($response);
+    }
+
+    private function setupResolver(
+        CommandBusInterface $commandBus,
+        SetupTwoFactorCommandFactoryInterface $commandFactory,
+        string $email,
+    ): SetupTwoFactorAuthMutationResolver {
+        return new SetupTwoFactorAuthMutationResolver(
+            $commandBus,
+            $this->authPayloadFactory(),
+            $this->currentUserIdentityResolver($email, '', $this->faker->uuid()),
+            $commandFactory
+        );
     }
 
     private function expectRecoveryResolver(

--- a/tests/Unit/User/Application/Resolver/SetupAndRecoveryCodesAuthMutationResolverTest.php
+++ b/tests/Unit/User/Application/Resolver/SetupAndRecoveryCodesAuthMutationResolverTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Unit\User\Application\Resolver;
 
+use App\Shared\Application\Bus\Guard\CommandResponseTypeGuard;
 use App\Shared\Domain\Bus\Command\CommandBusInterface;
 use App\User\Application\Command\RegenerateRecoveryCodesCommand;
 use App\User\Application\Command\SetupTwoFactorCommand;
@@ -52,6 +53,7 @@ final class SetupAndRecoveryCodesAuthMutationResolverTest extends AuthMutationRe
         );
         $resolver = new RegenerateRecoveryCodesAuthMutationResolver(
             $commandBus,
+            new CommandResponseTypeGuard(),
             $this->authPayloadFactory(),
             $this->currentUserIdentityResolver($email, $sessionId, $this->faker->uuid()),
             $commandFactory
@@ -87,6 +89,7 @@ final class SetupAndRecoveryCodesAuthMutationResolverTest extends AuthMutationRe
     ): SetupTwoFactorAuthMutationResolver {
         return new SetupTwoFactorAuthMutationResolver(
             $commandBus,
+            new CommandResponseTypeGuard(),
             $this->authPayloadFactory(),
             $this->currentUserIdentityResolver($email, '', $this->faker->uuid()),
             $commandFactory

--- a/tests/Unit/User/Application/Resolver/SignInAuthMutationResolverTest.php
+++ b/tests/Unit/User/Application/Resolver/SignInAuthMutationResolverTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Unit\User\Application\Resolver;
 
+use App\Shared\Application\Bus\Guard\CommandResponseTypeGuard;
 use App\Shared\Domain\Bus\Command\CommandBusInterface;
 use App\User\Application\Command\SignInCommand;
 use App\User\Application\DTO\AuthPayload;
@@ -12,6 +13,7 @@ use App\User\Application\DTO\SignInDto;
 use App\User\Application\Factory\SignInCommandFactoryInterface;
 use App\User\Application\Resolver\HttpRequestContextResolverInterface;
 use App\User\Application\Resolver\SignInAuthMutationResolver;
+use App\User\Application\Service\SignInCommandDispatcher;
 use App\User\Application\Validator\MutationInputValidator;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -38,10 +40,13 @@ final class SignInAuthMutationResolverTest extends AuthMutationResolverTestCase
         $this->setUpScenario();
         $this->resolver = new SignInAuthMutationResolver(
             $this->validator,
-            $this->commandBus,
             $this->authPayloadFactory(),
-            $this->commandFactory,
-            $this->requestContextResolver
+            new SignInCommandDispatcher(
+                $this->commandBus,
+                new CommandResponseTypeGuard(),
+                $this->commandFactory,
+                $this->requestContextResolver
+            )
         );
     }
 

--- a/tests/Unit/User/Application/Resolver/SignInAuthMutationResolverTest.php
+++ b/tests/Unit/User/Application/Resolver/SignInAuthMutationResolverTest.php
@@ -23,6 +23,7 @@ final class SignInAuthMutationResolverTest extends AuthMutationResolverTestCase
     private HttpRequestContextResolverInterface $requestContextResolver;
     private SignInAuthMutationResolver $resolver;
     private SignInCommand $command;
+    private SignInCommandResponse $commandResponse;
     private Request $request;
     private string $email;
     private string $password;
@@ -79,7 +80,7 @@ final class SignInAuthMutationResolverTest extends AuthMutationResolverTestCase
             $this->ipAddress,
             $this->userAgent
         );
-        $this->command->setResponse($this->response());
+        $this->commandResponse = $this->response();
     }
 
     private function expectValidation(): void
@@ -122,7 +123,8 @@ final class SignInAuthMutationResolverTest extends AuthMutationResolverTestCase
             ->willReturn($this->command);
         $this->commandBus->expects($this->once())
             ->method('dispatch')
-            ->with($this->command);
+            ->with($this->command)
+            ->willReturn($this->commandResponse);
     }
 
     /**
@@ -154,13 +156,12 @@ final class SignInAuthMutationResolverTest extends AuthMutationResolverTestCase
 
     private function assertPayload(AuthPayload $payload): void
     {
-        $response = $this->command->getResponse();
         $this->assertSame('auth-sign-in', $payload->getId());
         $this->assertFalse($payload->isTwoFactorEnabled());
-        $this->assertSame($response->getAccessToken(), $payload->getAccessToken());
-        $this->assertSame($response->getRefreshToken(), $payload->getRefreshToken());
+        $this->assertSame($this->commandResponse->getAccessToken(), $payload->getAccessToken());
+        $this->assertSame($this->commandResponse->getRefreshToken(), $payload->getRefreshToken());
         $this->assertSame(
-            $response->getPendingSessionId(),
+            $this->commandResponse->getPendingSessionId(),
             $payload->getPendingSessionId()
         );
     }

--- a/tests/Unit/User/Infrastructure/Decorator/RateLimitedRequestPasswordResetHandlerDecoratorTest.php
+++ b/tests/Unit/User/Infrastructure/Decorator/RateLimitedRequestPasswordResetHandlerDecoratorTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\Unit\User\Infrastructure\Decorator;
 use App\Tests\Unit\UnitTestCase;
 use App\User\Application\Command\RequestPasswordResetCommand;
 use App\User\Application\CommandHandler\RequestPasswordResetHandlerInterface;
+use App\User\Application\DTO\RequestPasswordResetCommandResponse;
 use App\User\Domain\Exception\PasswordResetRateLimitExceededException;
 use App\User\Infrastructure\Decorator\RateLimitedRequestPasswordResetHandlerDecorator;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -43,15 +44,17 @@ final class RateLimitedRequestPasswordResetHandlerDecoratorTest extends UnitTest
     {
         $email = $this->faker->email();
         $command = new RequestPasswordResetCommand($email);
+        $response = new RequestPasswordResetCommandResponse();
 
         $this->expectRateLimitCheck($email, accepted: true);
 
         $this->innerHandler
             ->expects($this->once())
             ->method('__invoke')
-            ->with($command);
+            ->with($command)
+            ->willReturn($response);
 
-        $this->decorator->__invoke($command);
+        $this->assertSame($response, $this->decorator->__invoke($command));
     }
 
     public function testThrowsExceptionWhenRateLimitExceeded(): void

--- a/tests/Unit/User/Infrastructure/Repository/TagAwareCacheSpy.php
+++ b/tests/Unit/User/Infrastructure/Repository/TagAwareCacheSpy.php
@@ -4,11 +4,8 @@ declare(strict_types=1);
 
 namespace App\Tests\Unit\User\Infrastructure\Repository;
 
-use function array_shift;
-use function count;
 use Override;
 use PHPUnit\Framework\Assert;
-use function sprintf;
 use Symfony\Contracts\Cache\TagAwareCacheInterface;
 
 final class TagAwareCacheSpy implements TagAwareCacheInterface
@@ -54,7 +51,7 @@ final class TagAwareCacheSpy implements TagAwareCacheInterface
     ): array|bool|float|int|object|string|null {
         $expectation = $this->takeExpectation(
             $this->getExpectations,
-            sprintf('Unexpected cache get call for key "%s".', $key)
+            \sprintf('Unexpected cache get call for key "%s".', $key)
         );
 
         return $expectation($key, $callback, $beta, $metadata);
@@ -65,7 +62,7 @@ final class TagAwareCacheSpy implements TagAwareCacheInterface
     {
         $expectation = $this->takeExpectation(
             $this->deleteExpectations,
-            sprintf('Unexpected cache delete call for key "%s".', $key)
+            \sprintf('Unexpected cache delete call for key "%s".', $key)
         );
 
         return $expectation($key) ?? true;
@@ -103,7 +100,7 @@ final class TagAwareCacheSpy implements TagAwareCacheInterface
      */
     private function takeExpectation(array &$expectations, string $message): callable
     {
-        $expectation = array_shift($expectations);
+        $expectation = \array_shift($expectations);
 
         if ($expectation === null) {
             Assert::fail($message);
@@ -118,7 +115,7 @@ final class TagAwareCacheSpy implements TagAwareCacheInterface
     private function assertQueueEmpty(array $expectations, string $message): void
     {
         if ($expectations !== []) {
-            Assert::fail(sprintf($message, count($expectations)));
+            Assert::fail(\sprintf($message, \count($expectations)));
         }
     }
 }


### PR DESCRIPTION
## Summary
- Refactors user command handlers with response DTOs to return `CommandResponseInterface` implementations instead of mutating command objects.
- Updates the in-memory Symfony command bus to return Messenger handled results and validates unsupported handler returns.
- Updates processors, GraphQL resolvers, controllers, and unit/integration tests to consume dispatch return values.

## Validation
- `docker compose run --rm --no-deps --entrypoint php -e APP_ENV=test php ./vendor/bin/phpunit ...` (focused 133 tests / 696 assertions)
- `docker compose run --rm --no-deps --entrypoint php -e APP_ENV=test php ./vendor/bin/php-cs-fixer fix $(git diff --name-only -- "*.php") --allow-risky=yes --config .php-cs-fixer.dist.php --dry-run --diff`
- `docker compose run --rm --no-deps --entrypoint php -e APP_ENV=test php ./vendor/bin/psalm --show-info=false --no-progress`
- `git diff --check`

Closes #230

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors the command bus and user command handlers to return typed responses, and adds a runtime guard to enforce response contracts. Also fixes refresh token hashing during rotation to prevent static hashing.

- **Refactors**
  - `CommandBusInterface::dispatch` now returns `?CommandResponseInterface`; in‑memory bus returns the last Messenger `HandledStamp` result and throws on invalid or missing responses.
  - Added `CommandResponseTypeGuard::expect`; used in controllers, processors, and GraphQL resolvers to assert and extract response types.
  - Handlers return DTOs implementing `CommandResponseInterface` (sign-in, refresh, two-factor, password reset, registration, recovery codes); updated the rate‑limit decorator and `RequestPasswordResetHandlerInterface` to return `RequestPasswordResetCommandResponse`.
  - Introduced services: `RefreshTokenIssuer`, `RefreshTokenTheftDetector`, `RefreshTokenContextResolver`, `PasswordResetConfirmationService`, plus command dispatchers for sign-in and two-factor flows.
  - Added BMAD tech spec at `specs/issue-230-command-response-refactor/tech-spec.md`; updated architecture rules (`deptrac.yaml`) to include `Service` under `App\User\Application`.
  - Updated unit tests to consume returned command responses (including password reset tests).

- **Migration**
  - Update handlers/decorators to return a `CommandResponseInterface` implementation and ensure call sites consume the returned value via `CommandResponseTypeGuard::expect` or the new dispatchers.
  - Remove response state from command classes and delete any `getResponse/setResponse` usage.

<sup>Written for commit 6e3425fa80303b8971300e5c8eabd60bbfad137a. Summary will update on new commits. <a href="https://cubic.dev/pr/VilnaCRM-Org/user-service/pull/285?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Restructured internal command handling architecture to improve code organization and maintainability through response-oriented patterns.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/VilnaCRM-Org/user-service/pull/285?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## BMAD Planning Evidence

- BMAD planning artifact: `specs/issue-230-command-response-refactor/tech-spec.md`
- BMALPH verification: `bmalph -C /home/kravtsov/Projects/user-service-issue230 status` reported Phase 1 - Analysis / Analyst / planning.
- The artifact maps issue #230 to the command response return design, guardrails, acceptance criteria, and validation plan.