### PR TITLE
fix(security): apply per-endpoint rate limiters to GraphQL auth mutations (#315)

### DIFF
--- a/specs/security-315-graphql-bypasses-rate-limiters/prd.md
+++ b/specs/security-315-graphql-bypasses-rate-limiters/prd.md
@@ -1,0 +1,84 @@
+# PRD — Security #315: GraphQL endpoint bypasses per-endpoint rate limiters
+
+## Problem
+
+The VilnaCRM user-service enforces tight per-endpoint authentication rate limits
+(sign-in by IP and by email, refresh-token, 2FA verification, password-reset
+confirmation) through `ApiRateLimitListener`. That listener selects which limiters
+to consume by matching the **REST URL path** of the incoming request
+(`ApiRateLimitRequestResolver` / `ApiRateLimitAuthTargetResolver`):
+
+- `signin_ip` (10/min) + `signin_email` (5/min) → `POST /api/signin`
+- `refresh_token` → `POST /api/token`
+- `twofa_verification_ip` + `twofa_verification_user` → `POST /api/signin/2fa`
+- `password_reset_confirm` → `POST /api/reset-password/confirm`
+- `signout` / `signout_all` → `POST /api/signout`, `POST /api/signout/all`
+
+API Platform also exposes the very same operations as GraphQL mutations
+(`signIn`, `refreshToken`, `completeTwoFactor`, `confirmPasswordReset`, `signOut`,
+`signOutAll`) served at a single endpoint, `POST /api/graphql`, which is
+`PUBLIC_ACCESS`. Because `/api/graphql` matches none of the REST path checks,
+`resolveEndpointLimiters` returns no endpoint limiters for GraphQL traffic and
+only the loose `global_api_anonymous` limiter (~100 req/min/IP) applies.
+
+**Impact (CWE-799, HIGH):** An attacker performs credential stuffing /
+password spraying against the `signIn` GraphQL mutation, 2FA code brute-forcing
+against `completeTwoFactor`, refresh-token abuse, or password-reset token guessing
+against `confirmPasswordReset`, fully bypassing the dedicated per-IP and
+per-identity throttles. The GraphQL path becomes a parallel, under-protected door
+to the same sensitive auth actions.
+
+## Functional requirements
+
+- **FR-1**: Rate-limit resolution MUST treat sensitive GraphQL mutations as
+  equivalent to their REST counterparts. A `POST /api/graphql` request whose
+  query contains `signIn` MUST consume the `signin_ip` limiter (keyed by client IP)
+  and, when an email is present, the `signin_email` limiter (keyed by lowercased
+  email) — identical names/keys to `POST /api/signin`.
+- **FR-2**: A GraphQL `refreshToken` mutation MUST consume the `refresh_token`
+  limiter keyed by client IP, matching `POST /api/token`.
+- **FR-3**: A GraphQL `completeTwoFactor` mutation MUST consume the
+  `twofa_verification_ip` limiter keyed by client IP and, when a resolvable
+  `pendingSessionId` maps to a user, the `twofa_verification_user` limiter keyed by
+  that user id, matching `POST /api/signin/2fa`.
+- **FR-4**: A GraphQL `confirmPasswordReset` mutation MUST consume the
+  `password_reset_confirm` limiter keyed by client IP, matching
+  `POST /api/reset-password/confirm`.
+- **FR-5**: GraphQL `signOut` / `signOutAll` mutations MUST consume the
+  `signout` / `signout_all` limiters keyed by the authenticated JWT subject,
+  matching their REST endpoints; when the request is unauthenticated, no per-user
+  limiter is emitted (the global authenticated limiter and `ROLE_USER` security
+  still apply).
+- **FR-6**: Non-sensitive GraphQL operations, non-POST GraphQL requests, malformed
+  JSON bodies, and requests without a `query` field MUST NOT emit endpoint limiters
+  (no behavioral regression, no false 429s).
+
+## Non-functional requirements
+
+- **NFR-Security**: The fix MUST close the bypass for every per-endpoint auth
+  limiter reachable via GraphQL, reusing the exact limiter names and key formats so
+  REST and GraphQL share a single throttle budget per identity/IP. The IP-keyed
+  limiter MUST always apply for a recognised sensitive mutation even when identity
+  arguments are absent, guaranteeing a hard security floor. Batch GraphQL requests
+  remain rejected by the existing `GraphQLBatchRejectListener` (defense in depth).
+- **NFR-Compatibility**: No public API contract, GraphQL schema, REST route,
+  limiter configuration (`rate_limiter.yaml`), or environment variable changes.
+  Existing REST throttling behavior is unchanged. No new env defaults introduced.
+- **NFR-Maintainability**: The new logic lives in a single-responsibility
+  `ApiRateLimitGraphQlResolver` in the existing `Resolver/RateLimit/` directory,
+  consistent with the surrounding hexagonal/DDD layering (Application layer, no new
+  directory, no `*Service` suffix). It reuses the established
+  `ApiRateLimitClientIdentityResolver`, the serializer, and the pending-2FA
+  repository port. Deptrac stays at 0 violations; PHPInsights complexity/quality/
+  style thresholds are preserved.
+
+## Out of scope
+
+- Changing limiter rates, intervals, or policies (config untouched).
+- Per-field GraphQL cost analysis / query-depth limiting beyond existing
+  batch rejection.
+- Throttling `requestPasswordReset` (already throttled in the command-handler
+  decorator for both REST and GraphQL) and authenticated 2FA setup/confirm/disable
+  management mutations, which are additionally guarded by `ROLE_USER` security.
+- GraphQL query parsing via a full AST; a targeted field-name match plus standard
+  `variables.input` extraction is sufficient and avoids new dependencies.

--- a/specs/security-315-graphql-bypasses-rate-limiters/stories.md
+++ b/specs/security-315-graphql-bypasses-rate-limiters/stories.md
@@ -1,0 +1,84 @@
+# Stories — Security #315: GraphQL endpoint bypasses per-endpoint rate limiters
+
+## Verification commands (one-off containers)
+
+```bash
+# Unit (RateLimit filter)
+docker run --rm -v $PWD:/app -v /home/kravtsov/Projects/user-service/vendor:/app/vendor:ro \
+  -w /app -e APP_ENV=test --entrypoint sh secfix-312-php:latest -lc \
+  'php -d memory_limit=-1 vendor/bin/phpunit --testsuite=Unit --filter "RateLimit" --no-coverage'
+
+# Deptrac
+docker run --rm -v $PWD:/app -v /home/kravtsov/Projects/user-service/vendor:/app/vendor:ro \
+  -w /app -e APP_ENV=test --entrypoint sh secfix-312-php:latest -lc \
+  'php -d memory_limit=-1 vendor/bin/deptrac analyse --config-file=deptrac.yaml --no-progress'
+
+# Psalm (changed files)
+docker run --rm -v $PWD:/app -v /home/kravtsov/Projects/user-service/vendor:/app/vendor:ro \
+  -w /app -e APP_ENV=test --entrypoint sh secfix-312-php:latest -lc \
+  'php -d memory_limit=-1 vendor/bin/psalm --no-cache --no-progress \
+   src/Shared/Application/Resolver/RateLimit/ApiRateLimitGraphQlResolver.php \
+   src/Shared/Application/Resolver/RateLimit/ApiRateLimitRequestResolver.php'
+
+# php-cs-fixer (changed files)
+docker run --rm -v $PWD:/app -v /home/kravtsov/Projects/user-service/vendor:/app/vendor:ro \
+  -w /app -e APP_ENV=test --entrypoint sh secfix-312-php:latest -lc \
+  'PHP_CS_FIXER_IGNORE_ENV=1 vendor/bin/php-cs-fixer fix --dry-run --allow-risky=yes \
+   --config=.php-cs-fixer.dist.php --path-mode=intersection \
+   src/Shared/Application/Resolver/RateLimit/ApiRateLimitGraphQlResolver.php'
+```
+
+## Story 1 — Map sensitive GraphQL mutations to REST limiter targets (FR-1..FR-6, NFR-Security)
+
+**Change:** New `App\Shared\Application\Resolver\RateLimit\ApiRateLimitGraphQlResolver`.
+For `POST /api/graphql` it decodes the JSON body, detects sensitive mutation field
+names in the `query`, and returns the same `{name, key}` limiter targets the REST
+resolvers would return — extracting `email` / `pendingSessionId` from
+`variables.input` and the JWT subject for sign-out mutations.
+
+**Tests** (`tests/Unit/.../ApiRateLimitGraphQlResolverTest.php`):
+
+- Positive:
+  - `testSignInMutationProducesIpAndEmailLimiters` — `signin_ip` (IP) + `signin_email` (email).
+  - `testRefreshTokenMutationProducesRefreshLimiter` — `refresh_token` (IP).
+  - `testConfirmPasswordResetMutationProducesConfirmLimiter` — `password_reset_confirm` (IP).
+  - `testCompleteTwoFactorMutationProducesIpAndUserLimiters` — `twofa_verification_ip` + `twofa_verification_user`.
+  - `testSignOutMutationProducesUserLimiterForAuthenticatedRequest` — `signout` keyed by JWT subject.
+  - `testMultipleSensitiveMutationsAreAllThrottled` — multiple fields each throttled.
+- Negative:
+  - `testNonGraphQlPathReturnsNoTargets`, `testGraphQlGetRequestReturnsNoTargets`,
+    `testNonSensitiveMutationReturnsNoTargets`, `testInvalidJsonBodyReturnsNoTargets`,
+    `testMissingQueryFieldReturnsNoTargets`, `testSignOutAllMutationSkippedWhenUnauthenticated`.
+- Edge:
+  - `testSignInMutationWithoutEmailStillThrottlesByIp` — IP floor with no email.
+  - `testCompleteTwoFactorWithoutPendingSessionOnlyThrottlesByIp` — IP floor, no resolvable user.
+
+**Fails without fix:** the class does not exist (the bypass is the absence of any
+GraphQL throttling), so these assertions cannot hold pre-fix.
+
+## Story 2 — Wire the GraphQL resolver into endpoint limiter resolution (FR-1..FR-5, NFR-Maintainability)
+
+**Change:** `ApiRateLimitRequestResolver` gains an `ApiRateLimitGraphQlResolver`
+constructor dependency (autowired) and appends its targets in
+`resolveEndpointLimiters`, so the existing `ApiRateLimitListener` consumes the
+GraphQL-derived limiters with no listener change.
+
+**Tests** (`tests/Unit/.../ApiRateLimitRequestResolverLimitersTest.php`):
+
+- Positive: `testResolveEndpointLimitersForGraphQlSignInMutation` (signin_ip + signin_email),
+  `testResolveEndpointLimitersForGraphQlRefreshTokenMutation` (refresh_token).
+- Regression: full existing REST limiter suite still green
+  (`testResolveEndpointLimitersForSignIn`, `...ForOauthTokenPath`, etc.).
+- Negative coverage inherited: `testResolveEndpointLimitersReturnsEmptyForUnrecognizedApiPath`.
+
+**Fails without fix:** before wiring, `resolveEndpointLimiters` returns `[]` for
+`/api/graphql`, so `signin_ip`/`signin_email`/`refresh_token` keys are absent.
+
+## Story 3 — Keep existing rate-limit tests constructing the resolver valid (NFR-Compatibility)
+
+**Change:** Update test factories `RateLimitClientTestCase::createRequestResolver`
+and `ApiRateLimitListenerTest` helpers to pass the new third constructor argument
+(via `createGraphQlResolver`).
+
+**Tests:** Entire `--filter RateLimit` Unit set (155 tests) and full Unit suite
+(2274 tests) pass; deptrac 0, psalm clean, php-cs-fixer clean.

--- a/src/Shared/Application/Resolver/RateLimit/ApiRateLimitGraphQlResolver.php
+++ b/src/Shared/Application/Resolver/RateLimit/ApiRateLimitGraphQlResolver.php
@@ -103,13 +103,19 @@ final readonly class ApiRateLimitGraphQlResolver
     }
 
     /**
-     * @return array<int, string>
+     * Returns one entry per field invocation so that repeated throttled
+     * mutations (e.g. aliased duplicates that GraphQL executes more than once)
+     * each consume a rate-limiter token instead of collapsing into a single
+     * hit. Deduplicating here would let an attacker batch N identical sensitive
+     * mutations into one request for the price of a single limiter consumption.
+     *
+     * @return list<string>
      */
     private function extractMutationNames(string $query): array
     {
         preg_match_all(self::MUTATION_FIELD_PATTERN, $query, $matches);
 
-        return array_unique($matches[1]);
+        return $matches[1];
     }
 
     /**

--- a/src/Shared/Application/Resolver/RateLimit/ApiRateLimitGraphQlResolver.php
+++ b/src/Shared/Application/Resolver/RateLimit/ApiRateLimitGraphQlResolver.php
@@ -1,0 +1,241 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Application\Resolver\RateLimit;
+
+use App\User\Domain\Repository\PendingTwoFactorRepositoryInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Serializer\Encoder\JsonDecode;
+use Symfony\Component\Serializer\Encoder\JsonEncoder;
+use Symfony\Component\Serializer\Exception\NotEncodableValueException;
+use Symfony\Component\Serializer\SerializerInterface;
+
+/**
+ * Maps sensitive GraphQL mutations to the same rate-limiter targets that protect
+ * their REST counterparts so that POST /api/graphql cannot be used to bypass the
+ * per-endpoint sign-in, refresh, 2FA and password-reset throttles.
+ *
+ * Security: CWE-799 - GraphQL endpoint bypasses per-endpoint rate limiters (#315).
+ */
+final readonly class ApiRateLimitGraphQlResolver
+{
+    private const GRAPHQL_PATH = '/api/graphql';
+    private const MUTATION_FIELD_PATTERN =
+        '/\b(signIn|refreshToken|completeTwoFactor|confirmPasswordReset|signOut|signOutAll)\b/';
+
+    public function __construct(
+        private SerializerInterface $serializer,
+        private ApiRateLimitClientIdentityResolver $clientIdentityResolver,
+        private ?PendingTwoFactorRepositoryInterface $pendingTwoFactorRepository = null,
+    ) {
+    }
+
+    /**
+     * @return list<array{name: string, key: string}>
+     */
+    public function resolve(Request $request): array
+    {
+        if (!$this->isGraphQlMutationRequest($request)) {
+            return [];
+        }
+
+        $payload = $this->decodePayload($request->getContent());
+        if ($payload === null) {
+            return [];
+        }
+
+        $query = $payload['query'] ?? null;
+        if (!is_string($query)) {
+            return [];
+        }
+
+        $input = $this->resolveInput($payload);
+
+        return $this->resolveTargetsForMutations($request, $query, $input);
+    }
+
+    private function isGraphQlMutationRequest(Request $request): bool
+    {
+        return $request->getPathInfo() === self::GRAPHQL_PATH
+            && strtoupper($request->getMethod()) === 'POST';
+    }
+
+    /**
+     * @param array<string, mixed> $input
+     *
+     * @return list<array{name: string, key: string}>
+     */
+    private function resolveTargetsForMutations(
+        Request $request,
+        string $query,
+        array $input
+    ): array {
+        if (preg_match_all(self::MUTATION_FIELD_PATTERN, $query, $matches) === false) {
+            return [];
+        }
+
+        $targets = [];
+        foreach (array_unique($matches[1]) as $mutation) {
+            foreach ($this->resolveMutationTargets($request, $mutation, $input) as $target) {
+                $targets[] = $target;
+            }
+        }
+
+        return $targets;
+    }
+
+    /**
+     * @param array<string, mixed> $input
+     *
+     * @return list<array{name: string, key: string}>
+     */
+    private function resolveMutationTargets(
+        Request $request,
+        string $mutation,
+        array $input
+    ): array {
+        return match ($mutation) {
+            'signIn' => $this->resolveSignInTargets($request, $input),
+            'refreshToken' => [
+                ['name' => 'refresh_token', 'key' => $this->buildIpKey($request)],
+            ],
+            'completeTwoFactor' => $this->resolveTwoFactorTargets($request, $input),
+            'confirmPasswordReset' => [
+                ['name' => 'password_reset_confirm', 'key' => $this->buildIpKey($request)],
+            ],
+            'signOut' => $this->resolveAuthenticatedTargets($request, 'signout'),
+            'signOutAll' => $this->resolveAuthenticatedTargets($request, 'signout_all'),
+            default => [],
+        };
+    }
+
+    /**
+     * @param array<string, mixed> $input
+     *
+     * @return list<array{name: string, key: string}>
+     */
+    private function resolveSignInTargets(Request $request, array $input): array
+    {
+        $targets = [['name' => 'signin_ip', 'key' => $this->buildIpKey($request)]];
+
+        $email = $this->resolveInputString($input, 'email');
+        if ($email !== null) {
+            $targets[] = [
+                'name' => 'signin_email',
+                'key' => $this->buildEmailKey(strtolower(trim($email))),
+            ];
+        }
+
+        return $targets;
+    }
+
+    /**
+     * @param array<string, mixed> $input
+     *
+     * @return list<array{name: string, key: string}>
+     */
+    private function resolveTwoFactorTargets(Request $request, array $input): array
+    {
+        $targets = [['name' => 'twofa_verification_ip', 'key' => $this->buildIpKey($request)]];
+
+        $userId = $this->resolveTwoFactorUserId($input);
+        if ($userId !== null) {
+            $targets[] = [
+                'name' => 'twofa_verification_user',
+                'key' => $this->buildUserKey($userId),
+            ];
+        }
+
+        return $targets;
+    }
+
+    /**
+     * @param array<string, mixed> $input
+     */
+    private function resolveTwoFactorUserId(array $input): ?string
+    {
+        $pendingSessionId = $this->resolveInputString($input, 'pendingSessionId');
+        if ($pendingSessionId === null || $this->pendingTwoFactorRepository === null) {
+            return null;
+        }
+
+        $userId = $this->pendingTwoFactorRepository->findById($pendingSessionId)?->getUserId();
+
+        return is_string($userId) && $userId !== '' ? $userId : null;
+    }
+
+    /**
+     * @return list<array{name: string, key: string}>
+     */
+    private function resolveAuthenticatedTargets(Request $request, string $limiterName): array
+    {
+        $subject = $this->clientIdentityResolver->resolveUserSubject($request);
+        if ($subject === null) {
+            return [];
+        }
+
+        return [['name' => $limiterName, 'key' => $this->buildUserKey($subject)]];
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function decodePayload(string $content): ?array
+    {
+        try {
+            $decoded = $this->serializer->decode(
+                $content,
+                JsonEncoder::FORMAT,
+                [JsonDecode::ASSOCIATIVE => true],
+            );
+        } catch (NotEncodableValueException) {
+            return null;
+        }
+
+        return is_array($decoded) ? $decoded : null;
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     *
+     * @return array<string, mixed>
+     */
+    private function resolveInput(array $payload): array
+    {
+        $variables = $payload['variables'] ?? null;
+        if (!is_array($variables)) {
+            return [];
+        }
+
+        $input = $variables['input'] ?? $variables;
+
+        return is_array($input) ? $input : [];
+    }
+
+    /**
+     * @param array<string, mixed> $input
+     */
+    private function resolveInputString(array $input, string $key): ?string
+    {
+        $value = $input[$key] ?? null;
+
+        return is_string($value) && $value !== '' ? $value : null;
+    }
+
+    private function buildIpKey(Request $request): string
+    {
+        $ipAddress = $request->getClientIp() ?? '0.0.0.0';
+        return sprintf('ip:%s', $ipAddress);
+    }
+
+    private function buildUserKey(string $userId): string
+    {
+        return sprintf('user:%s', $userId);
+    }
+
+    private function buildEmailKey(string $email): string
+    {
+        return sprintf('email:%s', $email);
+    }
+}

--- a/src/Shared/Application/Resolver/RateLimit/ApiRateLimitGraphQlResolver.php
+++ b/src/Shared/Application/Resolver/RateLimit/ApiRateLimitGraphQlResolver.php
@@ -6,7 +6,6 @@ namespace App\Shared\Application\Resolver\RateLimit;
 
 use App\User\Domain\Repository\PendingTwoFactorRepositoryInterface;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Serializer\Encoder\JsonDecode;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
 use Symfony\Component\Serializer\Exception\NotEncodableValueException;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -17,12 +16,20 @@ use Symfony\Component\Serializer\SerializerInterface;
  * per-endpoint sign-in, refresh, 2FA and password-reset throttles.
  *
  * Security: CWE-799 - GraphQL endpoint bypasses per-endpoint rate limiters (#315).
+ *
+ * @psalm-type GraphQlPayloadValue = array<array-key, scalar|array<array-key, scalar|array<array-key, scalar|null>|null>|null>|scalar|null
  */
 final readonly class ApiRateLimitGraphQlResolver
 {
     private const GRAPHQL_PATH = '/api/graphql';
-    private const MUTATION_FIELD_PATTERN =
-        '/\b(signIn|refreshToken|completeTwoFactor|confirmPasswordReset|signOut|signOutAll)\b/';
+
+    /**
+     * Captures every GraphQL field invocation (an identifier directly followed by
+     * an argument list). The allowlist of throttled mutations is enforced by the
+     * match expression in {@see resolveMutationTargets()} so that unknown fields
+     * resolve to no rate-limiter targets.
+     */
+    private const MUTATION_FIELD_PATTERN = '/([A-Za-z_][A-Za-z0-9_]*)\s*\(/';
 
     public function __construct(
         private SerializerInterface $serializer,
@@ -45,14 +52,28 @@ final readonly class ApiRateLimitGraphQlResolver
             return [];
         }
 
-        $query = $payload['query'] ?? null;
-        if (!is_string($query)) {
+        $query = $this->resolveQuery($payload);
+        if ($query === null) {
             return [];
         }
 
         $input = $this->resolveInput($payload);
 
         return $this->resolveTargetsForMutations($request, $query, $input);
+    }
+
+    /**
+     * @param array<string, GraphQlPayloadValue> $payload
+     */
+    private function resolveQuery(array $payload): ?string
+    {
+        if (!array_key_exists('query', $payload)) {
+            return null;
+        }
+
+        $query = $payload['query'];
+
+        return is_string($query) ? $query : null;
     }
 
     private function isGraphQlMutationRequest(Request $request): bool
@@ -62,7 +83,7 @@ final readonly class ApiRateLimitGraphQlResolver
     }
 
     /**
-     * @param array<string, mixed> $input
+     * @param array<string, array<int, string>|bool|float|int|string|null> $input
      *
      * @return list<array{name: string, key: string}>
      */
@@ -71,12 +92,8 @@ final readonly class ApiRateLimitGraphQlResolver
         string $query,
         array $input
     ): array {
-        if (preg_match_all(self::MUTATION_FIELD_PATTERN, $query, $matches) === false) {
-            return [];
-        }
-
         $targets = [];
-        foreach (array_unique($matches[1]) as $mutation) {
+        foreach ($this->extractMutationNames($query) as $mutation) {
             foreach ($this->resolveMutationTargets($request, $mutation, $input) as $target) {
                 $targets[] = $target;
             }
@@ -86,7 +103,17 @@ final readonly class ApiRateLimitGraphQlResolver
     }
 
     /**
-     * @param array<string, mixed> $input
+     * @return array<int, string>
+     */
+    private function extractMutationNames(string $query): array
+    {
+        preg_match_all(self::MUTATION_FIELD_PATTERN, $query, $matches);
+
+        return array_unique($matches[1]);
+    }
+
+    /**
+     * @param array<string, array<int, string>|bool|float|int|string|null> $input
      *
      * @return list<array{name: string, key: string}>
      */
@@ -111,7 +138,7 @@ final readonly class ApiRateLimitGraphQlResolver
     }
 
     /**
-     * @param array<string, mixed> $input
+     * @param array<string, array<int, string>|bool|float|int|string|null> $input
      *
      * @return list<array{name: string, key: string}>
      */
@@ -131,7 +158,7 @@ final readonly class ApiRateLimitGraphQlResolver
     }
 
     /**
-     * @param array<string, mixed> $input
+     * @param array<string, array<int, string>|bool|float|int|string|null> $input
      *
      * @return list<array{name: string, key: string}>
      */
@@ -151,7 +178,7 @@ final readonly class ApiRateLimitGraphQlResolver
     }
 
     /**
-     * @param array<string, mixed> $input
+     * @param array<string, array<int, string>|bool|float|int|string|null> $input
      */
     private function resolveTwoFactorUserId(array $input): ?string
     {
@@ -179,27 +206,29 @@ final readonly class ApiRateLimitGraphQlResolver
     }
 
     /**
-     * @return array<string, mixed>|null
+     * @return array<string, GraphQlPayloadValue>|null
      */
     private function decodePayload(string $content): ?array
     {
         try {
-            $decoded = $this->serializer->decode(
-                $content,
-                JsonEncoder::FORMAT,
-                [JsonDecode::ASSOCIATIVE => true],
-            );
+            // JsonEncoder decodes JSON objects to associative arrays by default,
+            // so nested GraphQL variables are returned as arrays we can traverse.
+            $decoded = $this->serializer->decode($content, JsonEncoder::FORMAT);
         } catch (NotEncodableValueException) {
             return null;
         }
 
-        return is_array($decoded) ? $decoded : null;
+        if (!is_array($decoded)) {
+            return null;
+        }
+
+        return $decoded;
     }
 
     /**
-     * @param array<string, mixed> $payload
+     * @param array<string, GraphQlPayloadValue> $payload
      *
-     * @return array<string, mixed>
+     * @return array<string, array<int, string>|bool|float|int|string|null>
      */
     private function resolveInput(array $payload): array
     {
@@ -208,13 +237,16 @@ final readonly class ApiRateLimitGraphQlResolver
             return [];
         }
 
-        $input = $variables['input'] ?? $variables;
+        $input = array_key_exists('input', $variables) ? $variables['input'] : $variables;
+        if (!is_array($input)) {
+            return [];
+        }
 
-        return is_array($input) ? $input : [];
+        return $input;
     }
 
     /**
-     * @param array<string, mixed> $input
+     * @param array<string, array<int, string>|bool|float|int|string|null> $input
      */
     private function resolveInputString(array $input, string $key): ?string
     {

--- a/src/Shared/Application/Resolver/RateLimit/ApiRateLimitRequestResolver.php
+++ b/src/Shared/Application/Resolver/RateLimit/ApiRateLimitRequestResolver.php
@@ -18,6 +18,7 @@ final readonly class ApiRateLimitRequestResolver
     public function __construct(
         private ApiRateLimitClientIdentityResolver $clientIdentityResolver,
         private ApiRateLimitAuthTargetResolver $authTargetResolver,
+        private ApiRateLimitGraphQlResolver $graphQlResolver,
     ) {
     }
 
@@ -59,6 +60,7 @@ final readonly class ApiRateLimitRequestResolver
             $this->resolveAuthenticatedSecurityLimiters($request, $path, $method)
         );
         $this->appendTargets($targets, $this->authTargetResolver->resolve($request));
