### PR TITLE
fix(security): remove unsalted SHA-256 recovery-code fallback (#322)

### DIFF
--- a/specs/security-322-recovery-code-unsalted-sha256/prd.md
+++ b/specs/security-322-recovery-code-unsalted-sha256/prd.md
@@ -1,0 +1,59 @@
+# PRD — Security #322: Recovery-code verification falls back to unsalted SHA-256
+
+## Problem
+
+`RecoveryCode::matchesCode()` selected the verification algorithm dynamically from the
+stored hash. When the stored value was a recognizable `password_hash()` output it used
+Argon2id via `password_verify()` (good), but otherwise it fell back to
+`legacyHash()` = `hash('sha256', strtolower($code))` compared with `hash_equals()`.
+
+That fallback is a **single-iteration, unsalted, GPU-friendly SHA-256** over a very small
+keyspace. Recovery codes are 8 chars from a 36-char alphabet and are lowercased before
+hashing, leaving ~41 bits of entropy (36^8 candidates). An attacker with read access to the
+`recovery_codes` collection (backup leak, read-only NoSQL injection, compromised replica,
+insider) can exhaustively crack any legacy-stored code in seconds-to-minutes with hashcat,
+and because the digest is unsalted a single precomputed pass attacks every user at once.
+A recovered code satisfies the second factor in
+`TwoFactorCodeValidator` / `CompleteTwoFactorCommandHandler`, bypassing 2FA.
+
+Separately, the Argon2id path used `memory_cost = 8192` KiB (8 MiB), below OWASP's
+recommended minimum of 19 MiB for Argon2id, weakening the primary path against
+brute-forcing these low-entropy secrets.
+
+CWE-916 (Use of Password Hash With Insufficient Computational Effort). Severity: MEDIUM.
+
+## Functional Requirements
+
+- **FR-1**: `RecoveryCode::matchesCode()` MUST verify a candidate code only against a
+  modern, salted, adaptive password hash (Argon2id via `password_verify()`).
+- **FR-2**: A stored value that is NOT a valid `password_hash()` output (e.g. a bare 64-hex
+  SHA-256 digest) MUST never match any candidate code; `matchesCode()` returns `false`.
+- **FR-3**: Recovery codes MUST continue to match case-insensitively (codes are normalized
+  with `strtolower()` before hashing and before verification), preserving existing UX.
+- **FR-4**: Newly issued recovery codes MUST be stored with Argon2id using a memory cost of
+  at least 19456 KiB (19 MiB).
+
+## Non-Functional Requirements
+
+- **NFR-Security**: Remove the unsalted SHA-256 verification branch entirely so a database
+  read alone is insufficient to recover plaintext recovery codes. Raise Argon2id
+  `memory_cost` to the OWASP-recommended 19 MiB minimum. No secrets logged.
+- **NFR-Compatibility**: Public API of `RecoveryCode` is unchanged (`matchesCode`,
+  `getCodeHash`, `markAsUsed`, `isUsed`, `isValidFormat`, constructor signature). Doctrine
+  ODM mapping (`codeHash` string field) is unchanged. Legacy SHA-256 rows simply stop
+  authenticating and must be re-issued via the existing
+  `RegenerateRecoveryCodesCommandHandler` flow — an intentional, documented behavior change.
+- **NFR-Maintainability**: Solution stays inside the Domain layer with no new framework
+  dependencies, no new directories, and no lowered quality thresholds (PHPInsights 94/100,
+  Deptrac 0, Psalm 0). Dead code (`legacyHash`, `isPasswordHash`, `LEGACY_HASH_ALGORITHM`)
+  is removed, reducing complexity.
+
+## Out of Scope
+
+- Data migration / re-hashing of existing stored SHA-256 rows (none are written by current
+  code; the factory always stores Argon2id). Operationally such rows are re-issued via
+  recovery-code regeneration.
+- Widening the recovery-code alphabet/length or removing lowercasing (entropy increase) —
+  a larger, behavior-changing effort tracked separately.
+- Introducing a server-side pepper/HMAC keyed secret (optional hardening, not required once
+  the fast unsalted path is removed).

--- a/specs/security-322-recovery-code-unsalted-sha256/stories.md
+++ b/specs/security-322-recovery-code-unsalted-sha256/stories.md
@@ -1,0 +1,69 @@
+# Stories — Security #322
+
+## Story 1 — Remove the unsalted SHA-256 verification fallback
+
+**As** the user-service, **I want** recovery-code verification to rely solely on Argon2id
+**so that** a leaked `recovery_codes` collection cannot be brute-forced offline.
+
+Change: `src/User/Domain/Entity/RecoveryCode.php`
+- `matchesCode()` now returns `password_verify($this->normalizeCode($plainCode), $this->codeHash)`.
+- Removed `legacyHash()`, `isPasswordHash()`, and the `LEGACY_HASH_ALGORITHM` constant.
+
+Covers: FR-1, FR-2, FR-3, NFR-Security, NFR-Maintainability.
+
+### Test mapping (`tests/Unit/User/Domain/Entity/RecoveryCodeTest.php`)
+- **Positive**: `testConstructorStoresCodeAsPasswordHash` — Argon2id-stored code still matches
+  its plaintext; a different random code does not.
+- **Positive (edge: case)**: `testMatchesCodeIsCaseInsensitive` — upper/lowercase variants of
+  the same code both match.
+- **Negative (regression — FAILS before fix)**: `testMatchesCodeRejectsLegacySha256Hashes` —
+  a stored bare SHA-256 digest of the code is rejected for the correct plaintext (both case
+  variants) and for an unrelated code. Before the fix the legacy branch returned `true` for
+  the correct plaintext; now it returns `false`.
+
+## Story 2 — Raise Argon2id memory cost to OWASP minimum (19 MiB)
+
+**As** the user-service, **I want** Argon2id hashing of recovery codes to use >= 19 MiB memory
+**so that** the primary hashing path resists brute force on low-entropy codes per OWASP.
+
+Change: `src/User/Domain/Entity/RecoveryCode.php`
+- `HASH_MEMORY_COST` raised from `8192` to `19456` (KiB).
+
+Covers: FR-4, NFR-Security.
+
+### Test mapping (`tests/Unit/User/Domain/Entity/RecoveryCodeTest.php`)
+- **Positive / edge (regression — FAILS before fix)**:
+  `testConstructorUsesOwaspCompliantArgon2idMemoryCost` — newly constructed code is an
+  `argon2id` hash whose `memory_cost` option is `>= 19456`. Before the fix it was `8192`.
+
+## Verification commands (one-off containers, read-only vendor)
+
+```bash
+# Unit (RecoveryCode filter)
+docker run --rm -v /home/kravtsov/Projects/secfix-322:/app \
+  -v /home/kravtsov/Projects/user-service/vendor:/app/vendor:ro -w /app -e APP_ENV=test \
+  --entrypoint sh secfix-312-php:latest -lc \
+  'php -d memory_limit=-1 vendor/bin/phpunit --testsuite=Unit --filter "RecoveryCode" --no-coverage'
+
+# Deptrac (architecture boundaries)
+docker run --rm -v /home/kravtsov/Projects/secfix-322:/app \
+  -v /home/kravtsov/Projects/user-service/vendor:/app/vendor:ro -w /app -e APP_ENV=test \
+  --entrypoint sh secfix-312-php:latest -lc \
+  'php -d memory_limit=-1 vendor/bin/deptrac analyse --config-file=deptrac.yaml --no-progress'
+
+# Psalm (static analysis on changed file)
+docker run --rm -v /home/kravtsov/Projects/secfix-322:/app \
+  -v /home/kravtsov/Projects/user-service/vendor:/app/vendor:ro -w /app -e APP_ENV=test \
+  --entrypoint sh secfix-312-php:latest -lc \
+  'php -d memory_limit=-1 vendor/bin/psalm --no-cache --no-progress src/User/Domain/Entity/RecoveryCode.php'
+
+# php-cs-fixer (style)
+docker run --rm -v /home/kravtsov/Projects/secfix-322:/app \
+  -v /home/kravtsov/Projects/user-service/vendor:/app/vendor:ro -w /app -e APP_ENV=test \
+  --entrypoint sh secfix-312-php:latest -lc \
+  'PHP_CS_FIXER_IGNORE_ENV=1 vendor/bin/php-cs-fixer fix --dry-run --allow-risky=yes \
+   --config=.php-cs-fixer.dist.php --path-mode=intersection \
+   src/User/Domain/Entity/RecoveryCode.php tests/Unit/User/Domain/Entity/RecoveryCodeTest.php'
+```
+
+Pass criteria: phpunit "OK", deptrac "Violations 0", psalm "No errors", php-cs-fixer "0 of N".

--- a/specs/security-322-recovery-code-unsalted-sha256/stories.md
+++ b/specs/security-322-recovery-code-unsalted-sha256/stories.md
@@ -46,25 +46,25 @@ Covers: FR-4, NFR-Security.
 # Unit (RecoveryCode filter)
 docker run --rm -v /home/kravtsov/Projects/secfix-322:/app \
   -v /home/kravtsov/Projects/user-service/vendor:/app/vendor:ro -w /app -e APP_ENV=test \
-  --entrypoint sh secfix-312-php:latest -lc \
+  --entrypoint sh secfix-322-php:latest -lc \
   'php -d memory_limit=-1 vendor/bin/phpunit --testsuite=Unit --filter "RecoveryCode" --no-coverage'
 
 # Deptrac (architecture boundaries)
 docker run --rm -v /home/kravtsov/Projects/secfix-322:/app \
   -v /home/kravtsov/Projects/user-service/vendor:/app/vendor:ro -w /app -e APP_ENV=test \
-  --entrypoint sh secfix-312-php:latest -lc \
+  --entrypoint sh secfix-322-php:latest -lc \
   'php -d memory_limit=-1 vendor/bin/deptrac analyse --config-file=deptrac.yaml --no-progress'
 
 # Psalm (static analysis on changed file)
 docker run --rm -v /home/kravtsov/Projects/secfix-322:/app \
   -v /home/kravtsov/Projects/user-service/vendor:/app/vendor:ro -w /app -e APP_ENV=test \
-  --entrypoint sh secfix-312-php:latest -lc \
+  --entrypoint sh secfix-322-php:latest -lc \
   'php -d memory_limit=-1 vendor/bin/psalm --no-cache --no-progress src/User/Domain/Entity/RecoveryCode.php'
 
 # php-cs-fixer (style)
 docker run --rm -v /home/kravtsov/Projects/secfix-322:/app \
   -v /home/kravtsov/Projects/user-service/vendor:/app/vendor:ro -w /app -e APP_ENV=test \
-  --entrypoint sh secfix-312-php:latest -lc \
+  --entrypoint sh secfix-322-php:latest -lc \
   'PHP_CS_FIXER_IGNORE_ENV=1 vendor/bin/php-cs-fixer fix --dry-run --allow-risky=yes \
    --config=.php-cs-fixer.dist.php --path-mode=intersection \
    src/User/Domain/Entity/RecoveryCode.php tests/Unit/User/Domain/Entity/RecoveryCodeTest.php'

--- a/specs/security-322-recovery-code-unsalted-sha256/stories.md
+++ b/specs/security-322-recovery-code-unsalted-sha256/stories.md
@@ -6,12 +6,14 @@
 **so that** a leaked `recovery_codes` collection cannot be brute-forced offline.
 
 Change: `src/User/Domain/Entity/RecoveryCode.php`
+
 - `matchesCode()` now returns `password_verify($this->normalizeCode($plainCode), $this->codeHash)`.
 - Removed `legacyHash()`, `isPasswordHash()`, and the `LEGACY_HASH_ALGORITHM` constant.
 
 Covers: FR-1, FR-2, FR-3, NFR-Security, NFR-Maintainability.
 
 ### Test mapping (`tests/Unit/User/Domain/Entity/RecoveryCodeTest.php`)
+
 - **Positive**: `testConstructorStoresCodeAsPasswordHash` — Argon2id-stored code still matches
   its plaintext; a different random code does not.
 - **Positive (edge: case)**: `testMatchesCodeIsCaseInsensitive` — upper/lowercase variants of
@@ -27,11 +29,13 @@ Covers: FR-1, FR-2, FR-3, NFR-Security, NFR-Maintainability.
 **so that** the primary hashing path resists brute force on low-entropy codes per OWASP.
 
 Change: `src/User/Domain/Entity/RecoveryCode.php`
+
 - `HASH_MEMORY_COST` raised from `8192` to `19456` (KiB).
 
 Covers: FR-4, NFR-Security.
 
 ### Test mapping (`tests/Unit/User/Domain/Entity/RecoveryCodeTest.php`)
+
 - **Positive / edge (regression — FAILS before fix)**:
   `testConstructorUsesOwaspCompliantArgon2idMemoryCost` — newly constructed code is an
   `argon2id` hash whose `memory_cost` option is `>= 19456`. Before the fix it was `8192`.

--- a/src/User/Domain/Entity/RecoveryCode.php
+++ b/src/User/Domain/Entity/RecoveryCode.php
@@ -10,8 +10,7 @@ final class RecoveryCode
 {
     public const COUNT = 8;
     public const SEGMENT_LENGTH = 4;
-    private const LEGACY_HASH_ALGORITHM = 'sha256';
-    private const HASH_MEMORY_COST = 8192;
+    private const HASH_MEMORY_COST = 19456;
     private const HASH_TIME_COST = PASSWORD_ARGON2_DEFAULT_TIME_COST;
     private const HASH_THREADS = 1;
 
@@ -59,12 +58,7 @@ final class RecoveryCode
 
     public function matchesCode(string $plainCode): bool
     {
-        $normalizedCode = $this->normalizeCode($plainCode);
-        if ($this->isPasswordHash($this->codeHash)) {
-            return password_verify($normalizedCode, $this->codeHash);
-        }
-
-        return hash_equals($this->codeHash, $this->legacyHash($normalizedCode));
+        return password_verify($this->normalizeCode($plainCode), $this->codeHash);
     }
 
     /** @psalm-suppress PossiblyUnusedMethod */
@@ -83,20 +77,8 @@ final class RecoveryCode
         ]);
     }
 
