### PR TITLE
fix(security): fail-closed CORS default for prod image (#319)

### DIFF
--- a/.env
+++ b/.env
@@ -134,7 +134,13 @@ SIGNOUT_ALL_RATE_LIMIT_INTERVAL="1 minute"
 ###< symfony/security-bundle ###
 
 ###> nelmio/cors-bundle ###
-CORS_ALLOW_ORIGIN='^https?://(localhost|127\.0\.0\.1)(:[0-9]+)?$'
+# REQUIRED at deploy time. This default is fail-closed: '(?!)' is a regex that
+# matches no origin, so cross-origin requests are denied until an operator sets a
+# real allow-list. Do NOT ship the dev localhost regex here — `composer dump-env
+# prod` bakes this value into the production image (.env.local.php). Set
+# CORS_ALLOW_ORIGIN to your trusted HTTPS origins in prod, e.g.
+# '^https://(app|www)\.example\.com$'. The localhost regex lives in .env.dev/.env.test.
+CORS_ALLOW_ORIGIN='(?!)'
 ###< nelmio/cors-bundle ###
 
 XDEBUG_MODE=off

--- a/.env.dev
+++ b/.env.dev
@@ -1,3 +1,9 @@
 OAUTH_ENCRYPTION_KEY=def00000ae8c5d8c5a0d6f5e6e5e6e5e6e5e6e5e6e5e6e5e6e5e6e5e6e5e
  # Dev-only placeholder key — NEVER use in production
 TWO_FACTOR_ENCRYPTION_KEY=MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=
+
+###> nelmio/cors-bundle ###
+# Dev-only localhost allow-list. NEVER ships to prod (the prod image bakes .env,
+# whose CORS_ALLOW_ORIGIN default is the fail-closed '(?!)' deny-all regex).
+CORS_ALLOW_ORIGIN='^https?://(localhost|127\.0\.0\.1)(:[0-9]+)?$'
+###< nelmio/cors-bundle ###

--- a/.env.test
+++ b/.env.test
@@ -85,6 +85,7 @@ DOMAIN_EVENTS_QUEUE_NAME=domain-events
 FAILED_DOMAIN_EVENTS_QUEUE_NAME=failed-domain-events
 DOMAIN_EVENTS_TRANSPORT_DSN=sqs://localstack:${LOCALSTACK_PORT:-4566}/000000000000/${DOMAIN_EVENTS_QUEUE_NAME}?sslmode=disable&region=us-east-1
 FAILED_DOMAIN_EVENTS_TRANSPORT_DSN=sqs://localstack:${LOCALSTACK_PORT:-4566}/000000000000/${FAILED_DOMAIN_EVENTS_QUEUE_NAME}?sslmode=disable&region=us-east-1
+# Test-only localhost allow-list (overrides the fail-closed default in .env).
 CORS_ALLOW_ORIGIN='^https?://(localhost|127\.0\.0\.1)(:[0-9]+)?$'
 OAUTH_PERSIST_ACCESS_TOKEN=1
 OAUTH_ENABLE_IMPLICIT_GRANT=0  # AC: NFR-64 - implicit grant disabled

--- a/specs/security-319-prod-cors-dev-regex-credentials/prd.md
+++ b/specs/security-319-prod-cors-dev-regex-credentials/prd.md
@@ -1,0 +1,82 @@
+# PRD — Security #319: Production image ships dev-only CORS regex with credentials
+
+## Problem
+
+The production Docker image bakes in a working development CORS allow-list. The
+committed `.env` defined:
+
+```
+CORS_ALLOW_ORIGIN='^https?://(localhost|127\.0\.0\.1)(:[0-9]+)?$'
+```
+
+`config/packages/nelmio_cors.yaml` enables `origin_regex: true` and
+`allow_credentials: true` for all paths (`/api`, `/api/graphql`, `/authorize`),
+reading `allow_origin` from `%env(CORS_ALLOW_ORIGIN)%` in dev, test and prod.
+The Dockerfile prod stage runs `composer dump-env prod`, which resolves `.env`
+and bakes `CORS_ALLOW_ORIGIN=<localhost regex>` into `.env.local.php` inside the
+production artifact.
+
+Consequence (CWE-942, Permissive Cross-domain Policy with Untrusted Domains):
+unless an operator explicitly sets `CORS_ALLOW_ORIGIN` at deploy time, the
+production API reflects any `http(s)://localhost` or `http://127.0.0.1` Origin
+into `Access-Control-Allow-Origin` AND returns
+`Access-Control-Allow-Credentials: true`. Because the JWT auth token is accepted
+from both the `__Host-auth_token` cookie and the `Authorization` header, a
+browser context the browser treats as `Origin: http://localhost` (local dev
+server, webview, browser-extension page, DNS-rebinding to 127.0.0.1) can read
+authenticated cross-origin API responses (profile, tokens, account data).
+
+There was no fail-closed guard: an empty `CORS_ALLOW_ORIGIN` is even worse, since
+nelmio compiles `allow_origin: ['']` to the regex `{}i`, which matches EVERY
+origin (verified: `preg_match('{}i', 'http://evil.example.com') === 1`). So the
+remediation must ship a non-empty deny-all default, not an empty value.
+
+## In scope
+
+- The committed `.env` default that reaches the production artifact.
+- Environment-scoped overrides for dev and test.
+- A regression unit test that pins the fail-closed default.
+
+## Functional requirements
+
+- **FR-1**: The committed `.env` (the file baked into the prod image by
+  `composer dump-env prod`) MUST default `CORS_ALLOW_ORIGIN` to a deny-all regex
+  (`(?!)`) that matches no origin. The dev localhost allow-list MUST NOT ship in
+  this default.
+- **FR-2**: The deny-all default MUST be non-empty so nelmio never compiles it to
+  the fail-open `{}i` regex, and MUST NOT be the `*` wildcard.
+- **FR-3**: The development environment (`.env.dev`) MUST provide the localhost
+  allow-list so local development keeps working.
+- **FR-4**: The test environment (`.env.test`) MUST keep the localhost allow-list
+  so existing functional/CORS tests keep working.
+- **FR-5**: `config/packages/nelmio_cors.yaml` MUST continue to read
+  `allow_origin` from `%env(CORS_ALLOW_ORIGIN)%` in dev, test and prod (the env
+  binding is the single source of truth; no per-env hardcoded origins).
+- **FR-6**: `.env` MUST document that `CORS_ALLOW_ORIGIN` is a required deploy
+  variable and provide an HTTPS prod example.
+
+## Non-functional requirements
+
+- **NFR-Security**: Fail-closed by default. With no operator-supplied value, the
+  production service denies all cross-origin requests; it never reflects
+  `Access-Control-Allow-Origin` + `Access-Control-Allow-Credentials: true` for
+  localhost or any untrusted origin. `allow_credentials` behaviour is preserved
+  for legitimately configured origins (no functional regression for valid SPAs).
+- **NFR-Compatibility**: No application code, controller, route, or public API
+  contract changes. nelmio CORS bundle wiring is unchanged. Dev and test flows
+  retain their localhost allow-list, so no developer or CI workflow breaks.
+- **NFR-Maintainability**: Change is config-only plus one focused unit test in the
+  existing `tests/Unit/Config/` location (mirrors `LeagueOAuth2ServerConfigTest`).
+  No new directories, no `*Service` suffixes, no Deptrac/threshold edits. The test
+  parses env files with `Symfony\Component\Dotenv\Dotenv`, matching how Symfony
+  resolves them, so it stays accurate if formatting changes.
+
+## Out of scope
+
+- Adding a runtime boot-time guard/exception when `CORS_ALLOW_ORIGIN` is unset
+  (the deny-all default already fails closed; a hard boot failure would be a
+  separate UX decision).
+- Per-endpoint disabling of `allow_credentials` or forcing HTTPS-only origins in
+  prod (deployment-time policy; the env example documents the HTTPS expectation).
+- Changes to `DualAuthenticator` cookie/header acceptance.
+- Adding a `.env.prod` or deployment manifest (deployment-environment concern).

--- a/specs/security-319-prod-cors-dev-regex-credentials/stories.md
+++ b/specs/security-319-prod-cors-dev-regex-credentials/stories.md
@@ -3,28 +3,29 @@
 Verification commands (one-off containers; never `make start`):
 
 ```bash
+# Run from the repository root. APP_IMAGE defaults to the project's PHP image;
+# override it if your local build is tagged differently.
+APP_ROOT="$(git rev-parse --show-toplevel)"
+APP_IMAGE="${APP_IMAGE:-user-service-php:latest}"
+
 # Unit (Cors filter)
-docker run --rm -v /home/kravtsov/Projects/secfix-319:/app \
-  -v /home/kravtsov/Projects/user-service/vendor:/app/vendor:ro \
-  -w /app -e APP_ENV=test --entrypoint sh secfix-312-php:latest \
+docker run --rm -v "$APP_ROOT":/app \
+  -w /app -e APP_ENV=test --entrypoint sh "$APP_IMAGE" \
   -lc 'php -d memory_limit=-1 vendor/bin/phpunit --testsuite=Unit --filter "Cors" --no-coverage 2>&1 | tail -25'
 
 # Deptrac
-docker run --rm -v /home/kravtsov/Projects/secfix-319:/app \
-  -v /home/kravtsov/Projects/user-service/vendor:/app/vendor:ro \
-  -w /app -e APP_ENV=test --entrypoint sh secfix-312-php:latest \
+docker run --rm -v "$APP_ROOT":/app \
+  -w /app -e APP_ENV=test --entrypoint sh "$APP_IMAGE" \
   -lc 'php -d memory_limit=-1 vendor/bin/deptrac analyse --config-file=deptrac.yaml --no-progress 2>&1 | tail -6'
 
 # Psalm (changed file)
-docker run --rm -v /home/kravtsov/Projects/secfix-319:/app \
-  -v /home/kravtsov/Projects/user-service/vendor:/app/vendor:ro \
-  -w /app -e APP_ENV=test --entrypoint sh secfix-312-php:latest \
+docker run --rm -v "$APP_ROOT":/app \
+  -w /app -e APP_ENV=test --entrypoint sh "$APP_IMAGE" \
   -lc 'php -d memory_limit=-1 vendor/bin/psalm --no-cache --no-progress tests/Unit/Config/CorsAllowOriginDefaultTest.php 2>&1 | tail -15'
 
 # php-cs-fixer (changed file)
-docker run --rm -v /home/kravtsov/Projects/secfix-319:/app \
-  -v /home/kravtsov/Projects/user-service/vendor:/app/vendor:ro \
-  -w /app -e APP_ENV=test --entrypoint sh secfix-312-php:latest \
+docker run --rm -v "$APP_ROOT":/app \
+  -w /app -e APP_ENV=test --entrypoint sh "$APP_IMAGE" \
   -lc 'PHP_CS_FIXER_IGNORE_ENV=1 vendor/bin/php-cs-fixer fix --dry-run --allow-risky=yes --config=.php-cs-fixer.dist.php --path-mode=intersection tests/Unit/Config/CorsAllowOriginDefaultTest.php 2>&1 | tail -15'
 ```
 

--- a/specs/security-319-prod-cors-dev-regex-credentials/stories.md
+++ b/specs/security-319-prod-cors-dev-regex-credentials/stories.md
@@ -1,0 +1,97 @@
+# Stories — Security #319
+
+Verification commands (one-off containers; never `make start`):
+
+```bash
+# Unit (Cors filter)
+docker run --rm -v /home/kravtsov/Projects/secfix-319:/app \
+  -v /home/kravtsov/Projects/user-service/vendor:/app/vendor:ro \
+  -w /app -e APP_ENV=test --entrypoint sh secfix-312-php:latest \
+  -lc 'php -d memory_limit=-1 vendor/bin/phpunit --testsuite=Unit --filter "Cors" --no-coverage 2>&1 | tail -25'
+
+# Deptrac
+docker run --rm -v /home/kravtsov/Projects/secfix-319:/app \
+  -v /home/kravtsov/Projects/user-service/vendor:/app/vendor:ro \
+  -w /app -e APP_ENV=test --entrypoint sh secfix-312-php:latest \
+  -lc 'php -d memory_limit=-1 vendor/bin/deptrac analyse --config-file=deptrac.yaml --no-progress 2>&1 | tail -6'
+
+# Psalm (changed file)
+docker run --rm -v /home/kravtsov/Projects/secfix-319:/app \
+  -v /home/kravtsov/Projects/user-service/vendor:/app/vendor:ro \
+  -w /app -e APP_ENV=test --entrypoint sh secfix-312-php:latest \
+  -lc 'php -d memory_limit=-1 vendor/bin/psalm --no-cache --no-progress tests/Unit/Config/CorsAllowOriginDefaultTest.php 2>&1 | tail -15'
+
+# php-cs-fixer (changed file)
+docker run --rm -v /home/kravtsov/Projects/secfix-319:/app \
+  -v /home/kravtsov/Projects/user-service/vendor:/app/vendor:ro \
+  -w /app -e APP_ENV=test --entrypoint sh secfix-312-php:latest \
+  -lc 'PHP_CS_FIXER_IGNORE_ENV=1 vendor/bin/php-cs-fixer fix --dry-run --allow-risky=yes --config=.php-cs-fixer.dist.php --path-mode=intersection tests/Unit/Config/CorsAllowOriginDefaultTest.php 2>&1 | tail -15'
+```
+
+---
+
+## Story 1 — Fail-closed CORS default in the production artifact (FR-1, FR-2, FR-6, NFR-Security)
+
+**Change**: `.env` — replace the localhost regex default with the deny-all regex
+`CORS_ALLOW_ORIGIN='(?!)'` and document that the variable is required at deploy
+time with an HTTPS prod example.
+
+Test mapping (`tests/Unit/Config/CorsAllowOriginDefaultTest.php`):
+
+- **Positive**: `testCommittedEnvShipsFailClosedDenyAllDefault` — `.env` default
+  equals `(?!)`.
+- **Negative**: `testCommittedEnvDefaultDoesNotAllowLocalhostOrAnyOrigin` — the
+  compiled regex `{(?!)}i` matches none of `http://localhost`,
+  `http://localhost:3000`, `http://127.0.0.1`, `http://127.0.0.1:8080`,
+  `https://app.vilnacrm.com`, `http://evil.example.com`.
+- **Edge**: same test asserts the default is NOT the empty string (which would
+  compile to the fail-open `{}i` matching every origin).
+
+Proof it is a real regression test: with the original `.env`
+(`^https?://(localhost|127\.0\.0\.1)(:[0-9]+)?$`) these two tests FAIL
+(`Failed asserting that 1 is identical to 0` for `http://localhost`); with the
+fix all 5 tests pass.
+
+---
+
+## Story 2 — Preserve dev allow-list (FR-3, NFR-Compatibility)
+
+**Change**: `.env.dev` — add `CORS_ALLOW_ORIGIN='^https?://(localhost|127\.0\.0\.1)(:[0-9]+)?$'`
+so local dev keeps reflecting localhost origins.
+
+Test mapping:
+
+- **Positive**: `testDevEnvKeepsLocalhostAllowList` — `.env.dev` value equals the
+  localhost regex and matches `http://localhost:3000`, `http://127.0.0.1`.
+- **Negative**: same test asserts `http://evil.example.com` is NOT matched.
+- **Edge**: dev override is read from `.env.dev` only, never from `.env`
+  (verified implicitly: `.env` default differs, Story 1).
+
+---
+
+## Story 3 — Preserve test allow-list (FR-4, NFR-Compatibility)
+
+**Change**: `.env.test` — keep the localhost regex (documented as a test-only
+override of the fail-closed `.env` default).
+
+Test mapping:
+
+- **Positive**: `testTestEnvKeepsLocalhostAllowList` — `.env.test` value equals the
+  localhost regex.
+- **Negative/Edge**: covered transitively — if `.env.test` lost the override the
+  fail-closed `.env` default would break existing CORS-dependent tests.
+
+---
+
+## Story 4 — nelmio binding unchanged (FR-5, NFR-Maintainability)
+
+**Change**: none to `config/packages/nelmio_cors.yaml`; pinned by test so a future
+edit cannot silently hardcode origins.
+
+Test mapping:
+
+- **Positive**: `testNelmioCorsBindsOriginToEnvVarInEveryEnvironment` — `when@dev`,
+  `when@test`, `when@prod` each set `allow_origin: ['%env(CORS_ALLOW_ORIGIN)%']`.
+- **Negative**: assertion fails if any env block hardcodes an origin instead of
+  the env binding.
+- **Edge**: all three environment blocks asserted, not just one.

--- a/tests/Unit/Config/CorsAllowOriginDefaultTest.php
+++ b/tests/Unit/Config/CorsAllowOriginDefaultTest.php
@@ -35,38 +35,46 @@ final class CorsAllowOriginDefaultTest extends UnitTestCase
         self::assertSame(
             self::DENY_ALL_REGEX,
             $value,
-            'The committed .env (baked into the prod image) must default to the '
-            . 'deny-all CORS regex, not a working localhost allow-list.'
+            'The committed .env (baked into the prod image) must default to a deny-all CORS regex.'
         );
     }
 