+        $this->appendTargets($targets, $this->graphQlResolver->resolve($request));
 
         return $targets;
     }

--- a/tests/Unit/Shared/Application/EventListener/ApiRateLimitListenerTest.php
+++ b/tests/Unit/Shared/Application/EventListener/ApiRateLimitListenerTest.php
@@ -8,6 +8,7 @@ use App\Shared\Application\Converter\JwtTokenConverterInterface;
 use App\Shared\Application\EventListener\ApiRateLimitListener;
 use App\Shared\Application\Resolver\RateLimit\ApiRateLimitAuthTargetResolver;
 use App\Shared\Application\Resolver\RateLimit\ApiRateLimitClientIdentityResolver;
+use App\Shared\Application\Resolver\RateLimit\ApiRateLimitGraphQlResolver;
 use App\Shared\Application\Resolver\RateLimit\ApiRateLimitPayloadValueResolver;
 use App\Shared\Application\Resolver\RateLimit\ApiRateLimitRequestResolver;
 use App\Tests\Unit\UnitTestCase;
@@ -307,6 +308,17 @@ final class ApiRateLimitListenerTest extends UnitTestCase
         return new ApiRateLimitRequestResolver(
             $clientIdentityResolver,
             new ApiRateLimitAuthTargetResolver(null, $clientIdentityResolver),
+            $this->createGraphQlResolver($clientIdentityResolver),
+        );
+    }
+
+    private function createGraphQlResolver(
+        ApiRateLimitClientIdentityResolver $clientIdentityResolver
+    ): ApiRateLimitGraphQlResolver {
+        return new ApiRateLimitGraphQlResolver(
+            $this->createJsonSerializer(),
+            $clientIdentityResolver,
+            null,
         );
     }
 
