### PR TITLE
fix(security): treat Facebook OAuth email as unverified (#318)

### DIFF
--- a/specs/security-318-facebook-oauth-account-takeover/prd.md
+++ b/specs/security-318-facebook-oauth-account-takeover/prd.md
@@ -29,7 +29,7 @@ without verifying ownership.
    `user@example.com` (Facebook does not verify ownership).
 3. Attacker signs in via "Sign in with Facebook".
 4. The adapter returned `OAuthUserProfile(email=user@example.com,
-   emailVerified=true)`.
+emailVerified=true)`.
 5. `OAuthUserResolver` found no existing Facebook `SocialIdentity`, passed the
    `emailVerified` gate, found the victim by email, and `handleAutoLink()`
    bound the attacker's Facebook identity to the victim's account — even
@@ -46,7 +46,7 @@ handle this correctly. Only Facebook was broken.
 - **FR-1**: `FacebookOAuthProvider::buildProfile()` MUST return an
   `OAuthUserProfile` with `emailVerified === false`, consistent with
   `emailAlwaysVerified() === false`. It MUST NOT hardcode `emailVerified:
-  true`.
+true`.
 - **FR-2**: When a Facebook profile reaches `OAuthUserResolver::resolve()` with
   no pre-existing `SocialIdentity`, the resolver MUST reject it with
   `UnverifiedProviderEmailException` (existing behaviour, now actually
@@ -54,7 +54,7 @@ handle this correctly. Only Facebook was broken.
   flip, no session issuance.
 - **FR-3**: Existing Facebook `SocialIdentity` records (already deliberately
   linked) continue to resolve to their user — the verified-email gate is only
-  reached for *new* identities, so already-linked sign-ins are unaffected.
+  reached for _new_ identities, so already-linked sign-ins are unaffected.
 
 ## Non-Functional Requirements
 

--- a/specs/security-318-facebook-oauth-account-takeover/prd.md
+++ b/specs/security-318-facebook-oauth-account-takeover/prd.md
@@ -1,0 +1,83 @@
+# PRD — Security #318: Facebook OAuth account takeover via forged `emailVerified=true`
+
+## Problem
+
+The Facebook social-login adapter
+(`src/OAuth/Infrastructure/Provider/FacebookOAuthProvider.php`) hardcoded
+`emailVerified: true` in the `OAuthUserProfile` it returned, after only
+checking that `getEmail() !== null`.
+
+This contradicts:
+
+- The adapter's own capability flag `emailAlwaysVerified()` which returns
+  `false` (Facebook cannot guarantee a verified email).
+- The OAuth Social Sign-In ADR
+  (`specs/oauth-social-signin-architecture.md`, sections 3, 4.3, 4.6), which
+  marks Facebook as `emailAlwaysVerified() = false` and requires every provider
+  to supply a **verified** email before the resolver may auto-link or create an
+  account.
+
+The Facebook Graph API exposes no email-verification field
+(`vendor/league/oauth2-facebook/src/Provider/FacebookUser.php`) and never proves
+the user owns the mailbox. Facebook allows a user to set a profile/login email
+without verifying ownership.
+
+### Exploit (CWE-287 — Improper Authentication)
+
+1. Victim has a local account `user@example.com`.
+2. Attacker creates a Facebook account and sets its email to
+   `user@example.com` (Facebook does not verify ownership).
+3. Attacker signs in via "Sign in with Facebook".
+4. The adapter returned `OAuthUserProfile(email=user@example.com,
+   emailVerified=true)`.
+5. `OAuthUserResolver` found no existing Facebook `SocialIdentity`, passed the
+   `emailVerified` gate, found the victim by email, and `handleAutoLink()`
+   bound the attacker's Facebook identity to the victim's account — even
+   marking an unconfirmed victim account `confirmed=true`.
+6. `HandleOAuthCallbackCommandHandler` issued a session/JWT for the victim.
+   The attacker is authenticated as the victim.
+
+GitHub (verified primary email via `/user/emails`), Google
+(`getEmailVerified() === true`) and Twitter (`emailVerified: false`) already
+handle this correctly. Only Facebook was broken.
+
+## Functional Requirements
+
+- **FR-1**: `FacebookOAuthProvider::buildProfile()` MUST return an
+  `OAuthUserProfile` with `emailVerified === false`, consistent with
+  `emailAlwaysVerified() === false`. It MUST NOT hardcode `emailVerified:
+  true`.
+- **FR-2**: When a Facebook profile reaches `OAuthUserResolver::resolve()` with
+  no pre-existing `SocialIdentity`, the resolver MUST reject it with
+  `UnverifiedProviderEmailException` (existing behaviour, now actually
+  exercised for Facebook). No auto-link, no account creation, no confirmation
+  flip, no session issuance.
+- **FR-3**: Existing Facebook `SocialIdentity` records (already deliberately
+  linked) continue to resolve to their user — the verified-email gate is only
+  reached for *new* identities, so already-linked sign-ins are unaffected.
+
+## Non-Functional Requirements
+
+- **NFR-Security**: A single mis-coded adapter must not be able to assert a
+  verified email it cannot prove. Facebook emails are treated as unverified
+  (fail-closed) until a dedicated post-OAuth email-verification flow exists
+  (out of scope). Eliminates the CWE-287 account-takeover vector.
+- **NFR-Compatibility**: No public API, DTO, route, or storage schema change.
+  `OAuthUserProfile` shape is unchanged. The `provider_email_unavailable`
+  (null email) path is preserved. Behaviour for GitHub/Google/Twitter is
+  untouched.
+- **NFR-Maintainability**: Change is a single boolean literal plus an
+  explanatory comment, keeping the adapter aligned with the Twitter adapter.
+  No new classes, directories, or dependencies; hexagonal/DDD boundaries and
+  Deptrac layers unchanged. PHPInsights complexity/quality/style thresholds
+  preserved.
+
+## Out of Scope
+
+- Building a post-OAuth email-verification flow that would let Facebook users
+  auto-link safely.
+- Refactoring `OAuthUserResolver::resolve()` to additionally consume the
+  provider's `emailAlwaysVerified()` capability for defense-in-depth — the
+  resolver already correctly gates on `profile->emailVerified`, and the
+  takeover is fully closed by FR-1 without expanding the resolver signature.
+- Changes to GitHub, Google, or Twitter adapters.

--- a/specs/security-318-facebook-oauth-account-takeover/stories.md
+++ b/specs/security-318-facebook-oauth-account-takeover/stories.md
@@ -1,0 +1,94 @@
+# Stories — Security #318: Facebook OAuth account takeover
+
+## Story 1 — Facebook adapter must not forge a verified email (FR-1, FR-2)
+
+**As** the OAuth resolver
+**I want** the Facebook adapter to report its email as unverified
+**So that** an attacker-controlled, Facebook-unverified email cannot auto-link
+to or confirm a victim's local account.
+
+### Change
+
+`src/OAuth/Infrastructure/Provider/FacebookOAuthProvider.php`
+— `buildProfile()` returns `OAuthUserProfile(..., emailVerified: false)`
+instead of `true`, with a comment documenting why (Graph API cannot prove
+email ownership; aligns with `emailAlwaysVerified() === false`).
+
+### Test mapping
+
+`tests/Unit/OAuth/Infrastructure/Provider/FacebookOAuthProviderTest.php`
+
+- **Positive**: `testFetchProfileReturnsUnverifiedProfileWhenEmailIsPresent`
+  — a present email yields a profile carrying email/name/providerId
+  (email is still surfaced; the flow does not regress to email-unavailable).
+- **Negative (regression for #318)**:
+  `testFetchProfileMarksEmailUnverifiedToPreventAutoLinkTakeover` — asserts
+  `$profile->emailVerified === false`. This FAILS on the old hardcoded `true`
+  and PASSES with the fix; it is the direct takeover regression guard.
+- **Edge**: `testFetchProfileThrowsEmailUnavailableWhenEmailIsNull` (unchanged)
+  — a null email still throws `OAuthEmailUnavailableException`
+  (`provider_email_unavailable`), proving the null path is preserved.
+- **Edge**: `testFetchProfileUsesEmptyStringWhenNameIsNull` (unchanged) —
+  a null name still maps to `''`.
+
+### End-to-end gate already enforced by the resolver (FR-2)
+
+`tests/Unit/OAuth/Application/Resolver/OAuthUserResolverTest.php` (unchanged,
+pre-existing) proves the consequence of `emailVerified === false`:
+
+- `testResolveRejectsUnverifiedEmailBeforeAutoLink` — no auto-link, no
+  `findByEmail`, no `save`; throws `UnverifiedProviderEmailException`.
+- `testResolveRejectsUnverifiedEmailBeforeNewUserCreation` — no account
+  creation; throws `UnverifiedProviderEmailException`.
+
+## Story 2 — Already-linked Facebook identities keep working (FR-3)
+
+**As** a user who previously linked Facebook
+**I want** my existing `SocialIdentity` to keep resolving
+**So that** the security fix does not lock out legitimate linked accounts.
+
+### Test mapping
+
+`tests/Unit/OAuth/Application/Resolver/OAuthUserResolverTest.php`
+(unchanged, pre-existing):
+
+- **Positive**: `testResolveReturnsExistingUserWhenIdentityExists` — when a
+  `SocialIdentity(provider, providerId)` already exists, resolution returns the
+  linked user *before* the `emailVerified` gate, so unverified Facebook emails
+  do not break already-linked sign-ins.
+
+## Verification commands
+
+Run from `/home/kravtsov/Projects/secfix-318` via one-off containers
+(image `secfix-312-php:latest`, read-only shared vendor):
+
+```bash
+# Unit (OAuth/Facebook/resolver)
+docker run --rm -v /home/kravtsov/Projects/secfix-318:/app \
+  -v /home/kravtsov/Projects/user-service/vendor:/app/vendor:ro \
+  -w /app -e APP_ENV=test --entrypoint sh secfix-312-php:latest -lc \
+  'php -d memory_limit=-1 vendor/bin/phpunit --testsuite=Unit \
+   --filter "OAuthUser|Facebook|OAuth" --no-coverage'
+
+# Architecture boundaries
+docker run --rm ... --entrypoint sh secfix-312-php:latest -lc \
+  'php -d memory_limit=-1 vendor/bin/deptrac analyse \
+   --config-file=deptrac.yaml --no-progress'
+
+# Static analysis (changed files)
+docker run --rm ... --entrypoint sh secfix-312-php:latest -lc \
+  'php -d memory_limit=-1 vendor/bin/psalm --no-cache --no-progress \
+   src/OAuth/Infrastructure/Provider/FacebookOAuthProvider.php \
+   tests/Unit/OAuth/Infrastructure/Provider/FacebookOAuthProviderTest.php'
+
+# Code style (changed files)
+docker run --rm ... --entrypoint sh secfix-312-php:latest -lc \
+  'PHP_CS_FIXER_IGNORE_ENV=1 vendor/bin/php-cs-fixer fix --dry-run \
+   --allow-risky=yes --config=.php-cs-fixer.dist.php \
+   --path-mode=intersection \
+   src/OAuth/Infrastructure/Provider/FacebookOAuthProvider.php \
+   tests/Unit/OAuth/Infrastructure/Provider/FacebookOAuthProviderTest.php'
+```
+
+**Pass criteria**: phpunit OK, deptrac `Violations 0`, psalm `No errors`,
+php-cs-fixer `0 of N files`.

--- a/specs/security-318-facebook-oauth-account-takeover/stories.md
+++ b/specs/security-318-facebook-oauth-account-takeover/stories.md
@@ -54,7 +54,7 @@ pre-existing) proves the consequence of `emailVerified === false`:
 
 - **Positive**: `testResolveReturnsExistingUserWhenIdentityExists` — when a
   `SocialIdentity(provider, providerId)` already exists, resolution returns the
-  linked user *before* the `emailVerified` gate, so unverified Facebook emails
+  linked user _before_ the `emailVerified` gate, so unverified Facebook emails
   do not break already-linked sign-ins.
 
 ## Verification commands

--- a/src/OAuth/Infrastructure/Provider/FacebookOAuthProvider.php
+++ b/src/OAuth/Infrastructure/Provider/FacebookOAuthProvider.php
@@ -118,11 +118,15 @@ final class FacebookOAuthProvider implements OAuthProviderInterface
             throw new OAuthEmailUnavailableException(self::PROVIDER_NAME);
         }
 
