### PR TITLE
fix(security): hash password-reset tokens at rest (#313)

### DIFF
--- a/config/services_test.yaml
+++ b/config/services_test.yaml
@@ -38,6 +38,10 @@ services:
       $innerLogger: '@App\Tests\Behat\Support\RecordingLogger.inner'
     public: true
 
+  App\Tests\Behat\Support\PasswordResetTokenRecorder:
+    public: true
+    tags: ['app.event_subscriber']
+
   App\Tests\Behat\:
     resource: '../tests/Behat/*'
     exclude: '../tests/Behat/Support/*'

--- a/specs/security-313-reset-confirm-tokens-plaintext/prd.md
+++ b/specs/security-313-reset-confirm-tokens-plaintext/prd.md
@@ -8,7 +8,7 @@ high-entropy raw token (`bin2hex(random_bytes($tokenLength))`) and that raw valu
 was both:
 
 1. **Stored** as the document identifier (`<id field-name="tokenValue"
-   strategy="NONE">`), and
+strategy="NONE">`), and
 2. **Emailed** to the user as the reset link credential.
 
 `MongoDBPasswordResetTokenRepository::findByToken()` looked the token up by exact

--- a/specs/security-313-reset-confirm-tokens-plaintext/prd.md
+++ b/specs/security-313-reset-confirm-tokens-plaintext/prd.md
@@ -1,0 +1,75 @@
+# PRD — Security #313: Password-reset tokens stored in plaintext at rest
+
+## Problem
+
+Password-reset tokens were persisted verbatim in the `password_reset_tokens`
+MongoDB collection. `PasswordResetTokenFactory::create()` generated a
+high-entropy raw token (`bin2hex(random_bytes($tokenLength))`) and that raw value
+was both:
+
+1. **Stored** as the document identifier (`<id field-name="tokenValue"
+   strategy="NONE">`), and
+2. **Emailed** to the user as the reset link credential.
+
+`MongoDBPasswordResetTokenRepository::findByToken()` looked the token up by exact
+equality on the raw value (`findOneBy(['tokenValue' => $token])`). Because the
+stored value equalled the emailed bearer credential, any read access to the
+collection (DB backup, replica snapshot, query log, read-only breach, or a
+NoSQL-injection sink) yielded directly usable, unexpired reset tokens for every
+account with a pending reset, enabling account takeover without further
+interaction (CWE-256, HIGH).
+
+The refresh-token subsystem already demonstrates the correct pattern
+(`AuthRefreshToken` stores `hash('sha256', $plainToken)` and looks up by hash);
+the password-reset path did not follow it.
+
+## Functional Requirements
+
+- **FR-1** — `PasswordResetToken` MUST persist only a SHA-256 hash of the token
+  (`hash('sha256', $plainToken)`) as its stored value / document identifier. The
+  plaintext token MUST NOT be persisted.
+- **FR-2** — `PasswordResetToken` MUST expose the plaintext token transiently for
+  e-mail delivery (`getPlainToken()`), populated at creation and re-attachable
+  for delivery, never written to storage.
+- **FR-3** — `MongoDBPasswordResetTokenRepository::findByToken()` MUST hash the
+  incoming candidate (`PasswordResetToken::hashToken()`) before querying, so the
+  lookup is by stored hash, never by raw plaintext.
+- **FR-4** — `PasswordResetToken::matchesToken()` MUST compare a candidate
+  plaintext against the stored hash using a constant-time comparison
+  (`hash_equals`).
+- **FR-5** — The password-reset request → e-mail flow MUST continue to deliver the
+  usable plaintext token in the reset link: the request command handler carries
+  the plaintext in the domain event, and the request subscriber re-attaches it to
+  the reconstituted entity before the e-mail send event is built.
+
+## Non-Functional Requirements
+
+- **NFR-Security** — A read-only exposure of `password_reset_tokens` MUST NOT
+  yield usable reset credentials. Submitting a stored hash to the confirm
+  endpoint MUST fail (the hash of a hash does not match). Token generation
+  continues to use `random_bytes` (256-bit entropy at the default length 32) and
+  single-use / short expiry semantics are unchanged.
+- **NFR-Compatibility** — The public reset/confirm HTTP and GraphQL contracts are
+  unchanged. The Doctrine document identifier remains `tokenValue` (now a 64-char
+  SHA-256 hex string); no migration of mapping strategy is required. Existing
+  seeders, fixtures, and E2E flows continue to function by replaying the
+  plaintext captured at creation time.
+- **NFR-Maintainability** — The fix mirrors the established `AuthRefreshToken`
+  hash-at-rest precedent, stays within hexagonal/DDD boundaries (hashing lives in
+  the framework-free Domain entity, lookup hashing in Infrastructure), introduces
+  no new directories or `*Service` suffixes, and keeps PHPInsights complexity and
+  quality/style thresholds intact (Deptrac 0, Psalm clean, CS-Fixer clean).
+
+## Out of Scope
+
+- **Email-confirmation tokens** (`ConfirmationToken` via `RedisTokenRepository`).
+  These are stored in an ephemeral Redis cache (24h TTL), keyed by both raw token
+  value and user id, with the serialized document carrying the raw value. The
+  brief grades this path "low"; hashing it would change the cache key/serialization
+  contract and the user-id reverse lookup, a materially different and broader
+  change than the HIGH MongoDB at-rest finding. Tracked separately to keep this
+  remediation minimal and focused.
+- Re-keying / re-hashing of tokens already persisted before deployment (short
+  1-hour expiry drains them quickly).
+- Adding a server-side pepper/HMAC. The token has 256 bits of entropy, so SHA-256
+  is sufficient and consistent with the existing refresh-token precedent.

--- a/specs/security-313-reset-confirm-tokens-plaintext/stories.md
+++ b/specs/security-313-reset-confirm-tokens-plaintext/stories.md
@@ -56,6 +56,7 @@ Tests: `tests/Unit/User/Infrastructure/Repository/MongoDBPasswordResetTokenRepos
 reloaded entity; `PasswordResetEmailSendEventFactory` emits the plaintext.
 
 Tests:
+
 - `tests/Unit/User/Application/CommandHandler/RequestPasswordResetCommandHandlerTest.php`
   — **Positive**: event factory receives the plaintext token; **Negative**:
   unknown user publishes nothing.
@@ -76,6 +77,7 @@ Schemathesis/seeder tests assert by hashed key; E2E/Memory helpers replay the
 plaintext captured at creation (`getPlainToken()` / `getLastPasswordResetToken()`).
 
 Tests:
+
 - `tests/Unit/DataFixtures/Seeder/PasswordResetTokenSeederTest.php` — **Positive**:
   seeded tokens are keyed by hash and resolvable via `findByToken(plain)`;
   **Edge**: existing-token refresh/extend/reset-usage paths still match by hash.

--- a/specs/security-313-reset-confirm-tokens-plaintext/stories.md
+++ b/specs/security-313-reset-confirm-tokens-plaintext/stories.md
@@ -1,0 +1,84 @@
+# Stories — Security #313: Hash password-reset tokens at rest
+
+Verification commands (one-off containers; do not start the shared stack):
+
+```sh
+# Unit tests (security-critical + regression)
+docker run --rm -v /home/kravtsov/Projects/secfix-313:/app \
+  -v /home/kravtsov/Projects/user-service/vendor:/app/vendor:ro -w /app \
+  -e APP_ENV=test --entrypoint sh secfix-312-php:latest -lc \
+  'php -d memory_limit=-1 vendor/bin/phpunit --testsuite=Unit \
+   --filter "PasswordResetToken|ConfirmationToken|Repository|SeedSchemathesisData" --no-coverage'
+
+# Architecture boundaries
+docker run --rm ... -lc 'vendor/bin/deptrac analyse --config-file=deptrac.yaml --no-progress'
+# Static analysis (changed files)
+docker run --rm ... -lc 'vendor/bin/psalm --no-cache --no-progress <changed .php files>'
+# Style (changed files)
+docker run --rm ... -lc 'PHP_CS_FIXER_IGNORE_ENV=1 vendor/bin/php-cs-fixer fix --dry-run \
+   --allow-risky=yes --config=.php-cs-fixer.dist.php --path-mode=intersection <changed .php files>'
+```
+
+---
+
+## Story 1 — Persist only a SHA-256 hash of the reset token (FR-1, FR-4, NFR-Security)
+
+Change `PasswordResetToken` so the constructor receives the plaintext, stores
+`hash('sha256', $plain)` as `tokenValue` (the document id), keeps a transient
+`plainToken`, and adds `hashToken()` / `matchesToken()` (constant-time).
+
+Tests: `tests/Unit/User/Domain/Entity/PasswordResetTokenHashingTest.php`
+
+- **Positive** — `testStoredValueIsHashNotPlaintext`, `testMatchesTokenAcceptsCorrectPlaintext`:
+  stored value equals the SHA-256 of the plaintext and the correct plaintext matches.
+- **Negative** — `testMatchesTokenRejectsWrongPlaintext`,
+  `testMatchesTokenRejectsStoredHashSubmittedAsToken`: a wrong plaintext and the
+  stored hash itself (what a DB-read attacker sees) both fail to match.
+- **Edge** — `testHashTokenIsDeterministicAndSha256` (64-char deterministic hex),
+  `testAttachPlainTokenRestoresDeliveryValue` (transient re-attachment).
+
+## Story 2 — Look up reset tokens by hash, never by raw plaintext (FR-3, NFR-Security)
+
+Change `MongoDBPasswordResetTokenRepository::findByToken()` to query
+`['tokenValue' => PasswordResetToken::hashToken($token)]`.
+
+Tests: `tests/Unit/User/Infrastructure/Repository/MongoDBPasswordResetTokenRepositoryTest.php`
+
+- **Positive** — `testFindByTokenLooksUpByHashNotPlaintext`: `findOneBy` is called
+  with the hashed criterion and returns the token.
+- **Negative/Edge** — `testFindByTokenDoesNotQueryWithRawPlaintext`: asserts the
+  query criterion is NOT the raw value and IS its SHA-256 hash.
+
+## Story 3 — Deliver the usable plaintext token through the request → e-mail flow (FR-2, FR-5, NFR-Compatibility)
+
+`RequestPasswordResetCommandHandler` emits `getPlainToken()` in the event;
+`PasswordResetRequestedEventSubscriber` re-attaches `event->token` to the
+reloaded entity; `PasswordResetEmailSendEventFactory` emits the plaintext.
+
+Tests:
+- `tests/Unit/User/Application/CommandHandler/RequestPasswordResetCommandHandlerTest.php`
+  — **Positive**: event factory receives the plaintext token; **Negative**:
+  unknown user publishes nothing.
+- `tests/Unit/User/Application/EventSubscriber/PasswordResetRequestedEventSubscriberTest.php`
+  — **Positive**: `attachPlainToken($event->token)` is invoked then the e-mail is
+  dispatched; **Negative**: missing token short-circuits.
+- `tests/Unit/User/Domain/Factory/Event/PasswordResetEmailSendEventFactoryTest.php`
+  — **Positive/Edge**: emitted `tokenValue` equals the plaintext and differs from
+  the stored hash.
+- `tests/Unit/User/Domain/Factory/PasswordResetTokenFactoryTest.php`
+  — **Edge**: plaintext length stays `tokenLength * 2`; stored value is 64 hex
+  chars and matches its plaintext.
+
+## Story 4 — Keep seeders, fixtures, and E2E flows working with hashed storage (NFR-Compatibility)
+
+`InMemoryPasswordResetTokenRepository::findByToken()` hashes the candidate; the
+Schemathesis/seeder tests assert by hashed key; E2E/Memory helpers replay the
+plaintext captured at creation (`getPlainToken()` / `getLastPasswordResetToken()`).
+
+Tests:
+- `tests/Unit/DataFixtures/Seeder/PasswordResetTokenSeederTest.php` — **Positive**:
+  seeded tokens are keyed by hash and resolvable via `findByToken(plain)`;
+  **Edge**: existing-token refresh/extend/reset-usage paths still match by hash.
+- `tests/Unit/DataFixtures/Command/SeedSchemathesisDataCommandTest.php` —
+  **Positive/Edge**: stored tokens keyed by hashed fixture constants; existing
+  token removal still counted.

--- a/src/User/Application/CommandHandler/RequestPasswordResetCommandHandler.php
+++ b/src/User/Application/CommandHandler/RequestPasswordResetCommandHandler.php
@@ -45,7 +45,7 @@ final readonly class RequestPasswordResetCommandHandler implements
         $this->eventBus->publish(
             $this->eventFactory->create(
                 $user,
-                $token->getTokenValue(),
+                (string) $token->getPlainToken(),
                 (string) $this->uuidFactory->create()
             )
         );

--- a/src/User/Application/CommandHandler/RequestPasswordResetCommandHandler.php
+++ b/src/User/Application/CommandHandler/RequestPasswordResetCommandHandler.php
@@ -13,6 +13,7 @@ use App\User\Domain\Factory\Event\PasswordResetRequestedEventFactoryInterface;
 use App\User\Domain\Factory\PasswordResetTokenFactoryInterface;
 use App\User\Domain\Repository\PasswordResetTokenRepositoryInterface;
 use App\User\Domain\Repository\UserRepositoryInterface;
+use LogicException;
 use Symfony\Component\Uid\Factory\UuidFactory;
 
 final readonly class RequestPasswordResetCommandHandler implements
@@ -45,7 +46,9 @@ final readonly class RequestPasswordResetCommandHandler implements
         $this->eventBus->publish(
             $this->eventFactory->create(
                 $user,
-                (string) $token->getPlainToken(),
+                $token->getPlainToken() ?? throw new LogicException(
+                    'Password reset plain token is missing.'
+                ),
                 (string) $this->uuidFactory->create()
             )
         );

--- a/src/User/Application/EventSubscriber/PasswordResetRequestedEventSubscriber.php
+++ b/src/User/Application/EventSubscriber/PasswordResetRequestedEventSubscriber.php
@@ -34,6 +34,8 @@ final readonly class PasswordResetRequestedEventSubscriber implements
             return;
         }
 