@@ -335,7 +347,8 @@ final class ApiRateLimitListenerTest extends UnitTestCase
         );
         $requestMatcher = new ApiRateLimitRequestResolver(
             $clientIdentityResolver,
-            $authTargetResolver
+            $authTargetResolver,
+            $this->createGraphQlResolver($clientIdentityResolver),
         );
 
         return $this->createListener($limiterFactories, $requestMatcher);

--- a/tests/Unit/Shared/Application/Resolver/RateLimit/ApiRateLimitGraphQlResolverEdgeCasesTest.php
+++ b/tests/Unit/Shared/Application/Resolver/RateLimit/ApiRateLimitGraphQlResolverEdgeCasesTest.php
@@ -1,0 +1,225 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Shared\Application\Resolver\RateLimit;
+
+use Symfony\Component\HttpFoundation\Request;
+
+final class ApiRateLimitGraphQlResolverEdgeCasesTest extends RateLimitClientTestCase
+{
+    public function testNonGraphQlPathReturnsNoTargets(): void
+    {
+        $request = Request::create('/api/users', 'POST');
+
+        self::assertSame([], $this->createGraphQlResolver()->resolve($request));
+    }
+
+    public function testGraphQlGetRequestReturnsNoTargets(): void
+    {
+        $request = Request::create(self::GRAPHQL_ENDPOINT, 'GET');
+
+        self::assertSame([], $this->createGraphQlResolver()->resolve($request));
+    }
+
+    public function testNonSensitiveMutationReturnsNoTargets(): void
+    {
+        $request = $this->createGraphQlRequest('mutation { createUser(input: {}) { id } }');
+
+        self::assertSame([], $this->createGraphQlResolver()->resolve($request));
+    }
+
+    public function testInvalidJsonBodyReturnsNoTargets(): void
+    {
+        $request = Request::create(
+            self::GRAPHQL_ENDPOINT,
+            'POST',
+            [],
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/json'],
+            'not-json'
+        );
+
+        self::assertSame([], $this->createGraphQlResolver()->resolve($request));
+    }
+
+    public function testMissingQueryFieldReturnsNoTargets(): void
+    {
+        $request = Request::create(
+            self::GRAPHQL_ENDPOINT,
+            'POST',
+            [],
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/json'],
+            json_encode(['variables' => ['input' => []]], JSON_THROW_ON_ERROR)
+        );
+
+        self::assertSame([], $this->createGraphQlResolver()->resolve($request));
+    }
+
+    public function testScalarJsonBodyReturnsNoTargets(): void
+    {
+        $request = Request::create(
+            self::GRAPHQL_ENDPOINT,
+            'POST',
+            [],
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/json'],
+            '"signIn"'
+        );
+
+        self::assertSame([], $this->createGraphQlResolver()->resolve($request));
+    }
+
+    public function testNullJsonBodyReturnsNoTargets(): void
+    {
+        $request = Request::create(
+            self::GRAPHQL_ENDPOINT,
+            'POST',
+            [],
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/json'],
+            'null'
+        );
+
+        self::assertSame([], $this->createGraphQlResolver()->resolve($request));
+    }
+
+    public function testNonArrayVariablesAreIgnored(): void
+    {
+        $request = Request::create(
+            self::GRAPHQL_ENDPOINT,
+            'POST',
+            [],
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/json'],
+            json_encode(
+                ['query' => 'mutation { signIn(input: {}) { id } }', 'variables' => 'not-an-array'],
+                JSON_THROW_ON_ERROR
+            )
+        );
+
+        $byName = array_column($this->createGraphQlResolver()->resolve($request), 'key', 'name');
+
+        self::assertSame(['signin_ip'], array_keys($byName));
+    }
+
+    public function testEmailFromVariablesIsLowercasedAndTrimmed(): void
+    {
+        $request = $this->createGraphQlRequest(
+            'mutation($input: signInInput!) { signIn(input: $input) { user { id } } }',
+            ['input' => ['email' => "  USER@Example.COM\t"]],
+            '198.51.100.6'
+        );
+
+        $byName = array_column($this->createGraphQlResolver()->resolve($request), 'key', 'name');
+
+        self::assertSame('email:user@example.com', $byName['signin_email']);
+    }
+
+    public function testTopLevelVariablesAreUsedWhenInputKeyMissing(): void
+    {
+        $request = $this->createGraphQlRequest(
+            'mutation($email: String!) { signIn(email: $email) { user { id } } }',
+            ['email' => 'top.level@example.com'],
+            '198.51.100.7'
+        );
+
+        $byName = array_column($this->createGraphQlResolver()->resolve($request), 'key', 'name');
+
+        self::assertSame('email:top.level@example.com', $byName['signin_email']);
+    }
+
+    public function testEmptyEmailStringIsTreatedAsAbsent(): void
+    {
+        $request = $this->createGraphQlRequest(
+            'mutation($input: signInInput!) { signIn(input: $input) { user { id } } }',
+            ['input' => ['email' => '']],
+            '198.51.100.44'
+        );
+
+        $byName = array_column($this->createGraphQlResolver()->resolve($request), 'key', 'name');
+
+        self::assertArrayHasKey('signin_ip', $byName);
+        self::assertArrayNotHasKey('signin_email', $byName);
+    }
+
+    public function testEmailIsResolvedRegardlessOfItsPositionInInput(): void
+    {
+        $request = $this->createGraphQlRequest(
+            'mutation($input: signInInput!) { signIn(input: $input) { user { id } } }',
+            ['input' => ['password' => 'secret', 'email' => 'positioned@example.com']],
+            '198.51.100.47'
+        );
+
+        $byName = array_column($this->createGraphQlResolver()->resolve($request), 'key', 'name');
+
+        self::assertSame('email:positioned@example.com', $byName['signin_email']);
+    }
+
+    public function testNonArrayInputKeyIsIgnored(): void
+    {
+        $request = Request::create(
+            self::GRAPHQL_ENDPOINT,
+            'POST',
+            [],
+            [],
+            [],
+            ['REMOTE_ADDR' => '198.51.100.46', 'CONTENT_TYPE' => 'application/json'],
+            json_encode(
+                [
+                    'query' => 'mutation { signIn(input: {}) { id } }',
+                    'variables' => ['input' => 'not-an-array'],
+                ],
+                JSON_THROW_ON_ERROR
+            )
+        );
+
+        $byName = array_column($this->createGraphQlResolver()->resolve($request), 'key', 'name');
+
+        self::assertSame(['signin_ip'], array_keys($byName));
+    }
+
+    public function testNonStringQueryFieldReturnsNoTargets(): void
+    {
+        $request = Request::create(
+            self::GRAPHQL_ENDPOINT,
+            'POST',
+            [],
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/json'],
+            json_encode(['query' => 12345], JSON_THROW_ON_ERROR)
+        );
+
+        self::assertSame([], $this->createGraphQlResolver()->resolve($request));
+    }
+
+    public function testNestedInputObjectIsDecodedAssociatively(): void
+    {
+        $request = Request::create(
+            self::GRAPHQL_ENDPOINT,
+            'POST',
+            [],
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/json'],
+            json_encode(
+                [
+                    'query' => 'mutation { signIn(input: {}) { id } }',
+                    'variables' => ['input' => ['email' => 'nested@example.com']],
+                ],
+                JSON_THROW_ON_ERROR
+            )
+        );
+
+        $byName = array_column($this->createGraphQlResolver()->resolve($request), 'key', 'name');
+
+        self::assertSame('email:nested@example.com', $byName['signin_email']);
+    }
+}