+        // Facebook's Graph API exposes no email-verification field and never
+        // proves the user owns the mailbox, so the email cannot be trusted for
+        // auto-linking. Mark it unverified (matching emailAlwaysVerified()
+        // === false) so the resolver rejects it via UnverifiedProviderEmailException.
         return new OAuthUserProfile(
             email: $owner->getEmail(),
             name: $owner->getName() ?? '',
             providerId: (string) $owner->getId(),
-            emailVerified: true,
+            emailVerified: false,
         );
     }
 }

--- a/tests/Unit/OAuth/Infrastructure/Provider/FacebookOAuthProviderTest.php
+++ b/tests/Unit/OAuth/Infrastructure/Provider/FacebookOAuthProviderTest.php
@@ -132,7 +132,7 @@ final class FacebookOAuthProviderTest extends UnitTestCase
         $this->provider->exchangeCode($invalidCode, null);
     }
 
-    public function testFetchProfileReturnsVerifiedProfileWhenEmailIsPresent(): void
+    public function testFetchProfileReturnsUnverifiedProfileWhenEmailIsPresent(): void
     {
         $email = $this->faker->safeEmail();
         $name = $this->faker->name();
@@ -151,7 +151,24 @@ final class FacebookOAuthProviderTest extends UnitTestCase
         $this->assertSame($email, $profile->email);
         $this->assertSame($name, $profile->name);
         $this->assertSame($id, $profile->providerId);
-        $this->assertTrue($profile->emailVerified);
+    }
+
+    /**
+     * Regression for #318: Facebook cannot prove email ownership, so the
+     * profile must be flagged unverified to block account-takeover auto-link.
+     */
+    public function testFetchProfileMarksEmailUnverifiedToPreventAutoLinkTakeover(): void
+    {
+        $owner = $this->createMock(FacebookUser::class);
+        $owner->method('getEmail')->willReturn($this->faker->safeEmail());
+        $owner->method('getName')->willReturn($this->faker->name());
+        $owner->method('getId')->willReturn($this->faker->uuid());
+
+        $this->facebook->method('getResourceOwner')->willReturn($owner);
+
+        $profile = $this->provider->fetchProfile($this->faker->sha256());
+
+        $this->assertFalse($profile->emailVerified);
     }
 
     public function testFetchProfileThrowsEmailUnavailableWhenEmailIsNull(): void


