### PR TITLE
fix(security): trust proxy hop so IP rate limits key on real client IP (#316)

### DIFF
--- a/.env
+++ b/.env
@@ -9,8 +9,8 @@ API_PREFIX=/api
 # returns the real client IP for IP-keyed rate limiters and X-Forwarded-For
 # from untrusted clients is ignored. In production override TRUSTED_PROXIES
 # with the exact proxy CIDR. Only X-Forwarded-For is trusted.
-TRUSTED_PROXIES=REMOTE_ADDR
 TRUSTED_HEADERS=x-forwarded-for
+TRUSTED_PROXIES=REMOTE_ADDR
 ###< symfony/framework-bundle ###
 
 ###> doctrine/mongodb-odm-bundle ###

--- a/.env
+++ b/.env
@@ -4,6 +4,13 @@ APP_SECRET=2e222659c5b006df8d0e68cc33913706
 API_BASE_URL=https://localhost
 API_URL=https://api.vilnacrm.com
 API_PREFIX=/api
+# Trust only the directly-connected reverse proxy (Caddy/FrankenPHP, AWS App
+# Runner load balancer). REMOTE_ADDR trusts a single hop so getClientIp()
+# returns the real client IP for IP-keyed rate limiters and X-Forwarded-For
+# from untrusted clients is ignored. In production override TRUSTED_PROXIES
+# with the exact proxy CIDR. Only X-Forwarded-For is trusted.
+TRUSTED_PROXIES=REMOTE_ADDR
+TRUSTED_HEADERS=x-forwarded-for
 ###< symfony/framework-bundle ###
 
 ###> doctrine/mongodb-odm-bundle ###

--- a/config/packages/framework.yaml
+++ b/config/packages/framework.yaml
@@ -6,6 +6,15 @@ framework:
   default_locale: en
   enabled_locales: [en, uk]
   secret: '%env(APP_SECRET)%'
+  # Trust only the directly-connected reverse proxy (Caddy/FrankenPHP, AWS App
+  # Runner LB) so getClientIp() returns the real client IP for IP-keyed rate
+  # limiters instead of the shared load-balancer address. The default REMOTE_ADDR
+  # token trusts a single hop, so X-Forwarded-For from untrusted clients is
+  # ignored and cannot be spoofed. Override TRUSTED_PROXIES with the exact proxy
+  # CIDR in production. Only X-Forwarded-For is trusted; other X-Forwarded-*
+  # headers are ignored.
+  trusted_proxies: '%env(TRUSTED_PROXIES)%'
+  trusted_headers: '%env(TRUSTED_HEADERS)%'
   #csrf_protection: true
   http_method_override: false
   serializer:

--- a/config/packages/test/framework.yaml
+++ b/config/packages/test/framework.yaml
@@ -1,2 +1,3 @@
 framework:
   trusted_proxies: '127.0.0.1,REMOTE_ADDR'
+  trusted_headers: 'x-forwarded-for'

--- a/specs/security-316-rate-limit-untrusted-client-ip/prd.md
+++ b/specs/security-316-rate-limit-untrusted-client-ip/prd.md
@@ -1,0 +1,72 @@
+# PRD — Rate limiters keyed on untrusted client IP (#316)
+
+## Problem
+
+The user-service runs behind a reverse proxy (Caddy/FrankenPHP) and, in
+production, behind the AWS App Runner managed load balancer. Every per-IP rate
+limiter (`signin_ip`, `twofa_verification_ip`, `registration`, `refresh_token`,
+`email_confirmation`, `password_reset_confirm`, `oauth_social_*`,
+`user_collection`, `resend_confirmation`, and the `global_api_*` buckets) builds
+its key from `Symfony\Component\HttpFoundation\Request::getClientIp()` inside
+`ApiRateLimitRequestResolver::buildIpKey()` and
+`ApiRateLimitAuthTargetResolver::buildIpKey()`.
+
+The production framework configuration (`config/packages/framework.yaml`) never
+set `framework.trusted_proxies` or `framework.trusted_headers`. With no trusted
+proxies, `getClientIp()` returns `REMOTE_ADDR`, which behind App Runner is the
+load balancer's internal IP — the **same value for every external client**.
+Consequences (CWE-307, Improper Restriction of Excessive Authentication
+Attempts):
+
+- All IP-keyed limiters collapse onto a single shared bucket keyed on the LB IP.
+- A single noisy client (or attacker) can exhaust the shared bucket and deny
+  service to the whole tenant (self-inflicted DoS).
+- The per-IP anti-automation throttles provide no per-attacker isolation; an
+  attacker is indistinguishable from legitimate traffic.
+
+The naive "fix" of trusting the proxy without pinning the proxy hop is equally
+dangerous: `getClientIp()` would then honour client-supplied `X-Forwarded-For`,
+making the key fully attacker-controlled and trivially spoofable (a fresh bucket
+per request).
+
+## Functional Requirements
+
+- **FR-1**: The production framework configuration MUST explicitly configure
+  `framework.trusted_proxies` and `framework.trusted_headers` so that
+  `getClientIp()` resolves to the real client IP rather than the load-balancer
+  address.
+- **FR-2**: Only the directly-connected proxy hop MUST be trusted. The default
+  (`TRUSTED_PROXIES=REMOTE_ADDR`) trusts a single hop; operators MUST be able to
+  override it with the exact proxy/App Runner CIDR via the `TRUSTED_PROXIES`
+  environment variable.
+- **FR-3**: Only the `X-Forwarded-For` header MUST be trusted
+  (`TRUSTED_HEADERS=x-forwarded-for`). Other `X-Forwarded-*` headers (host,
+  proto, port, prefix) MUST NOT be trusted.
+- **FR-4**: An `X-Forwarded-For` header originating from an untrusted client
+  (whose `REMOTE_ADDR` is not a trusted proxy) MUST be ignored; the IP key MUST
+  fall back to `REMOTE_ADDR`.
+- **FR-5**: When no proxy is trusted, client-supplied `X-Forwarded-For` MUST be
+  ignored entirely (no blanket XFF trust).
+
+## Non-Functional Requirements
+
+- **NFR-Security**: The IP dimension of the anti-automation controls MUST be
+  spoof-resistant. The trusted-header set MUST be minimal (`x-forwarded-for`
+  only) and the trusted-proxy set MUST be a single, configurable hop — never an
+  open/blanket trust. (CWE-307, OWASP API4:2023 Unrestricted Resource
+  Consumption.)
+- **NFR-Compatibility**: Existing rate-limiter behaviour and the integration
+  test contract (`ip:127.0.0.1` keys for local requests with no XFF) MUST remain
+  unchanged. No change to limiter names, thresholds, or env-driven limits.
+- **NFR-Maintainability**: The fix MUST be configuration-driven (env vars with
+  prod-safe defaults), introduce no new directories or classes outside existing
+  conventions, and keep PHPInsights complexity 94% / quality + style 100% and
+  Deptrac at 0 violations. Domain layer MUST stay framework-free.
+
+## Out of Scope
+
+- Re-architecting the limiter key strategy (email/user buckets, lockout logic).
+- Changing rate-limit thresholds or intervals.
+- The unrelated email/user-keyed bypass findings tracked separately.
+- Infrastructure-as-code provisioning of the exact App Runner CIDR (operators
+  set `TRUSTED_PROXIES` at deploy time).

--- a/specs/security-316-rate-limit-untrusted-client-ip/stories.md
+++ b/specs/security-316-rate-limit-untrusted-client-ip/stories.md
@@ -1,0 +1,93 @@
+# Stories — Rate limiters keyed on untrusted client IP (#316)
+
+## Story 1 — Configure trusted proxies and headers in production framework config
+
+**As** the platform operator, **I want** the framework to trust only the
+directly-connected reverse proxy and only the `X-Forwarded-For` header **so that**
+`getClientIp()` returns the real client IP for IP-keyed rate limiters and
+forged `X-Forwarded-For` is ignored.
+
+**Changes**
+
+- `config/packages/framework.yaml`: add
+  `trusted_proxies: '%env(TRUSTED_PROXIES)%'` and
+  `trusted_headers: '%env(TRUSTED_HEADERS)%'`.
+- `.env`: add prod-safe defaults `TRUSTED_PROXIES=REMOTE_ADDR` (single trusted
+  hop) and `TRUSTED_HEADERS=x-forwarded-for`.
+- `config/packages/test/framework.yaml`: pin `trusted_headers: 'x-forwarded-for'`
+  alongside the existing `trusted_proxies` so the test env applies the same
+  spoof-resistant header set.
+
+**Maps to**: FR-1, FR-2, FR-3, NFR-Security, NFR-Maintainability.
+
+**Test mapping**
+
+- Positive: `ApiRateLimitTrustedProxyIpKeyTest::testSignInIpKeyUsesRealClientIpWhenProxyIsTrusted`
+  and `::testRegistrationIpKeyUsesRealClientIpWhenProxyIsTrusted` — trusted proxy
+  + `X-Forwarded-For` ⇒ key uses the real client IP.
+- Negative (spoof): `::testForgedForwardedForFromUntrustedClientIsIgnored` —
+  untrusted client's forged `X-Forwarded-For` is ignored; key falls back to
+  `REMOTE_ADDR`.
+- Edge: `::testForwardedForIsIgnoredWhenNoProxyIsTrusted` — no trusted proxy ⇒
+  client-supplied `X-Forwarded-For` is ignored entirely (no blanket trust).
+- Regression: existing `ApiRateLimitListenerIntegrationTest` and resolver suites
+  keep `ip:127.0.0.1` for local requests with no XFF (NFR-Compatibility).
+
+**Verification commands** (one-off containers; vendor mounted read-only):
+
+```
+docker run --rm -v /home/kravtsov/Projects/secfix-316:/app \
+  -v /home/kravtsov/Projects/user-service/vendor:/app/vendor:ro -w /app \
+  -e APP_ENV=test --entrypoint sh secfix-312-php:latest -lc \
+  'php -d memory_limit=-1 vendor/bin/phpunit --testsuite=Unit --filter "RateLimit" --no-coverage'
+```
+
+## Story 2 — Regression tests proving the spoof-resistant IP key
+
+**As** a maintainer, **I want** unit tests that fail when IP-keyed limiters trust
+an untrusted client IP **so that** the fix cannot silently regress.
+
+**Changes**
+
+- `tests/Unit/Shared/Application/Resolver/RateLimit/ApiRateLimitTrustedProxyIpKeyTest.php`
+  (new): exercises both `ApiRateLimitAuthTargetResolver` (`signin_ip`) and
+  `ApiRateLimitRequestResolver` (`registration`) `buildIpKey()` paths under
+  `Request::setTrustedProxies()`, restoring global trusted-proxy state in
+  `tearDown()`.
+
+**Maps to**: FR-4, FR-5, NFR-Security.
+
+**Test mapping**
+
+- Positive / Negative / Edge as listed in Story 1.
+
+**Verification commands**
+
+```
+# Unit (full suite — no regressions)
+docker run --rm ... -e APP_ENV=test --entrypoint sh secfix-312-php:latest -lc \
+  'php -d memory_limit=-1 vendor/bin/phpunit --testsuite=Unit --no-coverage'
+
+# Deptrac (0 violations)
+docker run --rm ... --entrypoint sh secfix-312-php:latest -lc \
+  'php -d memory_limit=-1 vendor/bin/deptrac analyse --config-file=deptrac.yaml --no-progress'
+
+# Psalm (no errors)
+docker run --rm ... --entrypoint sh secfix-312-php:latest -lc \
+  'php -d memory_limit=-1 vendor/bin/psalm --no-cache --no-progress \
+   tests/Unit/Shared/Application/Resolver/RateLimit/ApiRateLimitTrustedProxyIpKeyTest.php'
+
+# PHP CS Fixer (0 of N files)
+docker run --rm ... --entrypoint sh secfix-312-php:latest -lc \
+  'PHP_CS_FIXER_IGNORE_ENV=1 vendor/bin/php-cs-fixer fix --dry-run --allow-risky=yes \
+   --config=.php-cs-fixer.dist.php --path-mode=intersection \
+   tests/Unit/Shared/Application/Resolver/RateLimit/ApiRateLimitTrustedProxyIpKeyTest.php'
+```
+
+## Local verification results
+
+- PHPUnit Unit (filter RateLimit): OK (143 tests, 258 assertions)
+- PHPUnit Unit (full): OK (2262 tests, 6215 assertions)
+- Deptrac: Errors 0
+- Psalm: No errors found
+- PHP CS Fixer: Found 0 of 1 files that can be fixed

--- a/specs/security-316-rate-limit-untrusted-client-ip/stories.md
+++ b/specs/security-316-rate-limit-untrusted-client-ip/stories.md
@@ -24,7 +24,7 @@ forged `X-Forwarded-For` is ignored.
 
 - Positive: `ApiRateLimitTrustedProxyIpKeyTest::testSignInIpKeyUsesRealClientIpWhenProxyIsTrusted`
   and `::testRegistrationIpKeyUsesRealClientIpWhenProxyIsTrusted` — trusted proxy
-  + `X-Forwarded-For` ⇒ key uses the real client IP.
+  - `X-Forwarded-For` ⇒ key uses the real client IP.
 - Negative (spoof): `::testForgedForwardedForFromUntrustedClientIsIgnored` —
   untrusted client's forged `X-Forwarded-For` is ignored; key falls back to
   `REMOTE_ADDR`.

--- a/specs/security-316-rate-limit-untrusted-client-ip/stories.md
+++ b/specs/security-316-rate-limit-untrusted-client-ip/stories.md
@@ -35,10 +35,10 @@ forged `X-Forwarded-For` is ignored.
 
 **Verification commands** (one-off containers; vendor mounted read-only):
 
-```
+```bash
 docker run --rm -v /home/kravtsov/Projects/secfix-316:/app \
   -v /home/kravtsov/Projects/user-service/vendor:/app/vendor:ro -w /app \
-  -e APP_ENV=test --entrypoint sh secfix-312-php:latest -lc \
+  -e APP_ENV=test --entrypoint sh secfix-316-php:latest -lc \
   'php -d memory_limit=-1 vendor/bin/phpunit --testsuite=Unit --filter "RateLimit" --no-coverage'
 ```
 
@@ -63,22 +63,22 @@ an untrusted client IP **so that** the fix cannot silently regress.
 
 **Verification commands**
 
-```
+```bash
 # Unit (full suite — no regressions)
-docker run --rm ... -e APP_ENV=test --entrypoint sh secfix-312-php:latest -lc \
+docker run --rm ... -e APP_ENV=test --entrypoint sh secfix-316-php:latest -lc \
   'php -d memory_limit=-1 vendor/bin/phpunit --testsuite=Unit --no-coverage'
 
 # Deptrac (0 violations)
-docker run --rm ... --entrypoint sh secfix-312-php:latest -lc \
+docker run --rm ... --entrypoint sh secfix-316-php:latest -lc \
   'php -d memory_limit=-1 vendor/bin/deptrac analyse --config-file=deptrac.yaml --no-progress'
 
 # Psalm (no errors)
-docker run --rm ... --entrypoint sh secfix-312-php:latest -lc \
+docker run --rm ... --entrypoint sh secfix-316-php:latest -lc \
   'php -d memory_limit=-1 vendor/bin/psalm --no-cache --no-progress \
    tests/Unit/Shared/Application/Resolver/RateLimit/ApiRateLimitTrustedProxyIpKeyTest.php'
 
 # PHP CS Fixer (0 of N files)
-docker run --rm ... --entrypoint sh secfix-312-php:latest -lc \
+docker run --rm ... --entrypoint sh secfix-316-php:latest -lc \
   'PHP_CS_FIXER_IGNORE_ENV=1 vendor/bin/php-cs-fixer fix --dry-run --allow-risky=yes \
    --config=.php-cs-fixer.dist.php --path-mode=intersection \
    tests/Unit/Shared/Application/Resolver/RateLimit/ApiRateLimitTrustedProxyIpKeyTest.php'

--- a/tests/Unit/Shared/Application/Resolver/RateLimit/ApiRateLimitTrustedProxyIpKeyTest.php
+++ b/tests/Unit/Shared/Application/Resolver/RateLimit/ApiRateLimitTrustedProxyIpKeyTest.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Shared\Application\Resolver\RateLimit;
+
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Regression tests for issue #316: IP-keyed rate limiters must derive the
+ * client IP from the spoof-resistant value resolved by Symfony's trusted-proxy
+ * handling, not from a blanket-trusted X-Forwarded-For header.
+ *
+ * When only the directly-connected proxy hop is trusted (a single proxy CIDR
+ * plus the x-forwarded-for header, matching the spoof-resistant configuration
+ * of config/packages/framework.yaml), the resolvers must key on the real
+ * client IP. A forged X-Forwarded-For sent from an untrusted client must be
+ * ignored.
+ */
+final class ApiRateLimitTrustedProxyIpKeyTest extends RateLimitClientTestCase
+{
+    /**
+     * @var array<int, string>
+     */
+    private array $previousTrustedProxies = [];
+
+    private int $previousTrustedHeaderSet = 0;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->previousTrustedProxies = Request::getTrustedProxies();
+        $this->previousTrustedHeaderSet = Request::getTrustedHeaderSet();
+    }
+
+    #[\Override]
+    protected function tearDown(): void
+    {
+        Request::setTrustedProxies(
+            $this->previousTrustedProxies,
+            $this->previousTrustedHeaderSet
+        );
+
+        parent::tearDown();
+    }
+
+    public function testSignInIpKeyUsesRealClientIpWhenProxyIsTrusted(): void
+    {
+        $this->trustDirectlyConnectedProxy();
+
+        $proxyIp = '10.0.0.5';
+        $realClientIp = '203.0.113.42';
+        $request = $this->createSignInRequest($proxyIp, $realClientIp);
+
+        $result = $this->createAuthTargetResolver()->resolve($request);
+
+        self::assertSame('signin_ip', $result[0]['name']);
+        self::assertSame('ip:' . $realClientIp, $result[0]['key']);
+    }
+
+    public function testRegistrationIpKeyUsesRealClientIpWhenProxyIsTrusted(): void
+    {
+        $this->trustDirectlyConnectedProxy();
+
+        $proxyIp = '10.0.0.5';
+        $realClientIp = '203.0.113.7';
+        $request = $this->createRegistrationRequest($proxyIp, $realClientIp);
+
+        $result = $this->createRequestResolver()->resolveEndpointLimiters($request);
+
+        self::assertSame('registration', $result[0]['name']);
+        self::assertSame('ip:' . $realClientIp, $result[0]['key']);
+    }
+
+    public function testForgedForwardedForFromUntrustedClientIsIgnored(): void
+    {
+        $this->trustDirectlyConnectedProxy();
+
+        $untrustedClientIp = '198.51.100.10';
+        $spoofedIp = '203.0.113.99';
+        $request = $this->createSignInRequest($untrustedClientIp, $spoofedIp);
+
+        $result = $this->createAuthTargetResolver()->resolve($request);
+
+        self::assertSame('ip:' . $untrustedClientIp, $result[0]['key']);
+        self::assertNotSame('ip:' . $spoofedIp, $result[0]['key']);
+    }
+
+    public function testForwardedForIsIgnoredWhenNoProxyIsTrusted(): void
+    {
+        Request::setTrustedProxies([], Request::HEADER_X_FORWARDED_FOR);
+
+        $remoteAddr = '10.0.0.5';
+        $spoofedIp = '203.0.113.123';
+        $request = $this->createSignInRequest($remoteAddr, $spoofedIp);
+
+        $result = $this->createAuthTargetResolver()->resolve($request);
+
+        self::assertSame('ip:' . $remoteAddr, $result[0]['key']);
+    }
+
+    private function trustDirectlyConnectedProxy(): void
+    {
+        Request::setTrustedProxies(['10.0.0.5'], Request::HEADER_X_FORWARDED_FOR);
+    }
+
+    private function createSignInRequest(string $remoteAddr, string $forwardedFor): Request
+    {
+        return Request::create(
+            '/api/signin',
+            'POST',
+            [],
+            [],
+            [],
+            [
+                'REMOTE_ADDR' => $remoteAddr,
+                'HTTP_X_FORWARDED_FOR' => $forwardedFor,
+            ]
+        );
+    }
+
+    private function createRegistrationRequest(string $remoteAddr, string $forwardedFor): Request
+    {
+        return Request::create(
+            '/api/users',
+            'POST',
+            [],
+            [],
+            [],
+            [
+                'REMOTE_ADDR' => $remoteAddr,
+                'HTTP_X_FORWARDED_FOR' => $forwardedFor,
+            ]
+        );
+    }
+}


### PR DESCRIPTION
## Security fix — Closes #316

### Vulnerability (HIGH, CWE-307)
IP-keyed rate limiters (`signin_ip`, `twofa_verification_ip`, `registration`, `refresh_token`, `email_confirmation`, `password_reset_confirm`, `oauth_social_*`, `user_collection`, `resend_confirmation`, and `global_api_*`) build their key from `Request::getClientIp()`. Production `config/packages/framework.yaml` never set `trusted_proxies`/`trusted_headers`, so behind Caddy/FrankenPHP and the AWS App Runner load balancer `getClientIp()` returned `REMOTE_ADDR` — the LB's internal IP, **identical for every external client**. Every per-IP bucket therefore collapsed onto a single shared bucket: one noisy client could lock out the whole tenant (self-inflicted DoS) and no attacker could be isolated. Naively trusting the proxy without pinning the hop would instead make the key fully spoofable via client-supplied `X-Forwarded-For`.

### Fix
- `config/packages/framework.yaml`: explicitly configure `trusted_proxies: '%env(TRUSTED_PROXIES)%'` and `trusted_headers: '%env(TRUSTED_HEADERS)%'`.
- `.env`: prod-safe defaults `TRUSTED_PROXIES=REMOTE_ADDR` (trusts a single directly-connected hop) and `TRUSTED_HEADERS=x-forwarded-for` (only `X-Forwarded-For` is trusted; host/proto/port/prefix are not). Operators override `TRUSTED_PROXIES` with the exact proxy/App Runner CIDR in production.
- `config/packages/test/framework.yaml`: pin the same `trusted_headers: 'x-forwarded-for'` set.
- New regression unit tests (`ApiRateLimitTrustedProxyIpKeyTest`) covering positive (trusted proxy ⇒ real client IP), spoof (untrusted client's forged `X-Forwarded-For` ignored), and no-trust (blanket XFF ignored) paths for both resolvers' `buildIpKey()`.

Result: `getClientIp()` returns the real client IP; forged `X-Forwarded-For` from untrusted clients is dropped; local requests with no XFF still key on `REMOTE_ADDR`, preserving existing limiter and integration-test behaviour.

### Local verification (one-off containers, vendor read-only)
- PHPUnit Unit (filter `RateLimit`): **OK (143 tests, 258 assertions)**
- PHPUnit Unit (full): **OK (2262 tests, 6215 assertions)**
- Deptrac: **Errors 0**
- Psalm: **No errors found**
- PHP CS Fixer: **0 of 1 files**

### BMAD spec
`specs/security-316-rate-limit-untrusted-client-ip/` (`prd.md`, `stories.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes IP-based rate limiting behind a proxy by trusting only the directly connected hop and `X-Forwarded-For`, so keys use the real client IP and spoofed headers are ignored. Prevents shared buckets on the load balancer IP and restores per-client isolation.

- **Bug Fixes**
  - Configure `framework.trusted_proxies` and `framework.trusted_headers` via env.
  - Defaults: `TRUSTED_PROXIES=REMOTE_ADDR`, `TRUSTED_HEADERS=x-forwarded-for`.
  - Test env pins `trusted_headers: 'x-forwarded-for'`.
  - Add regression tests for trusted proxy resolution, spoofed XFF from untrusted clients, and no-trust fallback.
  - Address review feedback (no functional changes): reorder `.env` keys and fix `stories.md` Docker tag/code fences.

- **Migration**
  - In production, set `TRUSTED_PROXIES` to your reverse proxy/App Runner CIDR. No other changes required.

<sup>Written for commit c6cad40750ae981f8fbe828ef06656f5286f14e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VilnaCRM-Org/user-service/pull/328?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed rate limiting to correctly identify actual client IP addresses when requests pass through reverse proxies, preventing legitimate users from being incorrectly rate limited as a single entity.

* **New Features**
  * Added configurable proxy trust settings via environment variables for flexible deployment configurations.

* **Documentation**
  * Added specifications and test documentation for rate-limiter proxy handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->