### PR TITLE
fix(security): reject non-first-party tokens, stop ROLE_SERVICE inference (#312)

### DIFF
--- a/config/api_platform/resources/User.yaml
+++ b/config/api_platform/resources/User.yaml
@@ -41,6 +41,10 @@ resources:
         input: 'App\User\Application\DTO\UserRegisterBatchDto'
         processor: 'App\User\Application\Processor\RegisterUserBatchProcessor'
         uriTemplate: 'users/batch'
+        # Defense-in-depth: the bulk user-import endpoint is service-only.
+        # The firewall already gates it on ROLE_SERVICE; this operation-level
+        # check ensures the restriction survives any firewall misconfiguration.
+        security: "is_granted('ROLE_SERVICE')"
         denormalizationContext:
           allow_extra_attributes: false
       confirm_http:

--- a/specs/security-312-accesstoken-role-service-escalation/prd.md
+++ b/specs/security-312-accesstoken-role-service-escalation/prd.md
@@ -1,0 +1,57 @@
+# PRD — Fix: OAuth2/JWT access tokens silently escalate to ROLE_SERVICE (issue #312)
+
+## Problem (FR)
+
+The custom `AccessTokenValidator` and `AccessTokenUserResolver` treat any
+validly-signed RS256 JWT that lacks both an `iss` and a `roles` claim as a
+`ROLE_SERVICE` principal, and skip issuer/audience validation for that class of
+token. Because the Lexik first-party JWT and the League OAuth2 authorization
+server are wired to the **same** RSA keypair (`config/jwt/private.pem` /
+`public.pem`), a League OAuth2 access token (shape: `aud=client_id`, `sub`,
+`scopes`, `exp/nbf`, **no** `iss`, **no** `roles`) passes signature
+verification and is auto-elevated to `ROLE_SERVICE`.
+
+`ROLE_SERVICE` is the sole gate for `POST /api/users/batch` (bulk user import)
+and also satisfies the `^/api/` `ROLE_USER` catch-all, so any token minted by
+`/api/oauth/token` — including a minimal-scope `client_credentials` token or a
+`password`-grant end-user token — gains service-level privileges.
+
+CWE-269 / CWE-287 / CWE-345. Severity: **critical**.
+
+## Functional requirements
+
+- **FR-1**: Issuer and audience MUST be validated for **every** accepted access
+  token, unconditionally. A token whose `iss != vilnacrm-user-service` or whose
+  `aud` does not contain `vilnacrm-api` MUST be rejected with
+  `Invalid access token claims.`
+- **FR-2**: `ROLE_SERVICE` MUST NOT be inferred from the absence of claims. A
+  token without an explicit `roles` claim defaults to the least-privilege
+  `ROLE_USER`.
+- **FR-3**: A token that carries a `roles` claim MUST also carry a `sid`
+  (session binding) — unchanged from prior behaviour.
+- **FR-4**: Legitimate first-party tokens (user and service) that carry
+  `iss=vilnacrm-user-service`, `aud=vilnacrm-api`, `sid`, and explicit `roles`
+  continue to validate and resolve exactly as before.
+- **FR-5 (defense-in-depth)**: `create_batch_http` (`POST /api/users/batch`)
+  carries an explicit API Platform `security: is_granted('ROLE_SERVICE')`
+  expression so the restriction survives firewall misconfiguration.
+
+## Non-functional requirements
+
+- **NFR-Security**: League OAuth2 tokens can no longer cross-verify as
+  first-party principals; privilege derives only from positively-asserted,
+  signed first-party claims (no insecure defaults — CWE-1188).
+- **NFR-Compatibility**: No change to the wire format of issued first-party
+  tokens; existing Behat/integration ROLE_SERVICE and ROLE_USER flows pass
+  unchanged.
+- **NFR-Maintainability**: Validation logic simplified — one mandatory
+  iss/aud gate instead of conditional branches.
+
+## Out of scope (tracked separately)
+
+- Separating the OAuth2 resource-server keypair from the first-party JWT key
+  (defense-in-depth hardening) — follow-up; the iss/aud gate already closes the
+  escalation with the shared key.
+- Session-revocation checks for genuine machine ROLE_SERVICE tokens (finding 11
+  residual): service tokens are M2M and stateless by design; the escalation
+  vector is closed because ROLE_SERVICE now requires a trusted signed claim.

--- a/specs/security-312-accesstoken-role-service-escalation/stories.md
+++ b/specs/security-312-accesstoken-role-service-escalation/stories.md
@@ -1,6 +1,7 @@
 # Stories — issue #312
 
 ## Story 1: Make issuer/audience validation mandatory for every token
+
 - **As** the API security boundary, **I** reject any access token whose `iss`
   is not `vilnacrm-user-service` or whose `aud` does not contain
   `vilnacrm-api`, **so that** tokens minted for other audiences (League OAuth2
@@ -15,6 +16,7 @@
   - edge: token with valid iss/aud but no roles → `ROLE_USER`.
 
 ## Story 2: Never infer ROLE_SERVICE from missing claims
+
 - **As** the role extractor, **I** default a token without an explicit `roles`
   claim to `ROLE_USER`, **so that** absence of claims cannot grant service
   privileges (CWE-1188 insecure default).
@@ -24,6 +26,7 @@
   `testValidateAcceptsExplicitServiceTokenWithFirstPartyClaims`.
 
 ## Story 3: Defense-in-depth on the bulk-import endpoint
+
 - **As** the bulk user-import operation, **I** also enforce
   `is_granted('ROLE_SERVICE')` at the API Platform layer, **so that** the
   service-only restriction survives a firewall misconfiguration.
@@ -33,6 +36,7 @@
   (403 without ROLE_SERVICE, success with ROLE_SERVICE) continue to pass.
 
 ## Verification
+
 - Unit: `tests/Unit/Shared/Infrastructure/Validator/*`,
   `tests/Unit/Shared/Infrastructure/Adapter/DualAuthenticatorTest.php`.
 - E2E: `features/auth_gate.feature`, `features/user_operations.feature`,

--- a/specs/security-312-accesstoken-role-service-escalation/stories.md
+++ b/specs/security-312-accesstoken-role-service-escalation/stories.md
@@ -1,0 +1,41 @@
+# Stories — issue #312
+
+## Story 1: Make issuer/audience validation mandatory for every token
+- **As** the API security boundary, **I** reject any access token whose `iss`
+  is not `vilnacrm-user-service` or whose `aud` does not contain
+  `vilnacrm-api`, **so that** tokens minted for other audiences (League OAuth2
+  client tokens) cannot authenticate as first-party principals.
+- Implementation: `AccessTokenValidator::validateClaims()` calls
+  `validateIssuerAndAudience()` unconditionally; the conditional
+  `validateFirstPartyClaims()` is replaced by `validateSessionBinding()`.
+- Tests (positive/negative/edge):
+  - positive: first-party token with valid iss/aud/sid/roles validates.
+  - negative: OAuth2-shaped token (no iss, `aud=client_id`) rejected.
+  - negative: token with `aud=vilnacrm-api` but no iss rejected.
+  - edge: token with valid iss/aud but no roles → `ROLE_USER`.
+
+## Story 2: Never infer ROLE_SERVICE from missing claims
+- **As** the role extractor, **I** default a token without an explicit `roles`
+  claim to `ROLE_USER`, **so that** absence of claims cannot grant service
+  privileges (CWE-1188 insecure default).
+- Implementation: `AccessTokenValidator::extractRoles()` returns `['ROLE_USER']`
+  when `roles` is absent.
+- Test: `testValidateDefaultsToRoleUserWhenRolesClaimAbsent`,
+  `testValidateAcceptsExplicitServiceTokenWithFirstPartyClaims`.
+
+## Story 3: Defense-in-depth on the bulk-import endpoint
+- **As** the bulk user-import operation, **I** also enforce
+  `is_granted('ROLE_SERVICE')` at the API Platform layer, **so that** the
+  service-only restriction survives a firewall misconfiguration.
+- Implementation: `security` expression on `create_batch_http` in
+  `config/api_platform/resources/User.yaml`.
+- Coverage: existing `features/auth_gate.feature` batch scenarios
+  (403 without ROLE_SERVICE, success with ROLE_SERVICE) continue to pass.
+
+## Verification
+- Unit: `tests/Unit/Shared/Infrastructure/Validator/*`,
+  `tests/Unit/Shared/Infrastructure/Adapter/DualAuthenticatorTest.php`.
+- E2E: `features/auth_gate.feature`, `features/user_operations.feature`,
+  `features/user_localization.feature`, `features/error_format.feature`.
+- Static: psalm, deptrac (no new boundary crossings — edits stay in
+  Infrastructure + config), phpcsfixer, phpinsights.

--- a/src/Shared/Infrastructure/Validator/AccessTokenValidator.php
+++ b/src/Shared/Infrastructure/Validator/AccessTokenValidator.php
@@ -100,22 +100,22 @@ final readonly class AccessTokenValidator
             throw new CustomUserMessageAuthenticationException('Invalid access token claims.');
         }
 
-        $this->validateFirstPartyClaims($payload);
+        // Issuer and audience are validated unconditionally for EVERY token.
+        // This rejects tokens that are signed with the shared RSA key but were
+        // not minted as first-party access tokens — notably League OAuth2
+        // access tokens (aud=client_id, no iss), which previously bypassed this
+        // check and were silently elevated to ROLE_SERVICE.
+        $this->validateIssuerAndAudience($payload);
+        $this->validateSessionBinding($payload);
     }
 
     /**
      * @param array<string, array<int, string>|bool|float|int|string|null> $payload
      */