-    private function legacyHash(string $value): string
-    {
-        return hash(self::LEGACY_HASH_ALGORITHM, $value);
-    }
-
     private function normalizeCode(string $value): string
     {
         return strtolower($value);
-    }
-
-    private function isPasswordHash(string $value): bool
-    {
-        $info = password_get_info($value);
-
-        return (string) ($info['algoName'] ?? 'unknown') !== 'unknown';
     }
 }

--- a/tests/Unit/User/Domain/Entity/RecoveryCodeTest.php
+++ b/tests/Unit/User/Domain/Entity/RecoveryCodeTest.php
@@ -47,7 +47,7 @@ final class RecoveryCodeTest extends UnitTestCase
         $this->assertTrue($recoveryCode->matchesCode(strtolower($upperCode)));
     }
 
-    public function testMatchesCodeSupportsLegacySha256Hashes(): void
+    public function testMatchesCodeRejectsLegacySha256Hashes(): void
     {
         $plainCode = strtoupper($this->faker->bothify('????-####'));
         $recoveryCode = new RecoveryCode(
@@ -59,8 +59,26 @@ final class RecoveryCodeTest extends UnitTestCase
         $reflection = new \ReflectionProperty($recoveryCode, 'codeHash');
         $reflection->setValue($recoveryCode, hash('sha256', strtolower($plainCode)));
 
-        $this->assertTrue($recoveryCode->matchesCode($plainCode));
+        $this->assertFalse($recoveryCode->matchesCode($plainCode));
+        $this->assertFalse($recoveryCode->matchesCode(strtolower($plainCode)));
         $this->assertFalse($recoveryCode->matchesCode('ZZZZ-9999'));
+    }
+
+    public function testConstructorUsesOwaspCompliantArgon2idMemoryCost(): void
+    {
+        $recoveryCode = new RecoveryCode(
+            $this->faker->uuid(),
+            $this->faker->uuid(),
+            strtolower($this->faker->bothify('????-????'))
+        );
+
+        $hashInfo = password_get_info($recoveryCode->getCodeHash());
+
+        $this->assertSame('argon2id', (string) $hashInfo['algoName']);
+        $this->assertGreaterThanOrEqual(
+            19456,
+            $hashInfo['options']['memory_cost'] ?? 0
+        );
     }
 
     public function testMarkAsUsedStoresTimestamp(): void


### PR DESCRIPTION
## Security fix — Closes #322

### Vulnerability (CWE-916, MEDIUM)
`RecoveryCode::matchesCode()` chose its verification algorithm from the stored hash. A recognizable `password_hash()` value used Argon2id (good), but **any other value fell back to an unsalted, single-iteration SHA-256** (`hash('sha256', strtolower($code))`) compared with `hash_equals()`. Recovery codes hold only ~41 bits of entropy (`36^8` lowercased candidates), so a leaked `recovery_codes` collection (backup, read-only NoSQL injection, compromised replica, insider) let an attacker brute-force any legacy-stored code offline in minutes with hashcat — and because it was unsalted, a single precomputed pass attacked every user at once. A recovered code satisfies the second factor in `TwoFactorCodeValidator` / `CompleteTwoFactorCommandHandler`, bypassing 2FA. The Argon2id path also used `memory_cost = 8192` KiB (8 MiB), below OWASP's 19 MiB minimum.

### Fix
- `matchesCode()` now verifies **exclusively** via `password_verify` (Argon2id). A bare SHA-256 (or any non-`password_hash` value) can never match, so a DB read alone is insufficient to recover plaintext codes. Removed the dead `legacyHash()`, `isPasswordHash()`, and `LEGACY_HASH_ALGORITHM` constant.
- Raised Argon2id `memory_cost` from `8192` to `19456` KiB (19 MiB) per OWASP.
- Case-insensitive matching and the public API / Doctrine mapping are unchanged. Legacy SHA-256 rows (none are written by current code — the factory always stores Argon2id) simply stop authenticating and are re-issued via the existing recovery-code regeneration flow.

### Tests
`tests/Unit/User/Domain/Entity/RecoveryCodeTest.php`: replaced the legacy "supports SHA-256" test with `testMatchesCodeRejectsLegacySha256Hashes` (negative regression) and added `testConstructorUsesOwaspCompliantArgon2idMemoryCost` (edge regression). Both **fail on the pre-fix source** and pass after the fix.

### Local verification (one-off container, read-only vendor)
- phpunit Unit `--filter RecoveryCode`: **OK (76 tests, 299 assertions)**
- phpunit Unit (full suite): **OK (2259 tests, 6212 assertions)**
- deptrac: **Violations 0**
- psalm `src/User/Domain/Entity/RecoveryCode.php`: **No errors**
- php-cs-fixer (changed files): **0 of 2 files**

### BMAD spec
`specs/security-322-recovery-code-unsalted-sha256/` (`prd.md`, `stories.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the unsalted SHA‑256 fallback for recovery-code verification; now verify only with Argon2id. Raised Argon2id memory cost to 19 MiB per OWASP to reduce offline brute‑force risk (addresses #322).

- **Bug Fixes**
  - Verify recovery codes only with Argon2id; removed SHA‑256 fallback and related helpers.
  - Increased Argon2id memory_cost from 8192 KiB to 19456 KiB (19 MiB).
  - Kept case-insensitive matching and the public API/Doctrine mapping unchanged.
  - Fixed spec verification commands to use the `secfix-322-php` image tag.

- **Migration**
  - Legacy SHA‑256 recovery codes no longer authenticate; regenerate codes via the existing flow.

<sup>Written for commit bf592fb3f49997e68819bba603862833b84104fa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VilnaCRM-Org/user-service/pull/332?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