--- a/tests/Unit/Shared/Application/Resolver/RateLimit/ApiRateLimitGraphQlResolverTest.php
+++ b/tests/Unit/Shared/Application/Resolver/RateLimit/ApiRateLimitGraphQlResolverTest.php
@@ -1,0 +1,227 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Shared\Application\Resolver\RateLimit;
+
+use App\Shared\Application\Resolver\RateLimit\ApiRateLimitGraphQlResolver;
+use App\User\Domain\Entity\PendingTwoFactor;
+use App\User\Domain\Repository\PendingTwoFactorRepositoryInterface;
+use DateTimeImmutable;
+use Symfony\Component\HttpFoundation\Request;
+
+final class ApiRateLimitGraphQlResolverTest extends RateLimitClientTestCase
+{
+    private const ENDPOINT = '/api/graphql';
+
+    /**
+     * @param array<string, mixed> $variables
+     */
+    private function createGraphQlRequest(
+        string $query,
+        array $variables = [],
+        string $clientIp = '203.0.113.7'
+    ): Request {
+        $body = ['query' => $query];
+        if ($variables !== []) {
+            $body['variables'] = $variables;
+        }
+
+        return Request::create(
+            self::ENDPOINT,
+            'POST',
+            [],
+            [],
+            [],
+            ['REMOTE_ADDR' => $clientIp, 'CONTENT_TYPE' => 'application/json'],
+            json_encode($body, JSON_THROW_ON_ERROR)
+        );
+    }
+
+    public function testSignInMutationProducesIpAndEmailLimiters(): void
+    {
+        $email = $this->faker->email();
+        $request = $this->createGraphQlRequest(
+            'mutation($input: signInInput!) { signIn(input: $input) { user { id } } }',
+            ['input' => ['email' => $email, 'password' => 'secret']],
+            '198.51.100.5'
+        );
+
+        $byName = array_column($this->createGraphQlResolver()->resolve($request), 'key', 'name');
+
+        self::assertSame('ip:198.51.100.5', $byName['signin_ip']);
+        self::assertSame('email:' . strtolower(trim($email)), $byName['signin_email']);
+    }
+
+    public function testSignInMutationWithoutEmailStillThrottlesByIp(): void
+    {
+        $request = $this->createGraphQlRequest(
+            'mutation { signIn(input: {password: "x"}) { user { id } } }',
+            [],
+            '198.51.100.9'
+        );
+
+        $byName = array_column($this->createGraphQlResolver()->resolve($request), 'key', 'name');
+
+        self::assertSame('ip:198.51.100.9', $byName['signin_ip']);
+        self::assertArrayNotHasKey('signin_email', $byName);
+    }
+
+    public function testRefreshTokenMutationProducesRefreshLimiter(): void
+    {
+        $request = $this->createGraphQlRequest(
+            'mutation($input: refreshTokenInput!) { refreshToken(input: $input) { user { id } } }',
+            ['input' => ['refreshToken' => $this->faker->sha256()]],
+            '198.51.100.20'
+        );
+
+        $byName = array_column($this->createGraphQlResolver()->resolve($request), 'key', 'name');
+
+        self::assertSame('ip:198.51.100.20', $byName['refresh_token']);
+    }
+
+    public function testConfirmPasswordResetMutationProducesConfirmLimiter(): void
+    {
+        $request = $this->createGraphQlRequest(
+            'mutation { confirmPasswordReset(input: {token: "t", newPassword: "p"}) { id } }',
+            [],
+            '198.51.100.30'
+        );
+
+        $byName = array_column($this->createGraphQlResolver()->resolve($request), 'key', 'name');
+
+        self::assertSame('ip:198.51.100.30', $byName['password_reset_confirm']);
+    }
+
+    public function testCompleteTwoFactorMutationProducesIpAndUserLimiters(): void
+    {
+        $sessionId = $this->faker->uuid();
+        $userId = $this->faker->uuid();
+
+        $repository = $this->createMock(PendingTwoFactorRepositoryInterface::class);
+        $repository->method('findById')->with($sessionId)->willReturn(
+            new PendingTwoFactor($sessionId, $userId, new DateTimeImmutable())
+        );
+
+        $request = $this->createGraphQlRequest(
+            'mutation($input: completeTwoFactorInput!) '
+            . '{ completeTwoFactor(input: $input) { user { id } } }',
+            ['input' => ['pendingSessionId' => $sessionId, 'twoFactorCode' => '123456']],
+            '198.51.100.40'
+        );
+
+        $resolver = new ApiRateLimitGraphQlResolver(
+            $this->createJsonSerializer(),
+            $this->createClientIdentityResolver(),
+            $repository
+        );
+        $byName = array_column($resolver->resolve($request), 'key', 'name');
+
+        self::assertSame('ip:198.51.100.40', $byName['twofa_verification_ip']);
+        self::assertSame('user:' . $userId, $byName['twofa_verification_user']);
+    }
+
+    public function testCompleteTwoFactorWithoutPendingSessionOnlyThrottlesByIp(): void
+    {
+        $request = $this->createGraphQlRequest(
+            'mutation { completeTwoFactor(input: {twoFactorCode: "123456"}) { user { id } } }'
+        );
+
+        $byName = array_column($this->createGraphQlResolver()->resolve($request), 'key', 'name');
+
+        self::assertArrayHasKey('twofa_verification_ip', $byName);
+        self::assertArrayNotHasKey('twofa_verification_user', $byName);
+    }
+
+    public function testSignOutMutationProducesUserLimiterForAuthenticatedRequest(): void
+    {
+        $userId = $this->faker->uuid();
+        $jwtConverter = $this->createMock(
+            \App\Shared\Application\Converter\JwtTokenConverterInterface::class
+        );
+        $jwtConverter->method('decode')->willReturn($this->buildValidPayload(['sub' => $userId]));
+
+        $request = $this->createGraphQlRequest('mutation { signOut(input: {}) { id } }');
+        $request->headers->set('Authorization', 'Bearer ' . $this->faker->sha256());
+
+        $resolver = $this->createGraphQlResolver(
+            $this->createClientIdentityResolver($jwtConverter)
+        );
+        $byName = array_column($resolver->resolve($request), 'key', 'name');
+
+        self::assertSame('user:' . $userId, $byName['signout']);
+    }
+
+    public function testSignOutAllMutationSkippedWhenUnauthenticated(): void
+    {
+        $request = $this->createGraphQlRequest('mutation { signOutAll(input: {}) { id } }');
+
+        $names = array_column($this->createGraphQlResolver()->resolve($request), 'name');
+
+        self::assertNotContains('signout_all', $names);
+    }
+
+    public function testNonGraphQlPathReturnsNoTargets(): void
+    {
+        $request = Request::create('/api/users', 'POST');
+
+        self::assertSame([], $this->createGraphQlResolver()->resolve($request));
+    }
+
+    public function testGraphQlGetRequestReturnsNoTargets(): void
+    {
+        $request = Request::create(self::ENDPOINT, 'GET');
+
+        self::assertSame([], $this->createGraphQlResolver()->resolve($request));
+    }
+
+    public function testNonSensitiveMutationReturnsNoTargets(): void
+    {
+        $request = $this->createGraphQlRequest('mutation { createUser(input: {}) { id } }');
+
+        self::assertSame([], $this->createGraphQlResolver()->resolve($request));
+    }
+
+    public function testInvalidJsonBodyReturnsNoTargets(): void
+    {
+        $request = Request::create(
+            self::ENDPOINT,
+            'POST',
+            [],
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/json'],
+            'not-json'
+        );
+
+        self::assertSame([], $this->createGraphQlResolver()->resolve($request));
+    }
+
+    public function testMissingQueryFieldReturnsNoTargets(): void
+    {
+        $request = Request::create(
+            self::ENDPOINT,
+            'POST',
+            [],
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/json'],
+            json_encode(['variables' => ['input' => []]], JSON_THROW_ON_ERROR)
+        );
+
+        self::assertSame([], $this->createGraphQlResolver()->resolve($request));
+    }
+
+    public function testMultipleSensitiveMutationsAreAllThrottled(): void
+    {
+        $request = $this->createGraphQlRequest(
+            'mutation { refreshToken(input: {refreshToken: "x"}) { user { id } } '
+            . 'confirmPasswordReset(input: {token: "t", newPassword: "p"}) { id } }'
+        );
+
+        $names = array_column($this->createGraphQlResolver()->resolve($request), 'name');
+
+        self::assertContains('refresh_token', $names);
+        self::assertContains('password_reset_confirm', $names);
+    }
+}

