### PR TITLE
docs: optimize code-review skill via Tessl evals

### DIFF
--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -40,14 +40,14 @@ When a comment (or a CI failure during verification) maps to one of the concerns
 | Quality threshold questions         | `quality-standards`             |
 | Comprehensive CI checks             | `ci-workflow`                   |
 
-### Tool-Driven Fixes (no skill — run the command)
+### Tool-Driven Fixes (no skill — run `make ci`)
 
-Some failure types have no dedicated skill because the tool itself is the remediation. Do NOT manually patch the underlying code; run the command.
+Some failure types have no dedicated skill because the tool itself is the remediation. Do NOT manually patch the underlying code; `make ci` runs every quality tool (Psalm, PHP CS Fixer, etc.) and is the single command for both fixing and verifying these issues.
 
-| Concern                              | Command            |
-| ------------------------------------ | ------------------ |
-| Static analysis errors (Psalm types) | `make psalm`       |
-| Code style violations                | `make phpcsfixer`  |
+| Concern                              | Command   |
+| ------------------------------------ | --------- |
+| Static analysis errors (Psalm types) | `make ci` |
+| Code style violations                | `make ci` |
 
 ## Execution Steps
 

--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -113,7 +113,7 @@ If `make ci` fails, route the failure type through **Skill Routing**. Do not fin
 
 **Commit Message Template** (Conventional Commits; the `(#PR)` suffix is appended by GitHub on squash-merge):
 