### PR DESCRIPTION
## Security fix — Closes #318

### Vulnerability (HIGH, CWE-287 — Improper Authentication)

`FacebookOAuthProvider::buildProfile()` hardcoded `emailVerified: true` after only checking that the email was non-null. Facebook's Graph API exposes **no** email-verification field (`vendor/league/oauth2-facebook/.../FacebookUser.php`) and never proves the user owns the mailbox — Facebook lets a user set a profile email without verifying ownership.

This contradicts the adapter's own `emailAlwaysVerified() === false` capability and the OAuth Social Sign-In ADR (`specs/oauth-social-signin-architecture.md`), which require a *verified* email before the resolver may auto-link or create an account.

**Exploit:** an attacker creates a Facebook account with a victim's email, signs in via "Sign in with Facebook", and `OAuthUserResolver` finds no existing Facebook `SocialIdentity`, passes the `emailVerified` gate, finds the victim by email, and `handleAutoLink()` binds the attacker's Facebook identity to the victim's account (even flipping an unconfirmed account to `confirmed`). `HandleOAuthCallbackCommandHandler` then issues a session/JWT for the victim — account takeover. GitHub, Google, and Twitter already handle this correctly; only Facebook was broken.

### Fix

`FacebookOAuthProvider::buildProfile()` now returns `emailVerified: false` (mirroring the Twitter adapter), consistent with `emailAlwaysVerified() === false`. The resolver already rejects unverified-email profiles with `UnverifiedProviderEmailException` *before* any auto-link, account creation, confirmation flip, or session issuance — so the takeover path is fully closed. Already-linked Facebook `SocialIdentity` records resolve before the gate and are unaffected. Minimal change: one boolean literal + explanatory comment + tests.