-    private function validateFirstPartyClaims(array $payload): void
+    private function validateSessionBinding(array $payload): void
     {
-        if (isset($payload['roles'])) {
-            $this->validateIssuerAndAudience($payload);
-
-            if (!isset($payload['sid'])) {
-                throw new CustomUserMessageAuthenticationException('Invalid access token claims.');
-            }
-        } elseif (($payload['iss'] ?? null) !== null) {
-            $this->validateIssuerAndAudience($payload);
+        if (isset($payload['roles']) && !isset($payload['sid'])) {
+            throw new CustomUserMessageAuthenticationException('Invalid access token claims.');
         }
     }
 
@@ -213,7 +213,11 @@ final readonly class AccessTokenValidator
     {
         $rawRoles = $payload['roles'] ?? null;
         if ($rawRoles === null) {
-            return isset($payload['iss']) ? ['ROLE_USER'] : ['ROLE_SERVICE'];
+            // Never infer a privileged role from the ABSENCE of claims. A token
+            // without an explicit roles claim is treated as the least-privilege
+            // ROLE_USER; ROLE_SERVICE must be positively asserted in the signed
+            // first-party token.
+            return ['ROLE_USER'];
         }
 
         if (!is_array($rawRoles) || $rawRoles === []) {

--- a/src/Shared/Infrastructure/Validator/AccessTokenValidator.php
+++ b/src/Shared/Infrastructure/Validator/AccessTokenValidator.php
@@ -100,11 +100,6 @@ final readonly class AccessTokenValidator
             throw new CustomUserMessageAuthenticationException('Invalid access token claims.');
         }
 
-        // Issuer and audience are validated unconditionally for EVERY token.
-        // This rejects tokens that are signed with the shared RSA key but were
-        // not minted as first-party access tokens — notably League OAuth2
-        // access tokens (aud=client_id, no iss), which previously bypassed this
-        // check and were silently elevated to ROLE_SERVICE.
         $this->validateIssuerAndAudience($payload);
         $this->validateSessionBinding($payload);
     }
@@ -114,7 +109,7 @@ final readonly class AccessTokenValidator
      */
     private function validateSessionBinding(array $payload): void
     {
-        if (isset($payload['roles']) && !isset($payload['sid'])) {
+        if (array_key_exists('roles', $payload) && !isset($payload['sid'])) {
             throw new CustomUserMessageAuthenticationException('Invalid access token claims.');
         }
     }
@@ -211,15 +206,11 @@ final readonly class AccessTokenValidator
      */
     private function extractRoles(array $payload): array
     {
-        $rawRoles = $payload['roles'] ?? null;
-        if ($rawRoles === null) {
-            // Never infer a privileged role from the ABSENCE of claims. A token
-            // without an explicit roles claim is treated as the least-privilege
-            // ROLE_USER; ROLE_SERVICE must be positively asserted in the signed
-            // first-party token.
+        if (!array_key_exists('roles', $payload)) {
             return ['ROLE_USER'];
         }
 
+        $rawRoles = $payload['roles'];
         if (!is_array($rawRoles) || $rawRoles === []) {
             throw new CustomUserMessageAuthenticationException('Invalid access token claims.');
         }

--- a/tests/Integration/Auth/PasswordGrantIntegrationTest.php
+++ b/tests/Integration/Auth/PasswordGrantIntegrationTest.php
@@ -47,14 +47,19 @@ final class PasswordGrantIntegrationTest extends AuthIntegrationTestCase
         $this->assertAccessTokenResponse($response);
     }
 
-    public function testOauthClientCredentialsAccessTokenCanReachProtectedServiceRoute(): void
+    public function testOauthClientCredentialsAccessTokenIsRejectedAtProtectedServiceRoute(): void
     {
+        // Regression for the ROLE_SERVICE privilege-escalation (#312): a League
+        // OAuth2 client_credentials access token (aud=client_id, no iss/roles)
+        // must NOT be auto-elevated to a first-party ROLE_SERVICE principal.
+        // It is now rejected with 401 at the protected bulk-import route because
+        // issuer/audience validation is mandatory and ROLE_SERVICE is never
+        // inferred from missing claims.
         $kernel = $this->resolveKernel();
         [$clientId, $clientSecret] = $this->createOAuthClient();
         $accessToken = $this->obtainAccessToken($kernel, $clientId, $clientSecret);
         $batchResponse = $this->sendAuthenticatedBatchRequest($kernel, $accessToken);
-        $this->assertNotSame(Response::HTTP_UNAUTHORIZED, $batchResponse->getStatusCode());
-        $this->assertNotSame(Response::HTTP_FORBIDDEN, $batchResponse->getStatusCode());
+        $this->assertSame(Response::HTTP_UNAUTHORIZED, $batchResponse->getStatusCode());
     }
 
     private function resolveKernel(): HttpKernelInterface

--- a/tests/Unit/Shared/Infrastructure/Validator/AccessTokenValidatorIdentityClaimsTest.php
+++ b/tests/Unit/Shared/Infrastructure/Validator/AccessTokenValidatorIdentityClaimsTest.php
@@ -101,6 +101,33 @@ final class AccessTokenValidatorIdentityClaimsTest extends AccessTokenValidatorT
         $this->assertSame($sid, $result['sid']);
     }
 
+    public function testValidateThrowsForExplicitNullRolesWithSid(): void
+    {
+        $token = $this->createValidToken();
+        $payload = $this->buildPayload($this->faker->email(), $this->faker->uuid(), ['ROLE_USER']);
+        $payload['roles'] = null;
+
+        $this->jwtEncoder->method('decode')->willReturn($payload);
+
+        $this->expectInvalidClaimsException();
+
+        $this->validator->validate($token);
+    }
+
+    public function testValidateThrowsForExplicitNullRolesWithoutSid(): void
+    {
+        $token = $this->createValidToken();
+        $payload = $this->buildPayload($this->faker->email(), $this->faker->uuid(), ['ROLE_USER']);
+        $payload['roles'] = null;
+        unset($payload['sid']);
+
+        $this->jwtEncoder->method('decode')->willReturn($payload);
+
+        $this->expectInvalidClaimsException();
+
+        $this->validator->validate($token);
+    }
+
     public function testValidateThrowsForEmptyRolesArray(): void
     {
         $token = $this->createValidToken();

--- a/tests/Unit/Shared/Infrastructure/Validator/AccessTokenValidatorIssuerAudienceTest.php
+++ b/tests/Unit/Shared/Infrastructure/Validator/AccessTokenValidatorIssuerAudienceTest.php
@@ -58,12 +58,57 @@ final class AccessTokenValidatorIssuerAudienceTest extends AccessTokenValidatorT
         $this->validator->validate($token);
     }
 
-    public function testValidateReturnsServiceRoleForOauthTokenWithoutIss(): void
+    public function testValidateRejectsOauthTokenWithoutIss(): void
     {
-        $subject = $this->faker->email();
+        // Regression for the ROLE_SERVICE privilege-escalation: a League OAuth2
+        // access token is signed with the shared RSA key but carries
+        // aud=client_id and no iss/roles claim. It must be rejected outright,
+        // never silently elevated to ROLE_SERVICE.
+        $token = $this->createValidToken();
+        $payload = [
+            'sub' => $this->faker->email(),
+            'aud' => 'some-oauth-client-id',
+            'nbf' => time() - 10,
+            'exp' => time() + 900,
+        ];
+
+        $this->jwtEncoder->method('decode')->willReturn($payload);
+
+        $this->expectInvalidClaimsException();
+
+        $this->validator->validate($token);
+    }
+
+    public function testValidateRejectsTokenWithApiAudienceButNoIssuer(): void
+    {
+        // Even when a non-first-party token happens to carry aud=vilnacrm-api,
+        // the absence of a valid issuer must cause rejection (no ROLE_SERVICE
+        // inference from missing claims).
+        $token = $this->createValidToken();
+        $payload = [
+            'sub' => $this->faker->email(),
+            'aud' => 'vilnacrm-api',
+            'nbf' => time() - 10,
+            'exp' => time() + 900,
+        ];
+
+        $this->jwtEncoder->method('decode')->willReturn($payload);
+
+        $this->expectInvalidClaimsException();
+
+        $this->validator->validate($token);
+    }
+
+    public function testValidateDefaultsToRoleUserWhenRolesClaimAbsent(): void
+    {
+        // A fully validated first-party token (valid iss + aud) that omits the
+        // explicit roles claim must default to the least-privilege ROLE_USER,
+        // never ROLE_SERVICE.
+        $subject = $this->faker->uuid();
         $token = $this->createValidToken();
         $payload = [
             'sub' => $subject,
+            'iss' => 'vilnacrm-user-service',
             'aud' => 'vilnacrm-api',
             'nbf' => time() - 10,
             'exp' => time() + 900,
@@ -74,7 +119,24 @@ final class AccessTokenValidatorIssuerAudienceTest extends AccessTokenValidatorT
         $result = $this->validator->validate($token);
 
         $this->assertSame($subject, $result['subject']);
-        $this->assertSame('', $result['sid']);
+        $this->assertSame(['ROLE_USER'], $result['roles']);
+    }
+
+    public function testValidateAcceptsExplicitServiceTokenWithFirstPartyClaims(): void
+    {
+        // ROLE_SERVICE remains valid only when positively asserted inside a
+        // fully validated first-party token (iss + aud + sid + roles).
+        $subject = $this->faker->uuid();
+        $sid = $this->faker->uuid();
+        $token = $this->createValidToken();
+        $payload = $this->buildPayload($subject, $sid, ['ROLE_SERVICE']);
+
+        $this->jwtEncoder->method('decode')->willReturn($payload);
+
+        $result = $this->validator->validate($token);
+
+        $this->assertSame($subject, $result['subject']);
+        $this->assertSame($sid, $result['sid']);
         $this->assertSame(['ROLE_SERVICE'], $result['roles']);
     }
 


### PR DESCRIPTION
## Security fix — Closes #312 (CRITICAL)

### Vulnerability
`AccessTokenValidator` silently elevated any RS256 JWT lacking **both** `iss` and `roles` to `ROLE_SERVICE`, and skipped issuer/audience validation for that token class. The Lexik first-party JWT and the League OAuth2 server share **one** RSA keypair, so a League OAuth2 access token (`aud=client_id`, no `iss`/`roles`) passed signature verification and was promoted to `ROLE_SERVICE` — the sole gate for `POST /api/users/batch` (bulk user import). Any low-privilege OAuth2 client (`client_credentials`) or `password`-grant end user could therefore bulk-provision accounts. CWE-269 / CWE-287 / CWE-345.

### Fix
- **Mandatory issuer/audience validation for every token** — `validateClaims()` calls `validateIssuerAndAudience()` unconditionally. League OAuth2 tokens (`aud=client_id`, no `iss`) are now rejected.
- **No privilege from absent claims** — `extractRoles()` defaults a missing `roles` claim to least-privilege `ROLE_USER`; `ROLE_SERVICE` must be positively asserted in a signed first-party token (CWE-1188).
- **Defense-in-depth** — explicit `security: is_granted('ROLE_SERVICE')` on the `create_batch_http` operation, so the restriction survives firewall misconfiguration.
- **Tests** — flipped the unit test that encoded the vulnerable behaviour (`testValidateReturnsServiceRoleForOauthTokenWithoutIss` → `testValidateRejectsOauthTokenWithoutIss`) to assert rejection; added regression tests for OAuth2-shaped tokens, the api-audience-without-issuer case, the absent-roles→ROLE_USER default, and the still-valid explicit service token.

### Compatibility
Legitimate first-party tokens (user and service) carry `iss=vilnacrm-user-service`, `aud=vilnacrm-api`, `sid`, and explicit `roles` (see `TestAccessTokenFactory`), so existing Behat/integration ROLE_SERVICE and ROLE_USER flows validate unchanged.

### Local verification
- Unit (validator/dual-authenticator/resolver): **118 passed**
- Deptrac: **0 violations** · Psalm: **no errors** · php-cs-fixer: **clean**

### BMAD
Spec bundle: `specs/security-312-accesstoken-role-service-escalation/` (prd.md, stories.md) with FR/NFR + positive/negative/edge test mapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #312 by rejecting non‑first‑party JWTs and removing implicit `ROLE_SERVICE`. Adds a service‑role gate to bulk import to prevent OAuth2 token escalation.

- **Bug Fixes**
  - Validate `iss` and `aud` for every token; reject tokens without `iss` or with non‑`vilnacrm-api` audience.
  - Never infer `ROLE_SERVICE`; missing `roles` defaults to `ROLE_USER`, explicit `roles: null` is rejected, and `sid` is required when `roles` is present.
  - Add `security: "is_granted('ROLE_SERVICE')"` to `POST /api/users/batch` for defense‑in‑depth.
  - Flip tests to assert secure behavior: OAuth2 `client_credentials` tokens now get 401 at the batch endpoint; add regressions for absent‑roles→`ROLE_USER`, api‑audience without issuer, and `roles: null`.

<sup>Written for commit cec441f7de3da0932e9baba7e93dae3fae48d334. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VilnaCRM-Org/user-service/pull/325?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Bulk user import endpoint now enforces explicit service-role authorization (defense-in-depth).
  * Access tokens are rejected unless issuer and audience are validated; tokens with roles must include a session id.
  * Missing roles now default to least-privileged role instead of inferring service privileges.

* **Documentation**
  * Added PRD and stories detailing token validation and compatibility requirements.

* **Tests**
  * Expanded unit and integration tests to cover new token validation and endpoint authorization behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->