--- a/tests/Unit/Shared/Application/Resolver/RateLimit/ApiRateLimitGraphQlResolverTest.php
+++ b/tests/Unit/Shared/Application/Resolver/RateLimit/ApiRateLimitGraphQlResolverTest.php
@@ -168,7 +168,7 @@ final class ApiRateLimitGraphQlResolverTest extends RateLimitClientTestCase
     public function testDuplicateMutationOccurrencesEachConsumeALimiterHit(): void
     {
         $request = $this->createGraphQlRequest(
-            'mutation { a: refreshToken(input: {x: 1}) { id } b: refreshToken(input: {y: 2}) { id } }',
+            'mutation { a: refreshToken(input: {}) { id } b: refreshToken(input: {}) { id } }',
             [],
             '198.51.100.8'
         );

--- a/tests/Unit/Shared/Application/Resolver/RateLimit/ApiRateLimitGraphQlResolverTest.php
+++ b/tests/Unit/Shared/Application/Resolver/RateLimit/ApiRateLimitGraphQlResolverTest.php
@@ -8,12 +8,9 @@ use App\Shared\Application\Resolver\RateLimit\ApiRateLimitGraphQlResolver;
 use App\User\Domain\Entity\PendingTwoFactor;
 use App\User\Domain\Repository\PendingTwoFactorRepositoryInterface;
 use DateTimeImmutable;
-use Symfony\Component\HttpFoundation\Request;
 
 final class ApiRateLimitGraphQlResolverTest extends RateLimitClientTestCase
 {
-    private const ENDPOINT = '/api/graphql';
-
     public function testSignInMutationProducesIpAndEmailLimiters(): void
     {
         $email = $this->faker->email();
@@ -136,55 +133,24 @@ final class ApiRateLimitGraphQlResolverTest extends RateLimitClientTestCase
         self::assertNotContains('signout_all', $names);
     }
 
-    public function testNonGraphQlPathReturnsNoTargets(): void
+    public function testSignOutAllMutationProducesUserLimiterForAuthenticatedRequest(): void
     {
-        $request = Request::create('/api/users', 'POST');
-
-        self::assertSame([], $this->createGraphQlResolver()->resolve($request));
-    }
-
-    public function testGraphQlGetRequestReturnsNoTargets(): void
-    {
-        $request = Request::create(self::ENDPOINT, 'GET');
-
-        self::assertSame([], $this->createGraphQlResolver()->resolve($request));
-    }
-
-    public function testNonSensitiveMutationReturnsNoTargets(): void
-    {
-        $request = $this->createGraphQlRequest('mutation { createUser(input: {}) { id } }');
-
-        self::assertSame([], $this->createGraphQlResolver()->resolve($request));
-    }
-
-    public function testInvalidJsonBodyReturnsNoTargets(): void
-    {
-        $request = Request::create(
-            self::ENDPOINT,
-            'POST',
-            [],
-            [],
-            [],
-            ['CONTENT_TYPE' => 'application/json'],
-            'not-json'
+        $userId = $this->faker->uuid();
+        $jwtConverter = $this->createMock(
+            \App\Shared\Application\Converter\JwtTokenConverterInterface::class
         );
+        $jwtConverter->method('decode')->willReturn($this->buildValidPayload(['sub' => $userId]));
 
-        self::assertSame([], $this->createGraphQlResolver()->resolve($request));
-    }
+        $request = $this->createGraphQlRequest('mutation { signOutAll(input: {}) { id } }');
+        $request->headers->set('Authorization', 'Bearer ' . $this->faker->sha256());
 
-    public function testMissingQueryFieldReturnsNoTargets(): void
-    {
-        $request = Request::create(
-            self::ENDPOINT,
-            'POST',
-            [],
-            [],
-            [],
-            ['CONTENT_TYPE' => 'application/json'],
-            json_encode(['variables' => ['input' => []]], JSON_THROW_ON_ERROR)
+        $resolver = $this->createGraphQlResolver(
+            $this->createClientIdentityResolver($jwtConverter)
         );
+        $byName = array_column($resolver->resolve($request), 'key', 'name');
 
-        self::assertSame([], $this->createGraphQlResolver()->resolve($request));
+        self::assertSame('user:' . $userId, $byName['signout_all']);
+        self::assertArrayNotHasKey('signout', $byName);
     }
 
     public function testMultipleSensitiveMutationsAreAllThrottled(): void
@@ -197,82 +163,6 @@ final class ApiRateLimitGraphQlResolverTest extends RateLimitClientTestCase
 
         self::assertContains('refresh_token', $names);
         self::assertContains('password_reset_confirm', $names);
-    }
-
-    public function testScalarJsonBodyReturnsNoTargets(): void
-    {
-        $request = Request::create(
-            self::ENDPOINT,
-            'POST',
-            [],
-            [],
-            [],
-            ['CONTENT_TYPE' => 'application/json'],
-            '"signIn"'
-        );
-
-        self::assertSame([], $this->createGraphQlResolver()->resolve($request));
-    }
-
-    public function testNullJsonBodyReturnsNoTargets(): void
-    {
-        $request = Request::create(
-            self::ENDPOINT,
-            'POST',
-            [],
-            [],
-            [],
-            ['CONTENT_TYPE' => 'application/json'],
-            'null'
-        );
-
-        self::assertSame([], $this->createGraphQlResolver()->resolve($request));
-    }
-
-    public function testNonArrayVariablesAreIgnored(): void
-    {
-        $request = Request::create(
-            self::ENDPOINT,
-            'POST',
-            [],
-            [],
-            [],
-            ['CONTENT_TYPE' => 'application/json'],
-            json_encode(
-                ['query' => 'mutation { signIn(input: {}) { id } }', 'variables' => 'not-an-array'],
-                JSON_THROW_ON_ERROR
-            )
-        );
-
-        $byName = array_column($this->createGraphQlResolver()->resolve($request), 'key', 'name');
-
-        self::assertSame(['signin_ip'], array_keys($byName));
-    }
-
-    public function testEmailFromVariablesIsLowercasedAndTrimmed(): void
-    {
-        $request = $this->createGraphQlRequest(
-            'mutation($input: signInInput!) { signIn(input: $input) { user { id } } }',
-            ['input' => ['email' => "  USER@Example.COM\t"]],
-            '198.51.100.6'
-        );
-
-        $byName = array_column($this->createGraphQlResolver()->resolve($request), 'key', 'name');
-
-        self::assertSame('email:user@example.com', $byName['signin_email']);
-    }
-
-    public function testTopLevelVariablesAreUsedWhenInputKeyMissing(): void
-    {
-        $request = $this->createGraphQlRequest(
-            'mutation($email: String!) { signIn(email: $email) { user { id } } }',
-            ['email' => 'top.level@example.com'],
-            '198.51.100.7'
-        );
-
-        $byName = array_column($this->createGraphQlResolver()->resolve($request), 'key', 'name');
-
-        self::assertSame('email:top.level@example.com', $byName['signin_email']);
     }
 
     public function testDuplicateMutationOccurrencesProduceSingleTargetSet(): void
@@ -357,20 +247,6 @@ final class ApiRateLimitGraphQlResolverTest extends RateLimitClientTestCase
         self::assertArrayNotHasKey('twofa_verification_user', $byName);
     }
 
-    public function testEmptyEmailStringIsTreatedAsAbsent(): void
-    {
-        $request = $this->createGraphQlRequest(
-            'mutation($input: signInInput!) { signIn(input: $input) { user { id } } }',
-            ['input' => ['email' => '']],
-            '198.51.100.44'
-        );
-
-        $byName = array_column($this->createGraphQlResolver()->resolve($request), 'key', 'name');
-
-        self::assertArrayHasKey('signin_ip', $byName);
-        self::assertArrayNotHasKey('signin_email', $byName);
-    }
-
     public function testCompleteTwoFactorWithoutSessionDoesNotQueryRepository(): void
     {
         $repository = $this->createMock(PendingTwoFactorRepositoryInterface::class);
@@ -391,123 +267,5 @@ final class ApiRateLimitGraphQlResolverTest extends RateLimitClientTestCase
 
         self::assertArrayHasKey('twofa_verification_ip', $byName);
         self::assertArrayNotHasKey('twofa_verification_user', $byName);
-    }
-
-    public function testEmailIsResolvedRegardlessOfItsPositionInInput(): void
-    {
-        $request = $this->createGraphQlRequest(
-            'mutation($input: signInInput!) { signIn(input: $input) { user { id } } }',
-            ['input' => ['password' => 'secret', 'email' => 'positioned@example.com']],
-            '198.51.100.47'
-        );
-
-        $byName = array_column($this->createGraphQlResolver()->resolve($request), 'key', 'name');
-
-        self::assertSame('email:positioned@example.com', $byName['signin_email']);
-    }
-
-    public function testNonArrayInputKeyIsIgnored(): void
-    {
-        $request = Request::create(
-            self::ENDPOINT,
-            'POST',
-            [],
-            [],
-            [],
-            ['REMOTE_ADDR' => '198.51.100.46', 'CONTENT_TYPE' => 'application/json'],
-            json_encode(
-                [
-                    'query' => 'mutation { signIn(input: {}) { id } }',
-                    'variables' => ['input' => 'not-an-array'],
-                ],
-                JSON_THROW_ON_ERROR
-            )
-        );
-
-        $byName = array_column($this->createGraphQlResolver()->resolve($request), 'key', 'name');
-
-        self::assertSame(['signin_ip'], array_keys($byName));
-    }
-
-    public function testNonStringQueryFieldReturnsNoTargets(): void
-    {
-        $request = Request::create(
-            self::ENDPOINT,
-            'POST',
-            [],
-            [],
-            [],
-            ['CONTENT_TYPE' => 'application/json'],
-            json_encode(['query' => 12345], JSON_THROW_ON_ERROR)
-        );
-
-        self::assertSame([], $this->createGraphQlResolver()->resolve($request));
-    }
-
-    public function testNestedInputObjectIsDecodedAssociatively(): void
-    {
-        $request = Request::create(
-            self::ENDPOINT,
-            'POST',
-            [],
-            [],
-            [],
-            ['CONTENT_TYPE' => 'application/json'],
-            json_encode(
-                [
-                    'query' => 'mutation { signIn(input: {}) { id } }',
-                    'variables' => ['input' => ['email' => 'nested@example.com']],
-                ],
-                JSON_THROW_ON_ERROR
-            )
-        );
-
-        $byName = array_column($this->createGraphQlResolver()->resolve($request), 'key', 'name');
-
-        self::assertSame('email:nested@example.com', $byName['signin_email']);
-    }
-
-    public function testSignOutAllMutationProducesUserLimiterForAuthenticatedRequest(): void
-    {
-        $userId = $this->faker->uuid();
-        $jwtConverter = $this->createMock(
-            \App\Shared\Application\Converter\JwtTokenConverterInterface::class
-        );
-        $jwtConverter->method('decode')->willReturn($this->buildValidPayload(['sub' => $userId]));
-
-        $request = $this->createGraphQlRequest('mutation { signOutAll(input: {}) { id } }');
-        $request->headers->set('Authorization', 'Bearer ' . $this->faker->sha256());
-
-        $resolver = $this->createGraphQlResolver(
-            $this->createClientIdentityResolver($jwtConverter)
-        );
-        $byName = array_column($resolver->resolve($request), 'key', 'name');
-
-        self::assertSame('user:' . $userId, $byName['signout_all']);
-        self::assertArrayNotHasKey('signout', $byName);
-    }
-
-    /**
-     * @param array<string, array<string, scalar|null>|scalar|null> $variables
-     */
-    private function createGraphQlRequest(
-        string $query,
-        array $variables = [],
-        string $clientIp = '203.0.113.7'
-    ): Request {
-        $body = ['query' => $query];
-        if ($variables !== []) {
-            $body['variables'] = $variables;
-        }
-
-        return Request::create(
-            self::ENDPOINT,
-            'POST',
-            [],
-            [],
-            [],
-            ['REMOTE_ADDR' => $clientIp, 'CONTENT_TYPE' => 'application/json'],
-            json_encode($body, JSON_THROW_ON_ERROR)
-        );
     }
 }

--- a/tests/Unit/Shared/Application/Resolver/RateLimit/ApiRateLimitGraphQlResolverTest.php
+++ b/tests/Unit/Shared/Application/Resolver/RateLimit/ApiRateLimitGraphQlResolverTest.php
@@ -14,30 +14,6 @@ final class ApiRateLimitGraphQlResolverTest extends RateLimitClientTestCase
 {
     private const ENDPOINT = '/api/graphql';
 
-    /**
-     * @param array<string, mixed> $variables
-     */
-    private function createGraphQlRequest(
-        string $query,
-        array $variables = [],
-        string $clientIp = '203.0.113.7'
-    ): Request {
-        $body = ['query' => $query];
-        if ($variables !== []) {
-            $body['variables'] = $variables;
-        }
-
-        return Request::create(
-            self::ENDPOINT,
-            'POST',
-            [],
-            [],
-            [],
-            ['REMOTE_ADDR' => $clientIp, 'CONTENT_TYPE' => 'application/json'],
-            json_encode($body, JSON_THROW_ON_ERROR)
-        );
-    }
-
     public function testSignInMutationProducesIpAndEmailLimiters(): void
     {
         $email = $this->faker->email();
@@ -104,8 +80,7 @@ final class ApiRateLimitGraphQlResolverTest extends RateLimitClientTestCase
         );
 
         $request = $this->createGraphQlRequest(
-            'mutation($input: completeTwoFactorInput!) '
-            . '{ completeTwoFactor(input: $input) { user { id } } }',
+            'mutation { completeTwoFactor(input: $input) { id } }',
             ['input' => ['pendingSessionId' => $sessionId, 'twoFactorCode' => '123456']],
             '198.51.100.40'
         );
@@ -215,13 +190,324 @@ final class ApiRateLimitGraphQlResolverTest extends RateLimitClientTestCase
     public function testMultipleSensitiveMutationsAreAllThrottled(): void
     {
         $request = $this->createGraphQlRequest(
-            'mutation { refreshToken(input: {refreshToken: "x"}) { user { id } } '
-            . 'confirmPasswordReset(input: {token: "t", newPassword: "p"}) { id } }'
+            'mutation { refreshToken(input: {}) { id } confirmPasswordReset(input: {}) { id } }'
         );
 
         $names = array_column($this->createGraphQlResolver()->resolve($request), 'name');
 
         self::assertContains('refresh_token', $names);
         self::assertContains('password_reset_confirm', $names);
+    }
+
+    public function testScalarJsonBodyReturnsNoTargets(): void
+    {
+        $request = Request::create(
+            self::ENDPOINT,
+            'POST',
+            [],
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/json'],
+            '"signIn"'
+        );
+
+        self::assertSame([], $this->createGraphQlResolver()->resolve($request));
+    }
+
+    public function testNullJsonBodyReturnsNoTargets(): void
+    {
+        $request = Request::create(
+            self::ENDPOINT,
+            'POST',
+            [],
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/json'],
+            'null'
+        );
+
+        self::assertSame([], $this->createGraphQlResolver()->resolve($request));
+    }
+
+    public function testNonArrayVariablesAreIgnored(): void
+    {
+        $request = Request::create(
+            self::ENDPOINT,
+            'POST',
+            [],
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/json'],
+            json_encode(
+                ['query' => 'mutation { signIn(input: {}) { id } }', 'variables' => 'not-an-array'],
+                JSON_THROW_ON_ERROR
+            )
+        );
+
+        $byName = array_column($this->createGraphQlResolver()->resolve($request), 'key', 'name');
+
+        self::assertSame(['signin_ip'], array_keys($byName));
+    }
+
+    public function testEmailFromVariablesIsLowercasedAndTrimmed(): void
+    {
+        $request = $this->createGraphQlRequest(
+            'mutation($input: signInInput!) { signIn(input: $input) { user { id } } }',
+            ['input' => ['email' => "  USER@Example.COM\t"]],
+            '198.51.100.6'
+        );
+
+        $byName = array_column($this->createGraphQlResolver()->resolve($request), 'key', 'name');
+
+        self::assertSame('email:user@example.com', $byName['signin_email']);
+    }
+
+    public function testTopLevelVariablesAreUsedWhenInputKeyMissing(): void
+    {
+        $request = $this->createGraphQlRequest(
+            'mutation($email: String!) { signIn(email: $email) { user { id } } }',
+            ['email' => 'top.level@example.com'],
+            '198.51.100.7'
+        );
+
+        $byName = array_column($this->createGraphQlResolver()->resolve($request), 'key', 'name');
+
+        self::assertSame('email:top.level@example.com', $byName['signin_email']);
+    }
+
+    public function testDuplicateMutationOccurrencesProduceSingleTargetSet(): void
+    {
+        $request = $this->createGraphQlRequest(
+            'mutation { refreshToken(input: {a: 1}) { id } refreshToken(input: {b: 2}) { id } }',
+            [],
+            '198.51.100.8'
+        );
+
+        $targets = $this->createGraphQlResolver()->resolve($request);
+
+        self::assertSame(
+            [['name' => 'refresh_token', 'key' => 'ip:198.51.100.8']],
+            $targets
+        );
+    }
+
+    public function testCompleteTwoFactorWithoutRepositoryOnlyThrottlesByIp(): void
+    {
+        $request = $this->createGraphQlRequest(
+            'mutation { completeTwoFactor(input: {pendingSessionId: "s-1"}) { id } }',
+            [],
+            '198.51.100.41'
+        );
+
+        $byName = array_column(
+            $this->createGraphQlResolver(null, null)->resolve($request),
+            'key',
+            'name'
+        );
+
+        self::assertArrayHasKey('twofa_verification_ip', $byName);
+        self::assertArrayNotHasKey('twofa_verification_user', $byName);
+    }
+
+    public function testCompleteTwoFactorWithUnknownPendingSessionOnlyThrottlesByIp(): void
+    {
+        $sessionId = $this->faker->uuid();
+        $repository = $this->createMock(PendingTwoFactorRepositoryInterface::class);
+        $repository->method('findById')->with($sessionId)->willReturn(null);
+
+        $request = $this->createGraphQlRequest(
+            'mutation { completeTwoFactor(input: $input) { id } }',
+            ['input' => ['pendingSessionId' => $sessionId]],
+            '198.51.100.42'
+        );
+
+        $resolver = new ApiRateLimitGraphQlResolver(
+            $this->createJsonSerializer(),
+            $this->createClientIdentityResolver(),
+            $repository
+        );
+        $byName = array_column($resolver->resolve($request), 'key', 'name');
+
+        self::assertArrayHasKey('twofa_verification_ip', $byName);
+        self::assertArrayNotHasKey('twofa_verification_user', $byName);
+    }
+
+    public function testCompleteTwoFactorWithEmptyUserIdOnlyThrottlesByIp(): void
+    {
+        $sessionId = $this->faker->uuid();
+        $repository = $this->createMock(PendingTwoFactorRepositoryInterface::class);
+        $repository->method('findById')->with($sessionId)->willReturn(
+            new PendingTwoFactor($sessionId, '', new DateTimeImmutable())
+        );
+
+        $request = $this->createGraphQlRequest(
+            'mutation { completeTwoFactor(input: $input) { id } }',
+            ['input' => ['pendingSessionId' => $sessionId]],
+            '198.51.100.43'
+        );
+
+        $resolver = new ApiRateLimitGraphQlResolver(
+            $this->createJsonSerializer(),
+            $this->createClientIdentityResolver(),
+            $repository
+        );
+        $byName = array_column($resolver->resolve($request), 'key', 'name');
+
+        self::assertArrayHasKey('twofa_verification_ip', $byName);
+        self::assertArrayNotHasKey('twofa_verification_user', $byName);
+    }
+
+    public function testEmptyEmailStringIsTreatedAsAbsent(): void
+    {
+        $request = $this->createGraphQlRequest(
+            'mutation($input: signInInput!) { signIn(input: $input) { user { id } } }',
+            ['input' => ['email' => '']],
+            '198.51.100.44'
+        );
+
+        $byName = array_column($this->createGraphQlResolver()->resolve($request), 'key', 'name');
+
+        self::assertArrayHasKey('signin_ip', $byName);
+        self::assertArrayNotHasKey('signin_email', $byName);
+    }
+
+    public function testCompleteTwoFactorWithoutSessionDoesNotQueryRepository(): void
+    {
+        $repository = $this->createMock(PendingTwoFactorRepositoryInterface::class);
+        $repository->expects(self::never())->method('findById');
+
+        $request = $this->createGraphQlRequest(
+            'mutation { completeTwoFactor(input: {twoFactorCode: "123456"}) { user { id } } }',
+            [],
+            '198.51.100.45'
+        );
+
+        $resolver = new ApiRateLimitGraphQlResolver(
+            $this->createJsonSerializer(),
+            $this->createClientIdentityResolver(),
+            $repository
+        );
+        $byName = array_column($resolver->resolve($request), 'key', 'name');
+
+        self::assertArrayHasKey('twofa_verification_ip', $byName);
+        self::assertArrayNotHasKey('twofa_verification_user', $byName);
+    }
+
+    public function testEmailIsResolvedRegardlessOfItsPositionInInput(): void
+    {
+        $request = $this->createGraphQlRequest(
+            'mutation($input: signInInput!) { signIn(input: $input) { user { id } } }',
+            ['input' => ['password' => 'secret', 'email' => 'positioned@example.com']],
+            '198.51.100.47'
+        );
+
+        $byName = array_column($this->createGraphQlResolver()->resolve($request), 'key', 'name');
+
+        self::assertSame('email:positioned@example.com', $byName['signin_email']);
+    }
+
+    public function testNonArrayInputKeyIsIgnored(): void
+    {
+        $request = Request::create(
+            self::ENDPOINT,
+            'POST',
+            [],
+            [],
+            [],
+            ['REMOTE_ADDR' => '198.51.100.46', 'CONTENT_TYPE' => 'application/json'],
+            json_encode(
+                [
+                    'query' => 'mutation { signIn(input: {}) { id } }',
+                    'variables' => ['input' => 'not-an-array'],
+                ],
+                JSON_THROW_ON_ERROR
+            )
+        );
+
+        $byName = array_column($this->createGraphQlResolver()->resolve($request), 'key', 'name');
+
+        self::assertSame(['signin_ip'], array_keys($byName));
+    }
+
+    public function testNonStringQueryFieldReturnsNoTargets(): void
+    {
+        $request = Request::create(
+            self::ENDPOINT,
+            'POST',
+            [],
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/json'],
+            json_encode(['query' => 12345], JSON_THROW_ON_ERROR)
+        );
+
+        self::assertSame([], $this->createGraphQlResolver()->resolve($request));
+    }
+
+    public function testNestedInputObjectIsDecodedAssociatively(): void
+    {
+        $request = Request::create(
+            self::ENDPOINT,
+            'POST',
+            [],
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/json'],
+            json_encode(
+                [
+                    'query' => 'mutation { signIn(input: {}) { id } }',
+                    'variables' => ['input' => ['email' => 'nested@example.com']],
+                ],
+                JSON_THROW_ON_ERROR
+            )
+        );
+
+        $byName = array_column($this->createGraphQlResolver()->resolve($request), 'key', 'name');
+
+        self::assertSame('email:nested@example.com', $byName['signin_email']);
+    }
+
+    public function testSignOutAllMutationProducesUserLimiterForAuthenticatedRequest(): void
+    {
+        $userId = $this->faker->uuid();
+        $jwtConverter = $this->createMock(
+            \App\Shared\Application\Converter\JwtTokenConverterInterface::class
+        );
+        $jwtConverter->method('decode')->willReturn($this->buildValidPayload(['sub' => $userId]));
+
+        $request = $this->createGraphQlRequest('mutation { signOutAll(input: {}) { id } }');
+        $request->headers->set('Authorization', 'Bearer ' . $this->faker->sha256());
+
+        $resolver = $this->createGraphQlResolver(
+            $this->createClientIdentityResolver($jwtConverter)
+        );
+        $byName = array_column($resolver->resolve($request), 'key', 'name');
+
+        self::assertSame('user:' . $userId, $byName['signout_all']);
+        self::assertArrayNotHasKey('signout', $byName);
+    }
+
+    /**
+     * @param array<string, array<string, scalar|null>|scalar|null> $variables
+     */
+    private function createGraphQlRequest(
+        string $query,
+        array $variables = [],
+        string $clientIp = '203.0.113.7'
+    ): Request {
+        $body = ['query' => $query];
+        if ($variables !== []) {
+            $body['variables'] = $variables;
+        }
+
+        return Request::create(
+            self::ENDPOINT,
+            'POST',
+            [],
+            [],
+            [],
+            ['REMOTE_ADDR' => $clientIp, 'CONTENT_TYPE' => 'application/json'],
+            json_encode($body, JSON_THROW_ON_ERROR)
+        );
     }
 }

--- a/tests/Unit/Shared/Application/Resolver/RateLimit/ApiRateLimitGraphQlResolverTest.php
+++ b/tests/Unit/Shared/Application/Resolver/RateLimit/ApiRateLimitGraphQlResolverTest.php
@@ -165,18 +165,24 @@ final class ApiRateLimitGraphQlResolverTest extends RateLimitClientTestCase
         self::assertContains('password_reset_confirm', $names);
     }
 