### Local verification (one-off `secfix-312-php` container, `APP_ENV=test`)

- phpunit Unit (filter `OAuthUser|Facebook|OAuth`): **OK (387 tests)**
- phpunit Unit (full suite): **OK (2259 tests)**
- deptrac analyse: **Violations 0**
- psalm (changed files): **No errors**
- php-cs-fixer (changed files): **0 of 2 files**

New regression test `testFetchProfileMarksEmailUnverifiedToPreventAutoLinkTakeover` **fails** on the old hardcoded `true` and **passes** with the fix (verified by temporarily reverting).

### BMAD spec

`specs/security-318-facebook-oauth-account-takeover/` (`prd.md` + `stories.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treat Facebook OAuth emails as unverified to block account takeover via forged “verified” emails. Fixes the provider returning `emailVerified: true` even though Facebook can’t prove email ownership (addresses #318).

- **Bug Fixes**
  - Set `emailVerified: false` in `FacebookOAuthProvider::buildProfile()` to match `emailAlwaysVerified() === false`.
  - The resolver now enforces the unverified-email gate for new Facebook sign-ins before any auto-link, account creation, confirmation, or session.
  - Existing linked Facebook identities continue to sign in normally.
  - Added a regression test to ensure the profile is marked unverified; updated Facebook provider tests and added security specs.

- **Refactors**
  - Fixed linting issues; no behavior changes.

<sup>Written for commit 1fd7d6fe7c74954f7e0d11970bdb0244a8401129. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VilnaCRM-Org/user-service/pull/326?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