-```
+```text
 <type>(#<issue>): <imperative description of what changed>
 
 [Optional: why, if non-obvious]
@@ -127,7 +127,7 @@ Ref: https://github.com/owner/repo/pull/XX#discussion_rYYYYYYY
 
 **Example**:
 
-```
+```text
 fix(#230): null-check user lookup before command dispatch
 
 Ref: https://github.com/VilnaCRM-Org/user-service/pull/285#discussion_r1234567890

--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: code-review
-description: Systematically retrieve and address PR code review comments using make pr-comments. Use when handling code review feedback or addressing PR comments.
+description: Fetch unresolved PR review comments, categorize by type (committable suggestions, LLM prompts, architecture concerns, questions, general feedback), apply changes, and verify with CI. Use when addressing pull request feedback, reviewer comments, requested changes, GitHub review suggestions, resolving review threads, or running `make pr-comments` / `make ai-review-loop`.
 ---
 
 # Code Review Workflow Skill
@@ -8,9 +8,7 @@ description: Systematically retrieve and address PR code review comments using m
 ## Context (Input)
 
 - PR has unresolved code review comments
-- Need systematic approach to address feedback
-- Ready to implement reviewer suggestions
-- Need to maintain quality standards during review implementation
+- Quality standards must hold while addressing feedback
 
 ## Task (Function)
 
@@ -18,258 +16,135 @@ Systematically retrieve, categorize, and address all PR code review comments whi
 
 **Success Criteria**: `make pr-comments` shows 0 unresolved AND `make ci` shows "✅ CI checks successfully passed!"
 
-## Workflow Overview
-
-```mermaid
-AI Review Loop → PR Comments → Categorize → Apply by Priority → Verify → Run CI → Done
-```
-
 ## Quick Start
 
 ```bash
-# 0. Run autonomous AI review + fix loop (Codex default, Claude optional)
-make ai-review-loop
-
-# 1. Get comments
-make pr-comments
-
-# 2. Apply each suggestion/fix (one commit per comment)
-git commit -m "Apply review suggestion: [description]
-
-Ref: [comment URL]"
-
-# 3. Verify all addressed
-make pr-comments  # Should show 0 unresolved
-
-# 4. Run CI
-make ci  # Must show "✅ CI checks successfully passed!"
+make ai-review-loop                                    # 0. Autonomous review + fix loop
+make pr-comments                                       # 1. Get unresolved comments
+# 2. Apply each fix and commit per comment (template below)
+make pr-comments                                       # 3. Verify 0 unresolved
+make ci                                                # 4. CI must pass
 ```
+
+## Skill Routing
+
+When a comment (or a CI failure during verification) maps to one of the concerns below, invoke the matching skill instead of fixing ad-hoc.
+
+| Concern                             | Skill                           |
+| ----------------------------------- | ------------------------------- |
+| Class placement / naming            | `code-organization`             |
+| DDD pattern violations              | `implementing-ddd-architecture` |
+| Deptrac / layer violations          | `deptrac-fixer`                 |
+| Cyclomatic complexity / PHPInsights | `complexity-management`         |
+| Test failures, coverage, mutation   | `testing-workflow`              |
+| Quality threshold questions         | `quality-standards`             |
+| Comprehensive CI checks             | `ci-workflow`                   |
+
+### Tool-Driven Fixes (no skill — run the command)
+
+Some failure types have no dedicated skill because the tool itself is the remediation. Do NOT manually patch the underlying code; run the command.
+
+| Concern                              | Command            |
+| ------------------------------------ | ------------------ |
+| Static analysis errors (Psalm types) | `make psalm`       |
+| Code style violations                | `make phpcsfixer`  |
 
 ## Execution Steps
 
 ### Step 0: Run Autonomous AI Review Loop
 
-Before addressing PR comments manually, run the autonomous review loop:
-
 ```bash
 make ai-review-loop
 ```
 
-This executes `scripts/ai-review-loop.sh`, which:
-
-1. Runs an AI review agent against the current diff (base: `main` by default)
-2. If issues are found (`STATUS: FAIL`), runs a fix agent to auto-remediate
-3. Verifies fixes with `make ci`
-4. Repeats up to `AI_REVIEW_MAX_ITER` times (default: 3)
-
-**Configuration** (all overridable via environment):
-
-| Variable               | Default         | Description                         |
-| ---------------------- | --------------- | ----------------------------------- |
-| `AI_REVIEW_AGENTS`     | `codex`         | Agent(s) to use (`codex`, `claude`) |
-| `AI_REVIEW_BASE`       | `main`          | Base branch for diff comparison     |
-| `AI_REVIEW_MAX_ITER`   | `3`             | Max review/fix iterations (0=∞)     |
-| `AI_REVIEW_VERIFY_CMD` | `make ci`       | Verification command after each fix |
-| `AI_REVIEW_LOG_DIR`    | `var/ai-review` | Directory for review/fix logs       |
-
-**Examples**:
-
-```bash
-# Use Claude instead of Codex
-AI_REVIEW_AGENTS=claude make ai-review-loop
-
-# Limit to 1 iteration, custom base branch
-AI_REVIEW_BASE=develop AI_REVIEW_MAX_ITER=1 make ai-review-loop
-
-# Run both agents
-AI_REVIEW_AGENTS=codex,claude make ai-review-loop
-```
-
-**Prompt templates**: `scripts/ai-review-prompts/review.md` (reviewer) and `scripts/ai-review-prompts/fix.md` (fixer).
+Configuration, alternative agents, and prompt template paths: [reference/ai-review-loop.md](reference/ai-review-loop.md).
 
 ### Step 1: Get PR Comments
 
 ```bash
 make pr-comments              # Auto-detect from current branch
-make pr-comments PR=62       # Specify PR number
+make pr-comments PR=62        # Specify PR number
 make pr-comments FORMAT=json  # JSON output
 ```
 
-**Output**: All unresolved comments with file/line, author, timestamp, URL
-
 ### Step 2: Categorize Comments
 
-| Type                   | Identifier                  | Priority | Action                               |
-| ---------------------- | --------------------------- | -------- | ------------------------------------ |
-| Committable Suggestion | Code block, "```suggestion" | Highest  | Apply immediately, commit separately |
-| LLM Prompt             | "🤖 Prompt for AI Agents"   | High     | Execute prompt, implement changes    |
-| Architecture Concern   | Class naming, file location | High     | Invoke appropriate skill             |
-| Question               | Ends with "?"               | Medium   | Answer inline or via code change     |
-| General Feedback       | Discussion, recommendation  | Low      | Consider and improve                 |
+| Type                   | Identifier                  | Priority | Action                                     |
+| ---------------------- | --------------------------- | -------- | ------------------------------------------ |
+| Committable Suggestion | Code block, "```suggestion" | Highest  | Apply verbatim, commit separately          |
+| LLM Prompt             | "🤖 Prompt for AI Agents"   | High     | Execute prompt, implement, commit          |
+| Architecture Concern   | Class naming, file location | High     | Route through Skill Routing                |
+| Question               | Ends with "?"               | Medium   | Answer inline or via code change           |
+| General Feedback       | Discussion, recommendation  | Low      | Apply if beneficial                        |
 
-### Step 3: Verify Architecture & Organization
+Per-type handling: [reference/comment-types.md](reference/comment-types.md).
 
-For code changes (suggestions, prompts, new files), invoke verification skills:
+### Step 3: Apply Changes Systematically
 
-| Concern Type           | Skill to Invoke                    |
-| ---------------------- | ---------------------------------- |
-| Class placement/naming | `code-organization`                |
-| DDD patterns           | `implementing-ddd-architecture`    |
-| Layer violations       | `deptrac-fixer` (if deptrac fails) |
+Process comments in priority order from Step 2. For each comment, route through **Skill Routing** when applicable; otherwise apply the change and commit using the template in [reference/comment-types.md](reference/comment-types.md).
 
-**Quick verification**: Run `make phpcsfixer && make psalm && make deptrac && make unit-tests`
+Local verification before pushing: `make ci`.
 
-### Step 4: Apply Changes Systematically
-
-#### For Committable Suggestions
-
-1. Apply code change exactly as suggested
-2. Commit with reference:
-
-   ```bash
-   git commit -m "Apply review suggestion: [brief description]
-
-   Ref: [comment URL]"
-   ```
-
-#### For LLM Prompts
-
-1. Copy prompt from comment
-2. Execute as instructed
-3. Verify output meets requirements
-4. Commit with reference
-
-#### For Architecture/Organization Concerns
-
-1. Invoke appropriate skill (`code-organization` or `implementing-ddd-architecture`)
-2. Implement recommended changes
-3. Verify: `make phpcsfixer && make psalm && make deptrac && make unit-tests`
-4. Commit with reference
-
-#### For Questions
-
-1. Determine if code change or reply needed
-2. If code: implement + commit
-3. If reply: respond on GitHub
-
-#### For General Feedback
-
-1. Evaluate suggestion merit
-2. Implement if beneficial
-3. Document reasoning if declined
-
-### Step 5: Verify All Addressed
+### Step 4: Verify Complete
 
 ```bash
-make pr-comments  # Should show zero unresolved comments
+make pr-comments  # Must show zero unresolved
+make ci           # Must show "✅ CI checks successfully passed!"
 ```
 
-### Step 6: Run Quality Checks
-
-**MANDATORY**: Run comprehensive CI checks after implementing all changes:
-
-```bash
-make ci  # Must output "✅ CI checks successfully passed!"
-```
-
-**If CI fails**, invoke appropriate skill:
-
-| Failure Type            | Skill to Use            |
-| ----------------------- | ----------------------- |
-| Architecture violations | `deptrac-fixer`         |
-| Complexity issues       | `complexity-management` |
-| Test failures           | `testing-workflow`      |
-| Mutation testing issues | `testing-workflow`      |
-| Code style              | Run `make phpcsfixer`   |
-| Static analysis         | Run `make psalm`        |
-
-**DO NOT** finish the task until `make ci` shows: `✅ CI checks successfully passed!`
+If `make ci` fails, route the failure type through **Skill Routing**. Do not finish until both commands succeed.
 
 ## Constraints (Parameters)
 
 **NEVER**:
 
-- Skip the autonomous AI review loop (`make ai-review-loop`) without justification
-- Skip committable suggestions
+- Skip `make ai-review-loop` without justification
 - Batch unrelated changes in one commit
-- Ignore LLM prompts from reviewers
-- Commit without running verification
-- Leave questions unanswered
-- Accept organizational violations (invoke `code-organization` skill)
-- Accept architecture violations (invoke `implementing-ddd-architecture` skill)
-- Add suppression/ignore annotations to "fix" review comments or CI failures
-- Finish task before `make ci` shows success message
+- Add suppression / ignore annotations to "fix" comments or CI failures
+- Finish before `make ci` succeeds
 
 **ALWAYS**:
 
-- Run `make ai-review-loop` before manually addressing PR comments
-- Apply suggestions exactly as provided
-- Commit each suggestion separately with URL reference
-- Invoke `code-organization` skill for structural issues
-- Invoke `implementing-ddd-architecture` skill for DDD violations
-- Run `make ci` after implementing all changes
-- Address ALL CI failures before finishing
-- Mark conversations resolved after addressing
+- Route concerns through **Skill Routing** rather than fixing ad-hoc
+- Include the comment URL in every commit message
+- Mark conversations resolved on GitHub after addressing
 
 ## Format (Output)
 
-**Commit Message Template**:
+**Commit Message Template** (Conventional Commits; the `(#PR)` suffix is appended by GitHub on squash-merge):
 
 ```
-Apply review suggestion: [concise description]
+<type>(#<issue>): <imperative description of what changed>
 
-[Optional: explanation if non-obvious]
+[Optional: why, if non-obvious]
 
 Ref: https://github.com/owner/repo/pull/XX#discussion_rYYYYYYY
 ```
 
-**Final Verification**:
+- `<type>` ∈ `feat | fix | refactor | docs | perf | test | chore`
+- `(#<issue>)` scope is optional — include the GitHub issue number when there is one
+- Subject is lowercase, imperative, describes the change (not "apply review suggestion")
 
-```bash
-✅ make pr-comments shows 0 unresolved
-✅ make ci shows "CI checks successfully passed!"
+**Example**:
+
+```
+fix(#230): null-check user lookup before command dispatch
+
+Ref: https://github.com/VilnaCRM-Org/user-service/pull/285#discussion_r1234567890
 ```
 
 ## Verification Checklist
 
-- [ ] Autonomous AI review loop run via `make ai-review-loop` (or skipped with justification)
-- [ ] All PR comments retrieved via `make pr-comments`
-- [ ] Comments categorized by type (suggestion/prompt/architecture/question/feedback)
-- [ ] Architecture verified using appropriate skills
-- [ ] `make deptrac` passes (0 violations)
-- [ ] Committable suggestions applied and committed separately
-- [ ] LLM prompts executed and implemented
-- [ ] Questions answered (code or reply)
-- [ ] General feedback evaluated and addressed
-- [ ] `make ci` shows "✅ CI checks successfully passed!"
+- [ ] `make ai-review-loop` run (or skipped with justification)
+- [ ] Comments retrieved and categorized per Step 2
+- [ ] Architecture concerns routed through matching skills
+- [ ] Suggestions applied verbatim, one commit per comment with URL ref
 - [ ] `make pr-comments` shows zero unresolved
+- [ ] `make ci` shows "✅ CI checks successfully passed!"
 - [ ] All conversations marked resolved on GitHub
-
-## Quick Reference: When to Use Related Skills
-
-During code review, you may need to invoke other skills:
-
-| Issue                    | Skill to Use                    |
-| ------------------------ | ------------------------------- |
-| Class in wrong directory | `code-organization`             |
-| Vague naming             | `code-organization`             |
-| DDD pattern violations   | `implementing-ddd-architecture` |
-| Deptrac failures         | `deptrac-fixer`                 |
-| Complexity too high      | `complexity-management`         |
-| Test failures            | `testing-workflow`              |
-| Quality standards        | `quality-standards`             |
-
-## Related Skills
-
-- **code-organization**: Enforces "Directory X contains ONLY class type X" and naming conventions
-- **implementing-ddd-architecture**: DDD patterns, layer structure, and boundaries
-- **deptrac-fixer**: Fixes architectural boundary violations
-- **complexity-management**: Reduces cyclomatic complexity
-- **testing-workflow**: Test coverage and mutation testing
-- **quality-standards**: Overall quality metrics and thresholds
-- **ci-workflow**: Comprehensive CI checks
 
 ## Related Documentation
 
-- Examples: `examples/organization-fixes.md` - Real-world organization fix examples
-- Reference: `reference/quality-standards.md` - Quality standards integration details
+- [reference/ai-review-loop.md](reference/ai-review-loop.md) — Configuration for `make ai-review-loop`
+- [reference/comment-types.md](reference/comment-types.md) — Per-type execution details
+- [reference/quality-standards.md](reference/quality-standards.md) — Quality standards integration

--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -69,13 +69,13 @@ make pr-comments FORMAT=json  # JSON output
 
 ### Step 2: Categorize Comments
 
-| Type                   | Identifier                  | Priority | Action                                     |
-| ---------------------- | --------------------------- | -------- | ------------------------------------------ |
-| Committable Suggestion | Code block, "```suggestion" | Highest  | Apply verbatim, commit separately          |
-| LLM Prompt             | "🤖 Prompt for AI Agents"   | High     | Execute prompt, implement, commit          |
-| Architecture Concern   | Class naming, file location | High     | Route through Skill Routing                |
-| Question               | Ends with "?"               | Medium   | Answer inline or via code change           |
-| General Feedback       | Discussion, recommendation  | Low      | Apply if beneficial                        |
+| Type                   | Identifier                  | Priority | Action                            |
+| ---------------------- | --------------------------- | -------- | --------------------------------- |
+| Committable Suggestion | Code block, "```suggestion" | Highest  | Apply verbatim, commit separately |
+| LLM Prompt             | "🤖 Prompt for AI Agents"   | High     | Execute prompt, implement, commit |
+| Architecture Concern   | Class naming, file location | High     | Route through Skill Routing       |
+| Question               | Ends with "?"               | Medium   | Answer inline or via code change  |
+| General Feedback       | Discussion, recommendation  | Low      | Apply if beneficial               |
 
 Per-type handling: [reference/comment-types.md](reference/comment-types.md).
 

--- a/.claude/skills/code-review/reference/ai-review-loop.md
+++ b/.claude/skills/code-review/reference/ai-review-loop.md
@@ -1,0 +1,38 @@
+# AI Review Loop Reference
+
+Detailed configuration for `make ai-review-loop`, which executes `scripts/ai-review-loop.sh`.
+
+## What it does
+
+1. Runs an AI review agent against the current diff (base: `main` by default)
+2. If issues are found (`STATUS: FAIL`), runs a fix agent to auto-remediate
+3. Verifies fixes with `make ci`
+4. Repeats up to `AI_REVIEW_MAX_ITER` times (default: 3)
+
+## Configuration (environment overrides)
+
+| Variable               | Default         | Description                         |
+| ---------------------- | --------------- | ----------------------------------- |
+| `AI_REVIEW_AGENTS`     | `codex`         | Agent(s) to use (`codex`, `claude`) |
+| `AI_REVIEW_BASE`       | `main`          | Base branch for diff comparison     |
+| `AI_REVIEW_MAX_ITER`   | `3`             | Max review/fix iterations (0=∞)     |
+| `AI_REVIEW_VERIFY_CMD` | `make ci`       | Verification command after each fix |
+| `AI_REVIEW_LOG_DIR`    | `var/ai-review` | Directory for review/fix logs       |
+
+## Examples
+
+```bash
+# Use Claude instead of Codex
+AI_REVIEW_AGENTS=claude make ai-review-loop
+
+# Limit to 1 iteration, custom base branch
+AI_REVIEW_BASE=develop AI_REVIEW_MAX_ITER=1 make ai-review-loop
+
+# Run both agents
+AI_REVIEW_AGENTS=codex,claude make ai-review-loop
+```
+
+## Prompt templates
+
+- Reviewer: `scripts/ai-review-prompts/review.md`
+- Fixer: `scripts/ai-review-prompts/fix.md`

--- a/.claude/skills/code-review/reference/comment-types.md
+++ b/.claude/skills/code-review/reference/comment-types.md
@@ -1,0 +1,33 @@
+# Per-Comment-Type Execution Reference
+
+Detailed handling per category from the Step 2 categorization table. Apply alongside the **Skill Routing** table in `SKILL.md`.
+
+## Committable Suggestions
+
+Apply the change verbatim, then commit using the Conventional Commits template from `SKILL.md`:
+
+```bash
+git commit -m "<type>(#<issue>): <imperative description>
+
+Ref: [comment URL]"
+```
+
+Use `fix` for bug-correcting suggestions, `refactor` for non-behavioral cleanups, `docs` for doc-only changes.
+
+## LLM Prompts
+
+Copy the prompt from the comment, execute it, verify output matches the reviewer's intent, commit with reference.
+
+## Architecture / Organization Concerns
+
+1. Invoke the matching skill from **Skill Routing**
+2. Verify: `make ci`
+3. Commit with reference
+
+## Questions
+
+If the answer requires a code change, implement + commit. Otherwise reply on GitHub and mark the thread resolved.
+
+## General Feedback
+
+Apply if it improves the change; otherwise reply with reasoning and resolve the thread.


### PR DESCRIPTION
## Description

Restructure `.claude/skills/code-review/SKILL.md` and add two bundle files (`reference/ai-review-loop.md`, `reference/comment-types.md`). File reduced from 276 → 132 lines while measurably improving agent behavior.

## Related Issue

None — self-driven skill improvement experiment using Tessl as the evaluation harness.

## Motivation and Context

The `code-review` skill is one of the workflows ALL contributors (human + AI) rely on for addressing PR feedback. Its quality directly affects whether reviewer suggestions are processed correctly, suppression annotations are refused, and CI failures are routed to specialized skills. Worth measuring and optimizing.

Findings from Tessl's tooling:
- Description was missing trigger-term variations → agents wouldn't activate the skill on natural language like "pull request feedback" or "reviewer comments".
- Three duplicated skill-routing tables (Steps 3, 6, Quick Reference) → maintenance hazard.
- Step 0 config table + per-comment-type sub-sections were inline clutter.
- Commit-message template didn't match the repo's Conventional Commits convention.
- The original wording grouped \`make psalm\`/\`make phpcsfixer\` as a footnote, which agents missed.

## How Has This Been Tested?

Two complementary Tessl evaluation tools, run anonymously via `npx @tessl/cli`:

**1. Static review (`tessl skill review`)** — lints + LLM-judges description and content:

| Version | Review Score | Description | Content |
|---|---|---|---|
| Original | 75% | 75% | 63% |
| Final | 90–97% | 100% | 77–92% |

**2. Behavioral eval (`tessl eval run`)** — Tessl-generated scenario \"CI failure skill routing and suppression rejection\" graded by `claude:claude-opus-4-7`:

| | Without skill (baseline) | With skill |
|---|---|---|
| Total score | 52% | **96%** |
| Routes deptrac violation | 0% | 100% |
| Routes test/mutation failure | 0% | 100% |
| Skill routing over ad-hoc | 0% | 100% |
| Routes quality issue | 40% | 100% |
| Tool-driven static analysis | 20% | 60% |

The skill produces a **measured +44 percentage point** improvement in Claude's behavior on a previously-unseen CI remediation task — including refusing reviewer suggestions to lower thresholds or add `@deptrac-ignore` annotations.

One iteration regressed to 42% when the routing table was renamed `Skill` → `Action` and rows became `Invoke skill X` mixed with `Run make Y`. Reverting to a homogeneous routing table + a separate `Tool-Driven Fixes` table restored 96%. The lesson is captured in the final structure.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change

(Skill content improvement — non-breaking; the public skill name and activation triggers remain compatible.)

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes. — Skills don't have unit tests; behavioral eval via Tessl is the validation, scenario kept locally (not committed).
- [x] All new and existing tests passed. — \`make ci\` not run on this branch since change is markdown-only; CI on PR will validate.
- [x] You have only one commit.
- [ ] Structurizr documentation has been updated to reflect any architectural changes. — No architectural changes (skill content only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restructured the `code-review` skill to simplify PR feedback handling and CI verification, and tightened docs to keep CI green. Unified routing, moved details into references, standardized fixes via `make ci`, and aligned commit messages — improving behavior in `@tessl/cli` evals.

- **Refactors**
  - Consolidated into one canonical Skill Routing table and a separate Tool-Driven Fixes table.
  - Standardized tool-driven fixes to use `make ci` as the single gateway for static analysis and style.
  - Added trigger-term variations so the skill activates on natural phrases like “pull request feedback” and “reviewer comments”.
  - Moved `make ai-review-loop` config and per-comment handling into `reference/ai-review-loop.md` and `reference/comment-types.md`.
  - Switched the commit template to Conventional Commits and require the comment URL in every commit.

- **Bug Fixes**
  - Added language tags to fenced code blocks to silence markdownlint MD040 and Prettier, keeping CI green.

<sup>Written for commit 280a2af57ef684b2235b53e99a69e39378a443fa. Summary will update on new commits. <a href="https://cubic.dev/pr/VilnaCRM-Org/user-service/pull/289?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reworked the code-review skill docs into a structured guide with clear execution steps and an autonomous review loop.
  * Added explicit Skill Routing and guidance for tool-driven fixes and verification via CI.
  * Introduced Conventional Commit templates (including review URL) and NEVER/ALWAYS rules for commit/resolve behavior.
  * Added reference guides for comment types and the AI review loop.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/VilnaCRM-Org/user-service/pull/289?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->