-    public function testDuplicateMutationOccurrencesProduceSingleTargetSet(): void
+    public function testDuplicateMutationOccurrencesEachConsumeALimiterHit(): void
     {
         $request = $this->createGraphQlRequest(
-            'mutation { refreshToken(input: {a: 1}) { id } refreshToken(input: {b: 2}) { id } }',
+            'mutation { a: refreshToken(input: {x: 1}) { id } b: refreshToken(input: {y: 2}) { id } }',
             [],
             '198.51.100.8'
         );
 
         $targets = $this->createGraphQlResolver()->resolve($request);
 
+        // Each aliased occurrence executes server-side, so each must consume a
+        // separate limiter token. Collapsing duplicates would let an attacker
+        // batch N identical sensitive mutations for the cost of a single hit.
         self::assertSame(
-            [['name' => 'refresh_token', 'key' => 'ip:198.51.100.8']],
+            [
+                ['name' => 'refresh_token', 'key' => 'ip:198.51.100.8'],
+                ['name' => 'refresh_token', 'key' => 'ip:198.51.100.8'],
+            ],
             $targets
         );
     }

--- a/tests/Unit/Shared/Application/Resolver/RateLimit/ApiRateLimitRequestResolverLimitersTest.php
+++ b/tests/Unit/Shared/Application/Resolver/RateLimit/ApiRateLimitRequestResolverLimitersTest.php
@@ -343,7 +343,7 @@ final class ApiRateLimitRequestResolverLimitersTest extends RateLimitClientTestC
             [],
             ['REMOTE_ADDR' => '203.0.113.11', 'CONTENT_TYPE' => 'application/json'],
             json_encode([
-                'query' => 'mutation($input: signInInput!) { signIn(input: $input) { user { id } } }',
+                'query' => 'mutation { signIn(input: $input) { id } }',
                 'variables' => ['input' => ['email' => $email, 'password' => 'secret']],
             ], JSON_THROW_ON_ERROR)
         );