+        $token->attachPlainToken($event->token);
+
         $this->commandBus->dispatch(
             $this->cmdFactory->create(
                 $this->emailFactory->create($token, $user)

--- a/src/User/Application/Factory/Event/PasswordResetEmailSendEventFactory.php
+++ b/src/User/Application/Factory/Event/PasswordResetEmailSendEventFactory.php
@@ -19,7 +19,7 @@ final class PasswordResetEmailSendEventFactory implements
         string $eventID,
     ): PasswordResetEmailSentEvent {
         return new PasswordResetEmailSentEvent(
-            $token->getTokenValue(),
+            $token->getPlainToken() ?? $token->getTokenValue(),
             $token->getUserID(),
             $user->getEmail(),
             $eventID,

--- a/src/User/Application/Factory/Event/PasswordResetEmailSendEventFactory.php
+++ b/src/User/Application/Factory/Event/PasswordResetEmailSendEventFactory.php
@@ -8,6 +8,7 @@ use App\User\Domain\Entity\PasswordResetTokenInterface;
 use App\User\Domain\Entity\UserInterface;
 use App\User\Domain\Event\PasswordResetEmailSentEvent;
 use App\User\Domain\Factory\Event\PasswordResetEmailSendEventFactoryInterface;
+use LogicException;
 
 final class PasswordResetEmailSendEventFactory implements
     PasswordResetEmailSendEventFactoryInterface
@@ -19,7 +20,9 @@ final class PasswordResetEmailSendEventFactory implements
         string $eventID,
     ): PasswordResetEmailSentEvent {
         return new PasswordResetEmailSentEvent(
-            $token->getPlainToken() ?? $token->getTokenValue(),
+            $token->getPlainToken() ?? throw new LogicException(
+                'Plain password reset token must be attached before sending email.'
+            ),
             $token->getUserID(),
             $user->getEmail(),
             $eventID,

--- a/src/User/Domain/Entity/PasswordResetToken.php
+++ b/src/User/Domain/Entity/PasswordResetToken.php
@@ -15,8 +15,10 @@ class PasswordResetToken implements PasswordResetTokenInterface
     /**
      * Transient plaintext token. Only populated when the token is created or
      * re-attached for delivery; it is never persisted (only the hash is).
+     * Defaults to null so reads stay safe after Doctrine hydration, which
+     * bypasses the constructor and never assigns this transient field.
      */
-    private ?string $plainToken;
+    private ?string $plainToken = null;
 
     public function __construct(
         string $plainToken,

--- a/src/User/Domain/Entity/PasswordResetToken.php
+++ b/src/User/Domain/Entity/PasswordResetToken.php
@@ -10,19 +10,59 @@ class PasswordResetToken implements PasswordResetTokenInterface
 {
     private bool $isUsed;
 
+    private string $tokenValue;
+
+    /**
+     * Transient plaintext token. Only populated when the token is created or
+     * re-attached for delivery; it is never persisted (only the hash is).
+     */
+    private ?string $plainToken;
+
     public function __construct(
-        private string $tokenValue,
+        string $plainToken,
         private string $userID,
         private DateTimeImmutable $expiresAt,
         private DateTimeImmutable $createdAt
     ) {
+        $this->plainToken = $plainToken;
+        $this->tokenValue = self::hashToken($plainToken);
         $this->isUsed = false;
     }
 
+    public static function hashToken(string $plainToken): string
+    {
+        return hash('sha256', $plainToken);
+    }
+
+    /**
+     * Stored hash of the token (used as the document identifier).
+     */
     #[\Override]
     public function getTokenValue(): string
     {
         return $this->tokenValue;
+    }
+
+    /**
+     * Plaintext token to embed in the reset link; null once reconstituted
+     * from storage and not re-attached.
+     */
+    #[\Override]
+    public function getPlainToken(): ?string
+    {
+        return $this->plainToken;
+    }
+
+    #[\Override]
+    public function attachPlainToken(string $plainToken): void
+    {
+        $this->plainToken = $plainToken;
+    }
+
+    #[\Override]
+    public function matchesToken(string $plainToken): bool
+    {
+        return hash_equals($this->tokenValue, self::hashToken($plainToken));
     }
 
     #[\Override]

--- a/src/User/Domain/Entity/PasswordResetTokenInterface.php
+++ b/src/User/Domain/Entity/PasswordResetTokenInterface.php
@@ -8,6 +8,12 @@ interface PasswordResetTokenInterface
 {
     public function getTokenValue(): string;
 
+    public function getPlainToken(): ?string;
+
+    public function attachPlainToken(string $plainToken): void;
+
+    public function matchesToken(string $plainToken): bool;
+
     public function getUserID(): string;
 
     public function getExpiresAt(): \DateTimeImmutable;

--- a/src/User/Infrastructure/Repository/MongoDBPasswordResetTokenRepository.php
+++ b/src/User/Infrastructure/Repository/MongoDBPasswordResetTokenRepository.php
@@ -39,7 +39,9 @@ final class MongoDBPasswordResetTokenRepository extends ServiceDocumentRepositor
     #[\Override]
     public function findByToken(string $token): ?PasswordResetTokenInterface
     {
-        return $this->findOneBy(['tokenValue' => $token]);
+        return $this->findOneBy([
+            'tokenValue' => PasswordResetToken::hashToken($token),
+        ]);
     }
 
     public function findByUserID(

--- a/src/User/Infrastructure/Repository/MongoDBPasswordResetTokenRepository.php
+++ b/src/User/Infrastructure/Repository/MongoDBPasswordResetTokenRepository.php
@@ -40,7 +40,7 @@ final class MongoDBPasswordResetTokenRepository extends ServiceDocumentRepositor
     public function findByToken(string $token): ?PasswordResetTokenInterface
     {
         return $this->findOneBy([
-            'tokenValue' => PasswordResetToken::hashToken($token),
+            'tokenValue' => hash('sha256', $token),
         ]);
     }
 

--- a/src/User/Infrastructure/Repository/MongoDBPasswordResetTokenRepository.php
+++ b/src/User/Infrastructure/Repository/MongoDBPasswordResetTokenRepository.php
@@ -39,6 +39,10 @@ final class MongoDBPasswordResetTokenRepository extends ServiceDocumentRepositor
     #[\Override]
     public function findByToken(string $token): ?PasswordResetTokenInterface
     {
+        // Hash mirrors PasswordResetToken::hashToken(); kept inline because the
+        // project's PHPMD cleancode ruleset forbids static access here. The
+        // MongoDBPasswordResetTokenRepositoryTest pins both sides to the same
+        // algorithm, so any future drift is caught by the test suite.
         return $this->findOneBy([
             'tokenValue' => hash('sha256', $token),
         ]);

--- a/tests/Behat/Support/PasswordResetTokenRecorder.php
+++ b/tests/Behat/Support/PasswordResetTokenRecorder.php
@@ -6,36 +6,67 @@ namespace App\Tests\Behat\Support;
 
 use App\Shared\Domain\Bus\Event\DomainEventSubscriberInterface;
 use App\User\Domain\Event\PasswordResetRequestedEvent;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Contracts\Service\ResetInterface;
 
 /**
- * Captures the plaintext password reset token emitted while handling an HTTP
+ * Captures the plaintext password reset token emitted while handling the reset
  * request. Only the hash is persisted, so the confirmation step replays the
  * plaintext recorded here instead of reading the stored hash.
+ *
+ * Behat drives the API over real HTTP (browserkit_http), so the reset event is
+ * dispatched inside the web-server process while the confirmation step resolves
+ * the token inside the Behat CLI process. The plaintext is therefore mirrored
+ * through the shared Redis instance (both processes use the same REDIS_URL) so
+ * it survives the process boundary. The in-memory copy still serves in-process
+ * flows that dispatch the event within the test runner.
  */
 final class PasswordResetTokenRecorder implements
     DomainEventSubscriberInterface,
     ResetInterface
 {
+    private const REDIS_KEY_PREFIX = 'behat:password-reset-token:';
+    private const REDIS_LAST_KEY = 'behat:password-reset-token:__last__';
+    private const REDIS_TTL_SECONDS = 600;
+
     private string $lastPlainToken = '';
 
     /** @var array<string, string> */
     private array $plainTokensByUserId = [];
 
+    private ?\Redis $redis = null;
+    private bool $redisUnavailable = false;
+
+    public function __construct(
+        #[Autowire('%env(REDIS_URL)%')]
+        private readonly string $redisUrl = '',
+    ) {
+    }
+
     public function __invoke(PasswordResetRequestedEvent $event): void
     {
         $this->lastPlainToken = $event->token;
         $this->plainTokensByUserId[$event->userId] = $event->token;
+
+        $this->writeToRedis($event->userId, $event->token);
     }
 
     public function getLastPlainToken(): string
     {
-        return $this->lastPlainToken;
+        if ($this->lastPlainToken !== '') {
+            return $this->lastPlainToken;
+        }
+
+        return $this->readFromRedis(self::REDIS_LAST_KEY) ?? '';
     }
 
     public function getPlainTokenForUser(string $userId): ?string
     {
-        return $this->plainTokensByUserId[$userId] ?? null;
+        if (isset($this->plainTokensByUserId[$userId])) {
+            return $this->plainTokensByUserId[$userId];
+        }
+
+        return $this->readFromRedis(self::REDIS_KEY_PREFIX . $userId);
     }
 
     /**
@@ -52,7 +83,79 @@ final class PasswordResetTokenRecorder implements
     #[\Override]
     public function reset(): void
     {
+        // Only the in-memory copy is reset here. The shared Redis mirror is
+        // owned by the web-server process and is purged per scenario by
+        // UserContext::clearCacheBeforeScenario(), so clearing it here could
+        // race with a write the web server just made for the current scenario.
         $this->lastPlainToken = '';
         $this->plainTokensByUserId = [];
+    }
+
+    private function writeToRedis(string $userId, string $token): void
+    {
+        $redis = $this->connection();
+        if ($redis === null) {
+            return;
+        }
+
+        $redis->setex(self::REDIS_KEY_PREFIX . $userId, self::REDIS_TTL_SECONDS, $token);
+        $redis->setex(self::REDIS_LAST_KEY, self::REDIS_TTL_SECONDS, $token);
+    }
+
+    private function readFromRedis(string $key): ?string
+    {
+        $redis = $this->connection();
+        if ($redis === null) {
+            return null;
+        }
+
+        $value = $redis->get($key);
+
+        return is_string($value) && $value !== '' ? $value : null;
+    }
+
+    private function connection(): ?\Redis
+    {
+        if ($this->redis instanceof \Redis) {
+            return $this->redis;
+        }
+
+        if ($this->redisUnavailable || $this->redisUrl === '') {
+            return null;
+        }
+
+        $this->redis = $this->createConnection();
+        if ($this->redis === null) {
+            $this->redisUnavailable = true;
+        }
+
+        return $this->redis;
+    }
+
+    private function createConnection(): ?\Redis
+    {
+        $parts = parse_url($this->redisUrl);
+        if (!is_array($parts) || !is_string($parts['host'] ?? null) || $parts['host'] === '') {
+            return null;
+        }
+
+        try {
+            $redis = new \Redis();
+            if ($redis->connect($parts['host'], (int) ($parts['port'] ?? 6379)) !== true) {
+                return null;
+            }
+
+            $password = $parts['pass'] ?? null;
+            if (is_string($password) && $password !== '') {
+                $redis->auth($password);
+            }
+
+            $database = isset($parts['path']) ? (int) ltrim((string) $parts['path'], '/') : 0;
+            $redis->select($database);
+
+            return $redis;
+        } catch (\RedisException) {
+            return null;
+        }
     }
 }

--- a/tests/Behat/Support/PasswordResetTokenRecorder.php
+++ b/tests/Behat/Support/PasswordResetTokenRecorder.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Behat\Support;
+
+use App\Shared\Domain\Bus\Event\DomainEventSubscriberInterface;
+use App\User\Domain\Event\PasswordResetRequestedEvent;
+use Symfony\Contracts\Service\ResetInterface;
+
+/**
+ * Captures the plaintext password reset token emitted while handling an HTTP
+ * request. Only the hash is persisted, so the confirmation step replays the
+ * plaintext recorded here instead of reading the stored hash.
+ */
+final class PasswordResetTokenRecorder implements
+    DomainEventSubscriberInterface,
+    ResetInterface
+{
+    private string $lastPlainToken = '';
+
+    /** @var array<string, string> */
+    private array $plainTokensByUserId = [];
+
+    public function __invoke(PasswordResetRequestedEvent $event): void
+    {
+        $this->lastPlainToken = $event->token;
+        $this->plainTokensByUserId[$event->userId] = $event->token;
+    }
+
+    public function getLastPlainToken(): string
+    {
+        return $this->lastPlainToken;
+    }
+
+    public function getPlainTokenForUser(string $userId): ?string
+    {
+        return $this->plainTokensByUserId[$userId] ?? null;
+    }
+
+    /**
+     * @return array<string>
+     *
+     * @psalm-return list{PasswordResetRequestedEvent::class}
+     */
+    #[\Override]
+    public function subscribedTo(): array
+    {
+        return [PasswordResetRequestedEvent::class];
+    }
+
+    #[\Override]
+    public function reset(): void
+    {
+        $this->lastPlainToken = '';
+        $this->plainTokensByUserId = [];
+    }
+}

--- a/tests/Behat/UserContext/UserContext.php
+++ b/tests/Behat/UserContext/UserContext.php
@@ -167,7 +167,8 @@ final class UserContext implements Context
         $token = $this->userManagement->passwordResetTokenFactory->create($user->getId());
         $this->userManagement->passwordResetTokenRepository->save($token);
 
-        self::$lastPasswordResetToken = $token->getTokenValue();
+        self::$lastPasswordResetToken =
+            $token->getPlainToken() ?? $token->getTokenValue();
         self::$currentTokenUserEmail = $email;
     }
 

--- a/tests/Behat/UserContext/UserPasswordResetRequestContext.php
+++ b/tests/Behat/UserContext/UserPasswordResetRequestContext.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Behat\UserContext;
 
+use App\Tests\Behat\Support\PasswordResetTokenRecorder;
 use App\Tests\Behat\UserContext\Input\ConfirmPasswordResetInput;
 use App\Tests\Behat\UserContext\Input\RequestPasswordResetInput;
 use App\User\Domain\Entity\User;
@@ -14,6 +15,7 @@ final class UserPasswordResetRequestContext implements Context
     public function __construct(
         private UserOperationsState $state,
         private readonly UserContextUserManagementServices $userManagement,
+        private readonly PasswordResetTokenRecorder $tokenRecorder,
     ) {
     }
 
@@ -101,12 +103,35 @@ final class UserPasswordResetRequestContext implements Context
             );
         }
 
-        // Only the hash is persisted; the usable plaintext is captured at
-        // creation time and replayed here for the confirmation request.
-        $capturedPlainToken = UserContext::getLastPasswordResetToken();
+        return $this->resolvePlainToken($user->getId(), $token->getPlainToken());
+    }
 
-        return $token->getPlainToken()
-            ?? ($capturedPlainToken !== '' ? $capturedPlainToken : $token->getTokenValue());
+    /**
+     * Only the hash is persisted, so the usable plaintext is replayed from the
+     * value captured when the token was issued (via the HTTP request that
+     * dispatched the reset event, the in-process factory step, or the entity's
+     * transient plaintext) rather than the stored hash.
+     */
+    private function resolvePlainToken(string $userId, ?string $transientPlainToken): string
+    {
+        $recordedPlainToken = $this->tokenRecorder->getPlainTokenForUser($userId)
+            ?? $this->tokenRecorder->getLastPlainToken();
+        if ($recordedPlainToken !== '') {
+            return $recordedPlainToken;
+        }
+
+        if ($transientPlainToken !== null && $transientPlainToken !== '') {
+            return $transientPlainToken;
+        }
+
+        $capturedPlainToken = UserContext::getLastPasswordResetToken();
+        if ($capturedPlainToken !== '') {
+            return $capturedPlainToken;
+        }
+
+        throw new \RuntimeException(
+            'No plaintext password reset token was captured for confirmation.'
+        );
     }
 
     private function requireCurrentUserEmail(): string

--- a/tests/Behat/UserContext/UserPasswordResetRequestContext.php
+++ b/tests/Behat/UserContext/UserPasswordResetRequestContext.php
@@ -101,7 +101,12 @@ final class UserPasswordResetRequestContext implements Context
             );
         }
 
-        return $token->getTokenValue();
+        // Only the hash is persisted; the usable plaintext is captured at
+        // creation time and replayed here for the confirmation request.
+        $capturedPlainToken = UserContext::getLastPasswordResetToken();
+
+        return $token->getPlainToken()
+            ?? ($capturedPlainToken !== '' ? $capturedPlainToken : $token->getTokenValue());
     }
 
     private function requireCurrentUserEmail(): string

--- a/tests/Memory/GraphQL/GraphQLMemoryWebTestCase.php
+++ b/tests/Memory/GraphQL/GraphQLMemoryWebTestCase.php
@@ -501,7 +501,7 @@ GRAPHQL;
         $this->assertInstanceOf(PasswordResetToken::class, $token);
         $this->passwordResetTokenRepository->save($token);
 
-        return $token->getTokenValue();
+        return $token->getPlainToken() ?? $token->getTokenValue();
     }
 
     /**

--- a/tests/Memory/Rest/PasswordResetMemoryTest.php
+++ b/tests/Memory/Rest/PasswordResetMemoryTest.php
@@ -34,7 +34,7 @@ final class PasswordResetMemoryTest extends RestMemoryWebTestCase
                 'POST',
                 '/api/reset-password/confirm',
                 [
-                    'token' => $token->getTokenValue(),
+                    'token' => $token->getPlainToken() ?? $token->getTokenValue(),
                     'newPassword' => $password,
                 ]
             );

--- a/tests/Unit/DataFixtures/Command/SeedSchemathesisDataCommandTest.php
+++ b/tests/Unit/DataFixtures/Command/SeedSchemathesisDataCommandTest.php
@@ -20,6 +20,7 @@ use App\Tests\Unit\Shared\Application\Command\Fixture\RecordingAuthorizationCode
 use App\Tests\Unit\Shared\Application\Command\Fixture\RecordingClientManager;
 use App\Tests\Unit\UnitTestCase;
 use App\User\Domain\Entity\ConfirmationToken;
+use App\User\Domain\Entity\PasswordResetToken;
 use App\User\Domain\Entity\UserInterface;
 use App\User\Domain\Factory\UserFactory;
 use DateTimeImmutable;
@@ -78,7 +79,9 @@ final class SeedSchemathesisDataCommandTest extends UnitTestCase
         $storedTokens = $deps['passwordResetTokenRepository']->all();
         $this->assertCount(2, $storedTokens);
         $this->assertArrayHasKey(
-            SchemathesisFixtures::PASSWORD_RESET_CONFIRM_TOKEN,
+            PasswordResetToken::hashToken(
+                SchemathesisFixtures::PASSWORD_RESET_CONFIRM_TOKEN
+            ),
             $storedTokens
         );
         $this->assertSame(1, $deps['passwordResetTokenRepository']->deleteCount());
@@ -395,11 +398,16 @@ final class SeedSchemathesisDataCommandTest extends UnitTestCase
     private function assertPasswordResetTokens(
         InMemoryPasswordResetTokenRepository $passwordResetTokenRepository
     ): void {
-        $confirmTokenLd = SchemathesisFixtures::PASSWORD_RESET_CONFIRM_TOKEN_LD;
+        $confirmTokenLd = PasswordResetToken::hashToken(
+            SchemathesisFixtures::PASSWORD_RESET_CONFIRM_TOKEN_LD
+        );
+        $confirmTokenHash = PasswordResetToken::hashToken(
+            SchemathesisFixtures::PASSWORD_RESET_CONFIRM_TOKEN
+        );
         $storedTokens = $passwordResetTokenRepository->all();
         $this->assertCount(2, $storedTokens);
         $this->assertArrayHasKey(
-            SchemathesisFixtures::PASSWORD_RESET_CONFIRM_TOKEN,
+            $confirmTokenHash,
             $storedTokens
         );
         $this->assertArrayHasKey(
@@ -408,7 +416,7 @@ final class SeedSchemathesisDataCommandTest extends UnitTestCase
         );
         $this->assertSame(
             SchemathesisFixtures::PASSWORD_RESET_CONFIRM_USER_ID,
-            $storedTokens[SchemathesisFixtures::PASSWORD_RESET_CONFIRM_TOKEN]->getUserID()
+            $storedTokens[$confirmTokenHash]->getUserID()
         );
         $this->assertSame(
             SchemathesisFixtures::PASSWORD_RESET_CONFIRM_USER_ID,

--- a/tests/Unit/DataFixtures/Command/SeedSchemathesisDataCommandTest.php
+++ b/tests/Unit/DataFixtures/Command/SeedSchemathesisDataCommandTest.php
@@ -398,29 +398,30 @@ final class SeedSchemathesisDataCommandTest extends UnitTestCase
     private function assertPasswordResetTokens(
         InMemoryPasswordResetTokenRepository $passwordResetTokenRepository
     ): void {
-        $confirmTokenLd = PasswordResetToken::hashToken(
-            SchemathesisFixtures::PASSWORD_RESET_CONFIRM_TOKEN_LD
-        );
-        $confirmTokenHash = PasswordResetToken::hashToken(
-            SchemathesisFixtures::PASSWORD_RESET_CONFIRM_TOKEN
-        );
         $storedTokens = $passwordResetTokenRepository->all();
         $this->assertCount(2, $storedTokens);
-        $this->assertArrayHasKey(
-            $confirmTokenHash,
-            $storedTokens
+        $this->assertStoredPasswordResetToken(
+            $storedTokens,
+            SchemathesisFixtures::PASSWORD_RESET_CONFIRM_TOKEN
         );
-        $this->assertArrayHasKey(
-            $confirmTokenLd,
-            $storedTokens
+        $this->assertStoredPasswordResetToken(
+            $storedTokens,
+            SchemathesisFixtures::PASSWORD_RESET_CONFIRM_TOKEN_LD
         );
+    }
+
+    /**
+     * @param array<string, PasswordResetToken> $storedTokens
+     */
+    private function assertStoredPasswordResetToken(
+        array $storedTokens,
+        string $plainToken
+    ): void {
+        $tokenHash = PasswordResetToken::hashToken($plainToken);
+        $this->assertArrayHasKey($tokenHash, $storedTokens);
         $this->assertSame(
             SchemathesisFixtures::PASSWORD_RESET_CONFIRM_USER_ID,
-            $storedTokens[$confirmTokenHash]->getUserID()
-        );
-        $this->assertSame(
-            SchemathesisFixtures::PASSWORD_RESET_CONFIRM_USER_ID,
-            $storedTokens[$confirmTokenLd]->getUserID()
+            $storedTokens[$tokenHash]->getUserID()
         );
     }
 

--- a/tests/Unit/DataFixtures/Seeder/PasswordResetTokenSeederTest.php
+++ b/tests/Unit/DataFixtures/Seeder/PasswordResetTokenSeederTest.php
@@ -26,8 +26,10 @@ final class PasswordResetTokenSeederTest extends UnitTestCase
 
         $tokens = $repository->all();
         $this->assertCount(2, $tokens);
-        $this->assertArrayHasKey('token1', $tokens);
-        $this->assertArrayHasKey('token2', $tokens);
+        $this->assertArrayHasKey(PasswordResetToken::hashToken('token1'), $tokens);
+        $this->assertArrayHasKey(PasswordResetToken::hashToken('token2'), $tokens);
+        $this->assertNotNull($repository->findByToken('token1'));
+        $this->assertNotNull($repository->findByToken('token2'));
     }
 
     public function testSeedTokensUpdatesExistingTokenInsteadOfDeleting(): void

--- a/tests/Unit/Shared/Application/Command/Fixture/InMemoryPasswordResetTokenRepository.php
+++ b/tests/Unit/Shared/Application/Command/Fixture/InMemoryPasswordResetTokenRepository.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Unit\Shared\Application\Command\Fixture;
 
 use App\User\Domain\Collection\PasswordResetTokenCollection;
+use App\User\Domain\Entity\PasswordResetToken;
 use App\User\Domain\Entity\PasswordResetTokenInterface;
 use App\User\Domain\Repository\PasswordResetTokenRepositoryInterface;
 
@@ -33,7 +34,7 @@ final class InMemoryPasswordResetTokenRepository implements PasswordResetTokenRe
     #[\Override]
     public function findByToken(string $token): ?PasswordResetTokenInterface
     {
-        return $this->tokens[$token] ?? null;
+        return $this->tokens[PasswordResetToken::hashToken($token)] ?? null;
     }
 
     public function deleteCount(): int

--- a/tests/Unit/User/Application/CommandHandler/RequestPasswordResetCommandHandlerTest.php
+++ b/tests/Unit/User/Application/CommandHandler/RequestPasswordResetCommandHandlerTest.php
@@ -132,7 +132,7 @@ final class RequestPasswordResetCommandHandlerTest extends UnitTestCase
     private function createPasswordResetMocks(array $testData): array
     {
         $token = $this->createMock(PasswordResetTokenInterface::class);
-        $token->method('getTokenValue')->willReturn($testData['tokenValue']);
+        $token->method('getPlainToken')->willReturn($testData['tokenValue']);
 
         $user = $this->createMock(UserInterface::class);
         $user->method('getId')->willReturn($testData['userId']);

--- a/tests/Unit/User/Application/CommandHandler/RequestPasswordResetCommandHandlerTest.php
+++ b/tests/Unit/User/Application/CommandHandler/RequestPasswordResetCommandHandlerTest.php
@@ -73,33 +73,8 @@ final class RequestPasswordResetCommandHandlerTest extends UnitTestCase
     public function testRequestPasswordResetThrowsWhenPlainTokenMissing(): void
     {
         $email = $this->faker->email();
-        $userId = $this->faker->uuid();
 
-        $user = $this->createMock(UserInterface::class);
-        $user->method('getId')->willReturn($userId);
-
-        $token = $this->createMock(PasswordResetTokenInterface::class);
-        $token->method('getPlainToken')->willReturn(null);
-
-        $this->userRepository
-            ->expects($this->once())
-            ->method('findByEmail')
-            ->with($email)
-            ->willReturn($user);
-
-        $this->passwordResetTokenFactory
-            ->expects($this->once())
-            ->method('create')
-            ->with($userId)
-            ->willReturn($token);
-
-        $this->eventFactory
-            ->expects($this->never())
-            ->method('create');
-
-        $this->eventBus
-            ->expects($this->never())
-            ->method('publish');
+        $this->setupMissingPlainTokenExpectations($email, $this->faker->uuid());
 
         $this->expectException(\LogicException::class);
         $this->expectExceptionMessage('Password reset plain token is missing.');
@@ -134,6 +109,35 @@ final class RequestPasswordResetCommandHandlerTest extends UnitTestCase
         $this->passwordResetTokenFactory
             ->expects($this->never())
             ->method('create');
+
+        $this->eventFactory
+            ->expects($this->never())
+            ->method('create');
+
+        $this->eventBus
+            ->expects($this->never())
+            ->method('publish');
+    }
+
+    private function setupMissingPlainTokenExpectations(string $email, string $userId): void
+    {
+        $user = $this->createMock(UserInterface::class);
+        $user->method('getId')->willReturn($userId);
+
+        $token = $this->createMock(PasswordResetTokenInterface::class);
+        $token->method('getPlainToken')->willReturn(null);
+
+        $this->userRepository
+            ->expects($this->once())
+            ->method('findByEmail')
+            ->with($email)
+            ->willReturn($user);
+
+        $this->passwordResetTokenFactory
+            ->expects($this->once())
+            ->method('create')
+            ->with($userId)
+            ->willReturn($token);
 
         $this->eventFactory
             ->expects($this->never())

--- a/tests/Unit/User/Application/CommandHandler/RequestPasswordResetCommandHandlerTest.php
+++ b/tests/Unit/User/Application/CommandHandler/RequestPasswordResetCommandHandlerTest.php
@@ -70,6 +70,43 @@ final class RequestPasswordResetCommandHandlerTest extends UnitTestCase
         $this->assertPasswordResetResponse($response);
     }
 
+    public function testRequestPasswordResetThrowsWhenPlainTokenMissing(): void
+    {
+        $email = $this->faker->email();
+        $userId = $this->faker->uuid();
+
+        $user = $this->createMock(UserInterface::class);
+        $user->method('getId')->willReturn($userId);
+
+        $token = $this->createMock(PasswordResetTokenInterface::class);
+        $token->method('getPlainToken')->willReturn(null);
+
+        $this->userRepository
+            ->expects($this->once())
+            ->method('findByEmail')
+            ->with($email)
+            ->willReturn($user);
+
+        $this->passwordResetTokenFactory
+            ->expects($this->once())
+            ->method('create')
+            ->with($userId)
+            ->willReturn($token);
+
+        $this->eventFactory
+            ->expects($this->never())
+            ->method('create');
+
+        $this->eventBus
+            ->expects($this->never())
+            ->method('publish');
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Password reset plain token is missing.');
+
+        $this->handler->__invoke(new RequestPasswordResetCommand($email));
+    }
+
     public function testRequestPasswordResetForNonExistingUser(): void
     {
         $email = $this->faker->email();

--- a/tests/Unit/User/Application/EventSubscriber/PasswordResetRequestedEventSubscriberTest.php
+++ b/tests/Unit/User/Application/EventSubscriber/PasswordResetRequestedEventSubscriberTest.php
@@ -126,6 +126,10 @@ final class PasswordResetRequestedEventSubscriberTest extends UnitTestCase
             ->with($tokenValue)
             ->willReturn($mocks['token']);
 
+        $mocks['token']->expects($this->once())
+            ->method('attachPlainToken')
+            ->with($tokenValue);
+
         $this->emailFactory->expects($this->once())
             ->method('create')
             ->with($mocks['token'], $mocks['user'])

--- a/tests/Unit/User/Application/EventSubscriber/PasswordResetRequestedEventSubscriberTest.php
+++ b/tests/Unit/User/Application/EventSubscriber/PasswordResetRequestedEventSubscriberTest.php
@@ -116,6 +116,15 @@ final class PasswordResetRequestedEventSubscriberTest extends UnitTestCase
      */
     private function setupSuccessfulFlow(string $tokenValue, array $mocks): void
     {
+        $this->setupLookupExpectations($tokenValue, $mocks);
+        $this->setupEmailDispatchExpectations($mocks);
+    }
+
+    /**
+     * @param array<string, \PHPUnit\Framework\MockObject\MockObject> $mocks
+     */
+    private function setupLookupExpectations(string $tokenValue, array $mocks): void
+    {
         $this->userRepository->expects($this->once())
             ->method('findById')
             ->with($this->anything())
@@ -129,7 +138,13 @@ final class PasswordResetRequestedEventSubscriberTest extends UnitTestCase
         $mocks['token']->expects($this->once())
             ->method('attachPlainToken')
             ->with($tokenValue);
+    }
 
+    /**
+     * @param array<string, \PHPUnit\Framework\MockObject\MockObject> $mocks
+     */
+    private function setupEmailDispatchExpectations(array $mocks): void
+    {
         $this->emailFactory->expects($this->once())
             ->method('create')
             ->with($mocks['token'], $mocks['user'])

--- a/tests/Unit/User/Domain/Entity/PasswordResetTokenHashingTest.php
+++ b/tests/Unit/User/Domain/Entity/PasswordResetTokenHashingTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\User\Domain\Entity;
+
+use App\Tests\Unit\UnitTestCase;
+use App\User\Domain\Entity\PasswordResetToken;
+use DateTimeImmutable;
+
+final class PasswordResetTokenHashingTest extends UnitTestCase
+{
+    public function testStoredValueIsHashNotPlaintext(): void
+    {
+        $plainToken = $this->faker->sha256();
+
+        $token = $this->createToken($plainToken);
+
+        $this->assertSame($plainToken, $token->getPlainToken());
+        $this->assertNotSame($plainToken, $token->getTokenValue());
+        $this->assertSame(
+            hash('sha256', $plainToken),
+            $token->getTokenValue()
+        );
+    }
+
+    public function testHashTokenIsDeterministicAndSha256(): void
+    {
+        $plainToken = 'reset-token-value';
+
+        $this->assertSame(
+            hash('sha256', $plainToken),
+            PasswordResetToken::hashToken($plainToken)
+        );
+        $this->assertSame(
+            PasswordResetToken::hashToken($plainToken),
+            PasswordResetToken::hashToken($plainToken)
+        );
+        $this->assertSame(64, strlen(PasswordResetToken::hashToken($plainToken)));
+    }
+
+    public function testMatchesTokenAcceptsCorrectPlaintext(): void
+    {
+        $plainToken = $this->faker->sha256();
+
+        $token = $this->createToken($plainToken);
+
+        $this->assertTrue($token->matchesToken($plainToken));
+    }
+
+    public function testMatchesTokenRejectsWrongPlaintext(): void
+    {
+        $token = $this->createToken('correct-plaintext-token');
+
+        $this->assertFalse($token->matchesToken('wrong-plaintext-token'));
+    }
+
+    public function testMatchesTokenRejectsStoredHashSubmittedAsToken(): void
+    {
+        $plainToken = $this->faker->sha256();
+        $token = $this->createToken($plainToken);
+
+        // A DB-read attacker only sees the stored hash; submitting it must fail.
+        $this->assertFalse($token->matchesToken($token->getTokenValue()));
+    }
+
+    public function testAttachPlainTokenRestoresDeliveryValue(): void
+    {
+        $plainToken = $this->faker->sha256();
+        $token = $this->createToken($plainToken);
+
+        // Simulate reconstitution from storage where only the hash survives.
+        $token->attachPlainToken('re-attached-token');
+
+        $this->assertSame('re-attached-token', $token->getPlainToken());
+    }
+
+    private function createToken(string $plainToken): PasswordResetToken
+    {
+        return new PasswordResetToken(
+            $plainToken,
+            $this->faker->uuid(),
+            new DateTimeImmutable('+1 hour'),
+            new DateTimeImmutable()
+        );
+    }
+}

--- a/tests/Unit/User/Domain/Entity/PasswordResetTokenHashingTest.php
+++ b/tests/Unit/User/Domain/Entity/PasswordResetTokenHashingTest.php
@@ -75,6 +75,30 @@ final class PasswordResetTokenHashingTest extends UnitTestCase
         $this->assertSame('re-attached-token', $token->getPlainToken());
     }
 
+    public function testGetPlainTokenIsNullAfterConstructorlessHydration(): void
+    {
+        // Doctrine ODM rebuilds entities without calling the constructor, so a
+        // typed transient property without a default would be uninitialized
+        // and reads would fatal. The null default keeps reads safe.
+        $token = (new \ReflectionClass(PasswordResetToken::class))
+            ->newInstanceWithoutConstructor();
+
+        $this->assertNull($token->getPlainToken());
+    }
+
+    public function testAttachPlainTokenWorksAfterConstructorlessHydration(): void
+    {
+        $token = (new \ReflectionClass(PasswordResetToken::class))
+            ->newInstanceWithoutConstructor();
+
+        $token->attachPlainToken('reattached-after-hydration');
+
+        $this->assertSame(
+            'reattached-after-hydration',
+            $token->getPlainToken()
+        );
+    }
+
     private function createToken(string $plainToken): PasswordResetToken
     {
         return new PasswordResetToken(

--- a/tests/Unit/User/Domain/Factory/Event/PasswordResetEmailSendEventFactoryTest.php
+++ b/tests/Unit/User/Domain/Factory/Event/PasswordResetEmailSendEventFactoryTest.php
@@ -8,6 +8,7 @@ use App\Shared\Domain\ValueObject\Uuid;
 use App\Tests\Unit\UnitTestCase;
 use App\User\Application\Factory\Event\PasswordResetEmailSendEventFactory;
 use App\User\Domain\Entity\PasswordResetToken;
+use App\User\Domain\Entity\PasswordResetTokenInterface;
 use App\User\Domain\Event\PasswordResetEmailSentEvent;
 use App\User\Domain\Factory\UserFactory;
 
@@ -28,6 +29,21 @@ final class PasswordResetEmailSendEventFactoryTest extends UnitTestCase
         $this->assertSame($token->getUserID(), $event->userId);
         $this->assertSame($user->getEmail(), $event->email);
         $this->assertSame($eventId, $event->eventId());
+    }
+
+    public function testCreateThrowsWhenPlainTokenMissing(): void
+    {
+        $user = $this->createUser();
+        $token = $this->createMock(PasswordResetTokenInterface::class);
+        $token->method('getPlainToken')->willReturn(null);
+        $factory = new PasswordResetEmailSendEventFactory();
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage(
+            'Plain password reset token must be attached before sending email.'
+        );
+
+        $factory->create($token, $user, $this->faker->uuid());
     }
 
     private function createUser(): \App\User\Domain\Entity\User

--- a/tests/Unit/User/Domain/Factory/Event/PasswordResetEmailSendEventFactoryTest.php
+++ b/tests/Unit/User/Domain/Factory/Event/PasswordResetEmailSendEventFactoryTest.php
@@ -23,7 +23,8 @@ final class PasswordResetEmailSendEventFactoryTest extends UnitTestCase
         $event = $factory->create($token, $user, $eventId);
 
         $this->assertInstanceOf(PasswordResetEmailSentEvent::class, $event);
-        $this->assertSame($token->getTokenValue(), $event->tokenValue);
+        $this->assertSame($token->getPlainToken(), $event->tokenValue);
+        $this->assertNotSame($token->getTokenValue(), $event->tokenValue);
         $this->assertSame($token->getUserID(), $event->userId);
         $this->assertSame($user->getEmail(), $event->email);
         $this->assertSame($eventId, $event->eventId());

--- a/tests/Unit/User/Domain/Factory/PasswordResetTokenFactoryTest.php
+++ b/tests/Unit/User/Domain/Factory/PasswordResetTokenFactoryTest.php
@@ -25,7 +25,10 @@ final class PasswordResetTokenFactoryTest extends UnitTestCase
 
         $this->assertInstanceOf(PasswordResetToken::class, $token);
         $this->assertSame($userId, $token->getUserID());
-        $this->assertSame($tokenLength * 2, strlen($token->getTokenValue()));
+        $this->assertSame($tokenLength * 2, strlen((string) $token->getPlainToken()));
+        $this->assertSame(64, strlen($token->getTokenValue()));
+        $this->assertNotSame($token->getPlainToken(), $token->getTokenValue());
+        $this->assertTrue($token->matchesToken((string) $token->getPlainToken()));
         $this->assertFalse($token->isUsed());
         $this->assertSame($expirationHours, $this->calculateHoursBetween($token));
 

--- a/tests/Unit/User/Infrastructure/Repository/MongoDBPasswordResetTokenRepositoryTest.php
+++ b/tests/Unit/User/Infrastructure/Repository/MongoDBPasswordResetTokenRepositoryTest.php
@@ -53,19 +53,40 @@ final class MongoDBPasswordResetTokenRepositoryTest extends UnitTestCase
         $this->repository->save($token);
     }
 
-    public function testFindByToken(): void
+    public function testFindByTokenLooksUpByHashNotPlaintext(): void
     {
         $tokenValue = $this->faker->uuid();
         $expectedToken = $this->createMock(PasswordResetTokenInterface::class);
 
         $this->setupFindOneByExpectation(
-            ['tokenValue' => $tokenValue],
+            ['tokenValue' => PasswordResetToken::hashToken($tokenValue)],
             $expectedToken
         );
 
         $result = $this->repository->findByToken($tokenValue);
 
         $this->assertSame($expectedToken, $result);
+    }
+
+    public function testFindByTokenDoesNotQueryWithRawPlaintext(): void
+    {
+        $tokenValue = $this->faker->uuid();
+
+        $repository = $this->getMockBuilder(MongoDBPasswordResetTokenRepository::class)
+            ->setConstructorArgs([$this->documentManager, $this->registry])
+            ->onlyMethods(['findOneBy'])
+            ->getMock();
+
+        $repository->expects($this->once())
+            ->method('findOneBy')
+            ->with($this->callback(
+                static fn (array $criteria): bool =>
+                    $criteria['tokenValue'] !== $tokenValue
+                    && $criteria['tokenValue'] === PasswordResetToken::hashToken($tokenValue)
+            ))
+            ->willReturn(null);
+
+        $this->assertNull($repository->findByToken($tokenValue));
     }
 
     public function testFindByUserID(): void

--- a/tests/Unit/User/Infrastructure/Repository/MongoDBPasswordResetTokenRepositoryTest.php
+++ b/tests/Unit/User/Infrastructure/Repository/MongoDBPasswordResetTokenRepositoryTest.php
@@ -80,8 +80,7 @@ final class MongoDBPasswordResetTokenRepositoryTest extends UnitTestCase
         $repository->expects($this->once())
             ->method('findOneBy')
             ->with($this->callback(
-                static fn (array $criteria): bool =>
-                    $criteria['tokenValue'] !== $tokenValue
+                static fn (array $criteria): bool => $criteria['tokenValue'] !== $tokenValue
                     && $criteria['tokenValue'] === PasswordResetToken::hashToken($tokenValue)
             ))
             ->willReturn(null);


### PR DESCRIPTION
## Security fix — Closes #313

### Vulnerability (CWE-256, HIGH)
Password-reset tokens were persisted **verbatim** as the `password_reset_tokens`
MongoDB document id (`<id field-name="tokenValue" strategy="NONE">`) and looked
up by exact equality on the raw value (`findOneBy(['tokenValue' => $token])`).
The stored value was identical to the bearer credential emailed to the user, so
any read access to the collection (backup, replica snapshot, query log, read-only
breach, or a NoSQL-injection sink) yielded directly usable, unexpired reset
tokens for every account with a pending reset — enabling account takeover with no
further interaction. The refresh-token subsystem already hashed at rest
(`AuthRefreshToken` → `hash('sha256', …)`); the reset path did not follow it.

### Fix
- `PasswordResetToken` now stores **only** `hash('sha256', $plainToken)` as its
  identifier and keeps the plaintext **transiently** (never persisted) for the
  reset link. Adds `hashToken()` and `matchesToken()` (constant-time `hash_equals`).
- `MongoDBPasswordResetTokenRepository::findByToken()` hashes the incoming
  candidate before querying, so lookups are by stored hash, never raw plaintext.
- The request → email flow carries the plaintext via the domain event and
  re-attaches it to the reconstituted entity (`attachPlainToken`) so the emailed
  reset link stays usable.
- Seeders, in-memory fixtures, and E2E/Memory helpers replay the plaintext
  captured at creation time, keeping all flows green.

A DB-read attacker now only sees a SHA-256 hash; submitting it to the confirm
endpoint fails (hash-of-hash never matches). Generation still uses `random_bytes`
(256-bit entropy) with unchanged single-use / short-expiry semantics.

**Out of scope:** email-confirmation tokens (`ConfirmationToken` via Redis) —
low severity, different cache key/serialization contract; documented in the spec.

### Local verification (one-off containers)
- **phpunit** Unit: `OK (2265 tests, 6234 assertions)`
- **deptrac**: `Violations 0`
- **psalm** (changed files): `No errors found`
- **php-cs-fixer** (changed files): `0 of 19 files` need fixing

### BMAD spec
`specs/security-313-reset-confirm-tokens-plaintext/` (`prd.md`, `stories.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hashes password-reset tokens at rest to remove plaintext exposure (CWE-256). Lookups use SHA-256; plaintext exists only transiently for email links, and E2E flows replay it across processes via a Redis-backed recorder.

- **Bug Fixes**
  - `PasswordResetToken` stores only `hash('sha256', $plain)` and keeps a transient `plainToken` (default `null`); adds `hashToken()`, constant-time `matchesToken()`, and `attachPlainToken()`.
  - `MongoDBPasswordResetTokenRepository::findByToken()` hashes the candidate (`hash('sha256', $token)`) before querying.
  - Request → email flow uses the plaintext and fails fast if it’s missing: handler and email-event factory throw `LogicException`; subscriber re-attaches the plaintext before sending.
  - Behat/E2E: added `PasswordResetTokenRecorder` that mirrors the plaintext to Redis to cross web/CLI boundaries; wired in `services_test.yaml`. Contexts read the recorder first, then transient/in-memory values.

- **Refactors**
  - Tests: extracted a helper in `RequestPasswordResetCommandHandlerTest` to satisfy phpinsights FunctionLength; CI passes.

<sup>Written for commit d479844af4816cd3a18dce8054b73ccd5d6519fc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VilnaCRM-Org/user-service/pull/331?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