-    public function testCommittedEnvDefaultDoesNotAllowLocalhostOrAnyOrigin(): void
+    public function testCommittedEnvDefaultIsNotEmptyFailOpenValue(): void
     {
         $value = $this->corsAllowOriginFrom('/.env');
 
         self::assertNotSame(
             '',
             $value,
-            'An empty CORS_ALLOW_ORIGIN compiles to the regex "{}i" which matches '
-            . 'every origin (fail-open); the default must be a deny-all pattern.'
+            'An empty CORS_ALLOW_ORIGIN compiles to "{}i" which matches every origin (fail-open).'
         );
+    }
 
-        $pattern = '{' . $value . '}i';
+    /**
+     * @dataProvider deniedOriginsProvider
+     */
+    public function testCommittedEnvDefaultDeniesEveryOrigin(string $origin): void
+    {
+        $value = $this->corsAllowOriginFrom('/.env');
 
-        foreach ([
-            'http://localhost',
-            'http://localhost:3000',
-            'http://127.0.0.1',
-            'http://127.0.0.1:8080',
-            'https://app.vilnacrm.com',
-            'http://evil.example.com',
-        ] as $origin) {
-            self::assertSame(
-                0,
-                preg_match($pattern, $origin),
-                sprintf('Origin "%s" must be denied by the committed CORS default.', $origin)
-            );
-        }
+        self::assertSame(
+            0,
+            preg_match('{' . $value . '}i', $origin),
+            sprintf('Origin "%s" must be denied by the committed CORS default.', $origin)
+        );
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function deniedOriginsProvider(): iterable
+    {
+        yield 'localhost' => ['http://localhost'];
+        yield 'localhost with port' => ['http://localhost:3000'];
+        yield 'loopback' => ['http://127.0.0.1'];
+        yield 'loopback with port' => ['http://127.0.0.1:8080'];
+        yield 'production host' => ['https://app.vilnacrm.com'];
+        yield 'attacker host' => ['http://evil.example.com'];
     }
 
     public function testDevEnvKeepsLocalhostAllowList(): void

--- a/tests/Unit/Config/CorsAllowOriginDefaultTest.php
+++ b/tests/Unit/Config/CorsAllowOriginDefaultTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Config;
+
+use App\Tests\Unit\UnitTestCase;
+use Symfony\Component\Dotenv\Dotenv;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Guards the fail-closed CORS default that ships in the production image.
+ *
+ * `composer dump-env prod` (Dockerfile) bakes the committed .env values into the
+ * production artifact. If .env shipped a working dev allow-list (localhost), the
+ * prod service would reflect Access-Control-Allow-Origin for any localhost origin
+ * together with Access-Control-Allow-Credentials: true (CWE-942). The committed
+ * default must instead deny every origin until an operator sets a real allow-list.
+ */
+final class CorsAllowOriginDefaultTest extends UnitTestCase
+{
+    /**
+     * A PCRE that, wrapped by nelmio as `{<value>}i`, matches no origin at all.
+     * An empty value would compile to `{}i`, which matches EVERY origin, so the
+     * fail-closed default must be a non-empty deny-all pattern.
+     */
+    private const DENY_ALL_REGEX = '(?!)';
+
+    private const DEV_LOCALHOST_REGEX = '^https?://(localhost|127\.0\.0\.1)(:[0-9]+)?$';
+
+    public function testCommittedEnvShipsFailClosedDenyAllDefault(): void
+    {
+        $value = $this->corsAllowOriginFrom('/.env');
+
+        self::assertSame(
+            self::DENY_ALL_REGEX,
+            $value,
+            'The committed .env (baked into the prod image) must default to the '
+            . 'deny-all CORS regex, not a working localhost allow-list.'
+        );
+    }
+
+    public function testCommittedEnvDefaultDoesNotAllowLocalhostOrAnyOrigin(): void
+    {
+        $value = $this->corsAllowOriginFrom('/.env');
+
+        self::assertNotSame(
+            '',
+            $value,
+            'An empty CORS_ALLOW_ORIGIN compiles to the regex "{}i" which matches '
+            . 'every origin (fail-open); the default must be a deny-all pattern.'
+        );
+
+        $pattern = '{' . $value . '}i';
+
+        foreach ([
+            'http://localhost',
+            'http://localhost:3000',
+            'http://127.0.0.1',
+            'http://127.0.0.1:8080',
+            'https://app.vilnacrm.com',
+            'http://evil.example.com',
+        ] as $origin) {
+            self::assertSame(
+                0,
+                preg_match($pattern, $origin),
+                sprintf('Origin "%s" must be denied by the committed CORS default.', $origin)
+            );
+        }
+    }
+
+    public function testDevEnvKeepsLocalhostAllowList(): void
+    {
+        $value = $this->corsAllowOriginFrom('/.env.dev');
+
+        self::assertSame(self::DEV_LOCALHOST_REGEX, $value);
+
+        $pattern = '{' . $value . '}i';
+        self::assertSame(1, preg_match($pattern, 'http://localhost:3000'));
+        self::assertSame(1, preg_match($pattern, 'http://127.0.0.1'));
+        self::assertSame(0, preg_match($pattern, 'http://evil.example.com'));
+    }
+
+    public function testTestEnvKeepsLocalhostAllowList(): void
+    {
+        $value = $this->corsAllowOriginFrom('/.env.test');
+
+        self::assertSame(self::DEV_LOCALHOST_REGEX, $value);
+    }
+
+    public function testNelmioCorsBindsOriginToEnvVarInEveryEnvironment(): void
+    {
+        $config = Yaml::parseFile($this->projectDir() . '/config/packages/nelmio_cors.yaml');
+
+        self::assertIsArray($config);
+
+        foreach (['when@dev', 'when@test', 'when@prod'] as $envBlock) {
+            $allowOrigin = $config[$envBlock]['nelmio_cors']['defaults']['allow_origin'] ?? null;
+
+            self::assertSame(
+                ['%env(CORS_ALLOW_ORIGIN)%'],
+                $allowOrigin,
+                sprintf('%s must read the origin allow-list from CORS_ALLOW_ORIGIN.', $envBlock)
+            );
+        }
+    }
+
+    private function corsAllowOriginFrom(string $relativeEnvPath): string
+    {
+        $path = $this->projectDir() . $relativeEnvPath;
+        self::assertFileExists($path);
+
+        $parsed = (new Dotenv())->parse((string) file_get_contents($path), $path);
+        self::assertArrayHasKey(
+            'CORS_ALLOW_ORIGIN',
+            $parsed,
+            sprintf('%s must define CORS_ALLOW_ORIGIN.', $relativeEnvPath)
+        );
+
+        return $parsed['CORS_ALLOW_ORIGIN'];
+    }
+
+    private function projectDir(): string
+    {
+        return dirname(__DIR__, 3);
+    }
+}


### PR DESCRIPTION
## Security fix — Closes #319

### Vulnerability (CWE-942, HIGH)
The committed `.env` shipped a working dev CORS allow-list:

```
CORS_ALLOW_ORIGIN='^https?://(localhost|127\.0\.0\.1)(:[0-9]+)?$'
```

`config/packages/nelmio_cors.yaml` enables `origin_regex: true` and `allow_credentials: true` for all paths (`/api`, `/api/graphql`, `/authorize`) and reads `allow_origin` from `%env(CORS_ALLOW_ORIGIN)%`. The Dockerfile prod stage runs `composer dump-env prod`, which bakes that localhost regex into the production image (`.env.local.php`). Unless an operator explicitly set `CORS_ALLOW_ORIGIN` at deploy time, the production API reflected any `http(s)://localhost` / `127.0.0.1` Origin into `Access-Control-Allow-Origin` together with `Access-Control-Allow-Credentials: true`. Because the JWT auth token is accepted from the `__Host-auth_token` cookie and the `Authorization` header, a browser context the browser treats as `Origin: http://localhost` (local dev server, webview, browser-extension page, DNS-rebinding to 127.0.0.1) could read authenticated cross-origin responses.

An **empty** value is not a safe fallback: nelmio compiles `allow_origin: ['']` to the regex `{}i`, which matches **every** origin (fail-open, verified). So the fix uses a non-empty deny-all default.

### Fix
- **`.env`**: default `CORS_ALLOW_ORIGIN` to the deny-all regex `'(?!)'` (matches no origin) and document it as a required HTTPS-only deploy variable. The dev localhost regex no longer ships in the prod artifact — prod now fails closed.
- **`.env.dev`**: add the localhost allow-list for local development.
- **`.env.test`**: keep the localhost allow-list (documented as a test override).
- **`tests/Unit/Config/CorsAllowOriginDefaultTest.php`**: new regression test that pins the fail-closed default, asserts it denies localhost/127.0.0.1/prod/evil origins, asserts it is non-empty (not fail-open), confirms dev/test keep their localhost allow-lists, and confirms nelmio still binds `allow_origin` to `%env(CORS_ALLOW_ORIGIN)%` in dev/test/prod.

### Local verification (one-off containers, vendor mounted read-only)
- `phpunit Unit --filter Cors`: **OK (5 tests, 25 assertions)** — and it **fails** against the original `.env` (proving it is a real regression test).
- `phpunit` full Unit suite: **OK (2263 tests)** — no regressions.
- `deptrac`: **Violations 0, Errors 0**.
- `psalm` (changed file): **No errors found**.
- `php-cs-fixer` (changed file): **0 of 1 files**.

### BMAD spec
`specs/security-319-prod-cors-dev-regex-credentials/` (`prd.md`, `stories.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sets a fail-closed CORS default for the production image to prevent localhost origins with credentials from being accepted when `CORS_ALLOW_ORIGIN` isn’t set (CWE-942). Moves the localhost regex to dev/test and adds a regression test to lock this down.

- **Bug Fixes**
  - `.env`: default `CORS_ALLOW_ORIGIN` to `(?!)` (deny-all) and document it as a required deploy variable.
  - `.env.dev` and `.env.test`: use the localhost allow-list for local and CI.
  - Tests: add `CorsAllowOriginDefaultTest` to pin the deny-all default and verify `allow_origin: ['%env(CORS_ALLOW_ORIGIN)%']` across dev/test/prod in `nelmio_cors.yaml` (via `nelmio/cors-bundle`).
  - CI: adjust phpinsights/Infection/test expectations so pipelines pass with the new defaults.
  - Specs: make verification commands portable using `$APP_ROOT` and `$APP_IMAGE` in `specs/security-319-prod-cors-dev-regex-credentials/stories.md`.

- **Migration**
  - In production, set `CORS_ALLOW_ORIGIN` to your trusted HTTPS origins (regex), e.g. '^https://(app|www)\.example\.com$'. An empty value is unsafe under `nelmio/cors-bundle`; until set, cross-origin requests are denied.

<sup>Written for commit 7602d60ed98bd0fc6845186497d5fbd7f6d17f06. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VilnaCRM-Org/user-service/pull/330?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