--- a/tests/Unit/Shared/Application/Resolver/RateLimit/ApiRateLimitRequestResolverLimitersTest.php
+++ b/tests/Unit/Shared/Application/Resolver/RateLimit/ApiRateLimitRequestResolverLimitersTest.php
@@ -331,4 +331,53 @@ final class ApiRateLimitRequestResolverLimitersTest extends RateLimitClientTestC
 
         self::assertContains('user_collection', $names);
     }
+
+    public function testResolveEndpointLimitersForGraphQlSignInMutation(): void
+    {
+        $email = $this->faker->email();
+        $request = Request::create(
+            '/api/graphql',
+            'POST',
+            [],
+            [],
+            [],
+            ['REMOTE_ADDR' => '203.0.113.11', 'CONTENT_TYPE' => 'application/json'],
+            json_encode([
+                'query' => 'mutation($input: signInInput!) { signIn(input: $input) { user { id } } }',
+                'variables' => ['input' => ['email' => $email, 'password' => 'secret']],
+            ], JSON_THROW_ON_ERROR)
+        );
+
+        $byName = array_column(
+            $this->resolver->resolveEndpointLimiters($request),
+            'key',
+            'name'
+        );
+
+        self::assertSame('ip:203.0.113.11', $byName['signin_ip']);
+        self::assertSame('email:' . strtolower(trim($email)), $byName['signin_email']);
+    }
+
+    public function testResolveEndpointLimitersForGraphQlRefreshTokenMutation(): void
+    {
+        $request = Request::create(
+            '/api/graphql',
+            'POST',
+            [],
+            [],
+            [],
+            ['REMOTE_ADDR' => '203.0.113.12', 'CONTENT_TYPE' => 'application/json'],
+            json_encode([
+                'query' => 'mutation { refreshToken(input: {refreshToken: "x"}) { user { id } } }',
+            ], JSON_THROW_ON_ERROR)
+        );
+
+        $byName = array_column(
+            $this->resolver->resolveEndpointLimiters($request),
+            'key',
+            'name'
+        );
+
+        self::assertSame('ip:203.0.113.12', $byName['refresh_token']);
+    }
 }

--- a/tests/Unit/Shared/Application/Resolver/RateLimit/RateLimitClientTestCase.php
+++ b/tests/Unit/Shared/Application/Resolver/RateLimit/RateLimitClientTestCase.php
@@ -12,9 +12,12 @@ use App\Shared\Application\Resolver\RateLimit\ApiRateLimitPayloadValueResolver;
 use App\Shared\Application\Resolver\RateLimit\ApiRateLimitRequestResolver;
 use App\Tests\Unit\UnitTestCase;
 use App\User\Domain\Repository\PendingTwoFactorRepositoryInterface;
+use Symfony\Component\HttpFoundation\Request;
 
 abstract class RateLimitClientTestCase extends UnitTestCase
 {
+    protected const GRAPHQL_ENDPOINT = '/api/graphql';
+
     protected JwtTokenConverterInterface $jwtConverter;
 
     #[\Override]
@@ -96,6 +99,30 @@ abstract class RateLimitClientTestCase extends UnitTestCase
                 $clientIdentityResolver,
                 $pendingTwoFactorRepository,
             ),
+        );
+    }
+
+    /**
+     * @param array<string, array<string, scalar|null>|scalar|null> $variables
+     */
+    protected function createGraphQlRequest(
+        string $query,
+        array $variables = [],
+        string $clientIp = '203.0.113.7'
+    ): Request {
+        $body = ['query' => $query];
+        if ($variables !== []) {
+            $body['variables'] = $variables;
+        }
+
+        return Request::create(
+            self::GRAPHQL_ENDPOINT,
+            'POST',
+            [],
+            [],
+            [],
+            ['REMOTE_ADDR' => $clientIp, 'CONTENT_TYPE' => 'application/json'],
+            json_encode($body, JSON_THROW_ON_ERROR)
         );
     }
 }

--- a/tests/Unit/Shared/Application/Resolver/RateLimit/RateLimitClientTestCase.php
+++ b/tests/Unit/Shared/Application/Resolver/RateLimit/RateLimitClientTestCase.php
@@ -7,6 +7,7 @@ namespace App\Tests\Unit\Shared\Application\Resolver\RateLimit;
 use App\Shared\Application\Converter\JwtTokenConverterInterface;
 use App\Shared\Application\Resolver\RateLimit\ApiRateLimitAuthTargetResolver;
 use App\Shared\Application\Resolver\RateLimit\ApiRateLimitClientIdentityResolver;
+use App\Shared\Application\Resolver\RateLimit\ApiRateLimitGraphQlResolver;
 use App\Shared\Application\Resolver\RateLimit\ApiRateLimitPayloadValueResolver;
 use App\Shared\Application\Resolver\RateLimit\ApiRateLimitRequestResolver;
 use App\Tests\Unit\UnitTestCase;
@@ -66,6 +67,19 @@ abstract class RateLimitClientTestCase extends UnitTestCase
         );
     }
 
+    protected function createGraphQlResolver(
+        ?ApiRateLimitClientIdentityResolver $clientIdentityResolver = null,
+        ?PendingTwoFactorRepositoryInterface $pendingTwoFactorRepository = null,
+    ): ApiRateLimitGraphQlResolver {
+        $resolver = $clientIdentityResolver ?? $this->createClientIdentityResolver();
+
+        return new ApiRateLimitGraphQlResolver(
+            $this->createJsonSerializer(),
+            $resolver,
+            $pendingTwoFactorRepository,
+        );
+    }
+
     protected function createRequestResolver(
         ?JwtTokenConverterInterface $jwtConverter = null,
         ?PendingTwoFactorRepositoryInterface $pendingTwoFactorRepository = null,
@@ -77,6 +91,10 @@ abstract class RateLimitClientTestCase extends UnitTestCase
             $this->createAuthTargetResolver(
                 $pendingTwoFactorRepository,
                 $clientIdentityResolver,
+            ),
+            $this->createGraphQlResolver(
+                $clientIdentityResolver,
+                $pendingTwoFactorRepository,
             ),
         );
     }


### PR DESCRIPTION
## Security fix — Closes #315

### Vulnerability (HIGH, CWE-799)
Per-endpoint authentication rate limiters (`signin_ip` 10/min, `signin_email` 5/min, `refresh_token`, `twofa_verification_ip`/`twofa_verification_user`, `password_reset_confirm`, `signout`, `signout_all`) were selected solely by matching the **REST URL path** in `ApiRateLimitRequestResolver` / `ApiRateLimitAuthTargetResolver`. API Platform also exposes the same operations as GraphQL mutations (`signIn`, `refreshToken`, `completeTwoFactor`, `confirmPasswordReset`, `signOut`, `signOutAll`) served at `POST /api/graphql` (PUBLIC_ACCESS). That path matched none of the REST checks, so only the loose `global_api_anonymous` limiter (~100 req/min/IP) applied. An attacker could bypass every tight auth throttle by issuing the equivalent GraphQL mutation — enabling credential stuffing against `signIn`, 2FA brute force against `completeTwoFactor`, refresh-token abuse, and reset-token guessing against `confirmPasswordReset`.

### Fix
- New `App\Shared\Application\Resolver\RateLimit\ApiRateLimitGraphQlResolver` (Application layer, existing `Resolver/RateLimit/` directory). For `POST /api/graphql` it decodes the JSON body, detects sensitive mutation field names in the `query`, and emits the **exact same limiter names and keys** as the REST resolvers:
  - IP-keyed limiter is always applied for a recognised sensitive mutation (hard security floor).
  - Identity keys added when present: lowercased `email` from `variables.input` (sign-in), pending-2FA-derived user id (complete 2FA), JWT subject (sign-out).
- Wired into `ApiRateLimitRequestResolver::resolveEndpointLimiters`, so the existing `ApiRateLimitListener` enforces it with no listener change. REST and GraphQL now share one throttle budget per identity/IP.
- No limiter config, env, REST route, or GraphQL schema changes. Batch GraphQL requests remain rejected by the existing `GraphQLBatchRejectListener` (defense in depth).

### Local verification (one-off containers)
- `phpunit --testsuite=Unit --filter RateLimit`: **OK (155 tests)** — includes 14 new `ApiRateLimitGraphQlResolverTest` cases (positive/negative/edge) + 2 wiring tests.
- `phpunit --testsuite=Unit` (full): **OK (2274 tests)**.
- `deptrac analyse`: **Violations 0**.
- `psalm` (changed files): **No errors found**.
- `php-cs-fixer --dry-run` (changed files): **0 of 6 files**.

### BMAD spec
`specs/security-315-graphql-bypasses-rate-limiters/` — `prd.md` (Problem, FR-1..FR-6, NFR-Security/Compatibility/Maintainability, Out-of-scope) and `stories.md` (per-change stories with positive/negative/edge test mapping and verification commands).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Applied per-endpoint auth rate limiters to GraphQL mutations at POST `/api/graphql` to close a bypass for sign-in, 2FA, refresh-token, password-reset, and sign-out throttles. REST and GraphQL now share the same limiter budgets per IP and identity; each mutation occurrence consumes its own token. Fixes #315.

- **Bug Fixes**
  - Added ApiRateLimitGraphQlResolver to parse the GraphQL body, detect sensitive mutations via a field-capture regex and allowlist, and emit the same limiter names/keys as REST (IP floor; plus `email`, 2FA user, or JWT subject when present). Duplicate occurrences are each throttled.
  - Wired into ApiRateLimitRequestResolver::resolveEndpointLimiters so the existing listener enforces these without changes; multiple sensitive fields in one query are all throttled.
  - No changes to limiter config, REST routes, or GraphQL schema; batch GraphQL requests continue to be rejected.

- **Refactors**
  - Tightened types and guarded array access; removed redundant JSON options. Split tests into behavior and edge-case classes, hoisted the GraphQL request helper and endpoint constant into RateLimitClientTestCase. Addressed final CI quality gates.

<sup>Written for commit 334664dff2271254d4f33b7fbeaddac036e6e413. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VilnaCRM-Org/user-service/pull/329?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

