### PR TITLE
fix(security): scope user read operations to the owner (#320)

### DIFF
--- a/config/api_platform/resources/User.yaml
+++ b/config/api_platform/resources/User.yaml
@@ -16,6 +16,7 @@ resources:
 
     operations:
       ApiPlatform\Metadata\GetCollection:
+        provider: 'App\User\Application\Provider\UserCollectionProvider'
         paginationClientItemsPerPage: true
         paginationClientPartial: true
         paginationMaximumItemsPerPage: 100
@@ -25,6 +26,7 @@ resources:
           vary: ['Accept', 'Accept-Language', 'Authorization']
         etag: true
       ApiPlatform\Metadata\Get:
+        security: "is_granted('ROLE_USER') and object.getId() == user.getId().__toString()"
         cacheHeaders:
           max_age: 600
           public: false
@@ -67,9 +69,10 @@ resources:
 
     graphQlOperations:
       - class: 'ApiPlatform\Metadata\GraphQl\Query'
-        security: "is_granted('ROLE_USER')"
+        security: "is_granted('ROLE_USER') and object.getId() == user.getId().__toString()"
       - class: 'ApiPlatform\Metadata\GraphQl\QueryCollection'
         security: "is_granted('ROLE_USER')"
+        provider: 'App\User\Application\Provider\UserCollectionProvider'
       - class: 'ApiPlatform\Metadata\GraphQl\DeleteMutation'
         normalizationContext:
           groups: ['deleteMutationOutput']

--- a/features/auth_gate.feature
+++ b/features/auth_gate.feature
@@ -276,11 +276,16 @@ Feature: Authentication Gate and Access Control
     When GET request is send to "/api/users/8be90127-9840-4235-a6da-39b8debfb220"
     Then the response status code should be 401
 
-  Scenario: Authenticated user can GET single user
-    Given I am authenticated as user "get-user@test.com"
-    And user with id "8be90127-9840-4235-a6da-39b8debfb247" exists
+  Scenario: Authenticated user can GET their own user record
+    Given I am authenticated as user "get-user@test.com" with id "8be90127-9840-4235-a6da-39b8debfb247"
     When GET request is send to "/api/users/8be90127-9840-4235-a6da-39b8debfb247"
     Then the response status code should be 200
+
+  Scenario: Authenticated user cannot GET another user's record
+    Given I am authenticated as user "get-user-owner@test.com" with id "8be90127-9840-4235-a6da-39b8debfb248"
+    And user with id "8be90127-9840-4235-a6da-39b8debfb249" exists
+    When GET request is send to "/api/users/8be90127-9840-4235-a6da-39b8debfb249"
+    Then the response status code should be 403
 
   # Password change without newPassword does not revoke sessions (FR-19)
 

--- a/features/user_graphql_operations.feature
+++ b/features/user_graphql_operations.feature
@@ -140,7 +140,7 @@ Feature: User GraphQL Operations
     Then graphql error message should be 'Item "/api/users/8be90127-9840-4235-a6da-39b8debfb112" not found.'
 
   Scenario: Getting user
-    Given I am authenticated as user "gql-ops-auth19@test.com"
+    Given I am authenticated as user "gql-ops-auth19@test.com" with id "8be90127-9840-4235-a6da-39b8debfb113"
     And requesting to return user's id and email
     And user with id "8be90127-9840-4235-a6da-39b8debfb113" exists
     And getting user with id "8be90127-9840-4235-a6da-39b8debfb113"

--- a/features/user_operations.feature
+++ b/features/user_operations.feature
@@ -146,7 +146,7 @@ Feature: User Operations
     And violation should be "Duplicate email in a batch"
 
   Scenario: Getting a user
-    Given I am authenticated as user "get-auth@test.com"
+    Given I am authenticated as user "get-auth@test.com" with id "8be90127-9840-4235-a6da-39b8debfb220"
     And user with id "8be90127-9840-4235-a6da-39b8debfb220" exists
     When GET request is send to "/api/users/8be90127-9840-4235-a6da-39b8debfb220"
     Then the response status code should be 200

--- a/specs/security-320-broken-object-level-authz-pii/prd.md
+++ b/specs/security-320-broken-object-level-authz-pii/prd.md
@@ -1,0 +1,65 @@
+# PRD — Security #320: Broken Object-Level Authorization / PII Enumeration
+
+## Problem
+
+The User API resource (`config/api_platform/resources/User.yaml`) exposes read
+operations with no object-level authorization:
+
+- REST `GET /api/users/{id}` (item `Get`) — only inherits the firewall rule
+  `^/api/ -> ROLE_USER`.
+- REST `GET /api/users` (`GetCollection`, up to 100/page) — uses the default
+  Doctrine ODM provider that returns every user record.
+- GraphQL `user(id:)` (`Query`) and `users` (`QueryCollection`) — only require
+  `ROLE_USER`.
+
+The write operations (`Patch`/`Put`/`Delete` and GraphQL `update`/`delete`)
+already enforce
+`is_granted('ROLE_USER') and object.getId() == user.getId().__toString()`, but
+the read operations do not. The serialized `output` group
+(`config/serialization/User.yaml`) exposes `id`, `email`, `initials`, and
+`confirmed`.
+
+**Impact (CWE-639, Broken Object Level Authorization):** any authenticated
+`ROLE_USER` can read an arbitrary user by id and page through the entire user
+base, harvesting every user's email and confirmation status. This is a
+cross-tenant PII disclosure and account-enumeration primitive. No password hash
+is exposed, which bounds severity to MEDIUM.
+
+## Functional Requirements
+
+- **FR-1 (Item read scoped to owner):** The REST item `Get` and the GraphQL
+  `Query` operation MUST return a user record only when the requested object
+  belongs to the authenticated caller. A `ROLE_USER` requesting another user's
+  id MUST be denied (403), consistent with the existing write operations.
+- **FR-2 (Collection scoped to owner):** The REST `GetCollection` and GraphQL
+  `QueryCollection` operation MUST return only the authenticated caller's own
+  record. They MUST NOT return other users' records, so paging cannot enumerate
+  the user base.
+- **FR-3 (Graceful empty collection):** When there is no authenticated
+  `AuthorizationUserDto` caller, or the caller's own record no longer exists,
+  the collection MUST return an empty list rather than leaking records or
+  erroring.
+
+## Non-Functional Requirements
+
+- **NFR-Security:** Read access to user PII is restricted to the resource owner,
+  matching the authorization model already enforced on write operations. No new
+  PII is exposed; the enumeration and cross-tenant-read primitives are removed.
+- **NFR-Compatibility:** The owner can still read their own record via item and
+  collection endpoints; pagination, cache headers, and ETag behavior on the
+  collection are preserved. No public/PUBLIC_ACCESS route changes. Request and
+  response shapes are unchanged for legitimate self-access.
+- **NFR-Maintainability:** The fix reuses existing patterns — the same security
+  expression as the write operations and a single API Platform state provider in
+  the Application layer (`src/User/Application/Provider/`). It respects
+  hexagonal/DDD boundaries (Domain stays framework-free; no Deptrac, PHPInsights,
+  or other threshold config changed) and adds focused unit tests.
+
+## Out of Scope
+
+- Adding an admin/elevated role that can read all users (no such role exists for
+  end users today; can be introduced later behind an explicit role if
+  cross-user reads become a product requirement).
+- Changes to write-operation authorization (already correct).
+- Field-level serialization changes to `config/serialization/User.yaml`.
+- OAuth `ROLE_SERVICE` flows and batch endpoints.

--- a/specs/security-320-broken-object-level-authz-pii/stories.md
+++ b/specs/security-320-broken-object-level-authz-pii/stories.md
@@ -1,0 +1,62 @@
+# Stories — Security #320
+
+## Story 1 — Scope item read (REST Get + GraphQL Query) to the owner
+
+**Change:** In `config/api_platform/resources/User.yaml`, add
+`security: "is_granted('ROLE_USER') and object.getId() == user.getId().__toString()"`
+to the `ApiPlatform\Metadata\Get` operation and to the
+`ApiPlatform\Metadata\GraphQl\Query` operation. This mirrors the existing
+`Patch`/`Put`/`Delete` and GraphQL `update`/`delete` expressions, where the
+authenticated `user` is an `AuthorizationUserDto` (its `getId()` returns a
+Stringable `UuidInterface`) and `object` is the loaded `User` entity.
+
+**Test mapping:**
+
+- Positive: owner requests their own id → record returned (existing
+  authorization-expression behavior, exercised by item-read functional/Behat
+  coverage in CI; the expression is identical to the already-tested write ops).
+- Negative: a `ROLE_USER` requests another user's id → 403 (expression evaluates
+  false, same denial path as write ops).
+- Edge: unauthenticated request → 401 from firewall (`^/api/ -> ROLE_USER`).
+
+**Verification commands:** see Story 3 (config validated by deptrac/cs-fixer/psalm
+on changed files; expression parity with write ops is the regression guard).
+
+## Story 2 — Scope collection read (REST GetCollection + GraphQL QueryCollection)
+
+**Change:** Add `src/User/Application/Provider/UserCollectionProvider.php`, an
+API Platform `ProviderInterface<User>` that resolves the current authenticated
+`AuthorizationUserDto` via `Security`, loads only that user's `User` entity via
+`GetUserQueryHandlerInterface`, and returns it as a single-element list. Wire it
+as `provider:` on `ApiPlatform\Metadata\GetCollection` and
+`ApiPlatform\Metadata\GraphQl\QueryCollection` in
+`config/api_platform/resources/User.yaml`. Returns `[]` when there is no
+`AuthorizationUserDto` caller or the caller's own record is missing.
+
+**Test mapping** (`tests/Unit/User/Application/Provider/UserCollectionProviderTest.php`):
+
+- Positive — `testProvideReturnsOnlyCurrentAuthenticatedUser`: authenticated
+  caller → list contains exactly the caller's own record (loaded by their id).
+- Negative — `testProvideReturnsEmptyWhenNotAuthorizationUser`: a non-DTO
+  `UserInterface` principal → `[]`, query handler never called (no enumeration).
+- Negative — `testProvideReturnsEmptyWhenNoAuthenticatedUser`: `getUser()` null
+  → `[]`, query handler never called.
+- Edge — `testProvideReturnsEmptyWhenOwnRecordMissing`: caller's record deleted
+  (`UserNotFoundException`) → `[]` instead of a 404.
+
+These tests FAIL without the provider (the previous default provider returned
+all users) and PASS with it.
+
+## Story 3 — Local verification (one-off containers)
+
+Run from `/home/kravtsov/Projects/secfix-320` (image `secfix-312-php:latest`,
+read-only shared vendor):
+
+- Unit (focused): `phpunit --testsuite=Unit --filter "User"` → expect OK.
+- Unit (provider only):
+  `phpunit --testsuite=Unit --filter UserCollectionProvider` → 4 tests pass.
+- Deptrac: `deptrac analyse --config-file=deptrac.yaml` → Violations 0.
+- Psalm (changed files):
+  `psalm src/User/Application/Provider/UserCollectionProvider.php tests/Unit/User/Application/Provider/UserCollectionProviderTest.php`
+  → No errors.
+- PHP CS Fixer (dry-run, changed files) → 0 of N files need fixing.

--- a/src/User/Application/Provider/UserCollectionProvider.php
+++ b/src/User/Application/Provider/UserCollectionProvider.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\User\Application\Provider;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProviderInterface;
+use App\User\Application\DTO\AuthorizationUserDto;
+use App\User\Application\Query\GetUserQueryHandlerInterface;
+use App\User\Domain\Collection\UserCollection;
+use App\User\Domain\Exception\UserNotFoundException;
+use Symfony\Bundle\SecurityBundle\Security;
+
+/**
+ * Scopes the User collection to the current authenticated user only.
+ *
+ * Without this provider the default Doctrine ODM provider returns every user
+ * record, letting any authenticated user enumerate all users' PII
+ * (GET /api/users). This provider returns at most the caller's own record.
+ *
+ * @implements ProviderInterface<UserCollection>
+ */
+final readonly class UserCollectionProvider implements ProviderInterface
+{
+    public function __construct(
+        private Security $security,
+        private GetUserQueryHandlerInterface $getUserQueryHandler,
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $uriVariables
+     * @param array<string, mixed> $context
+     */
+    #[\Override]
+    public function provide(
+        Operation $operation,
+        array $uriVariables = [],
+        array $context = []
+    ): UserCollection {
+        $user = $this->security->getUser();
+        if (!$user instanceof AuthorizationUserDto) {
+            return new UserCollection();
+        }
+
+        try {
+            $ownRecord = $this->getUserQueryHandler->handle(
+                (string) $user->getId()
+            );
+        } catch (UserNotFoundException) {
+            return new UserCollection();
+        }
+
+        return new UserCollection([$ownRecord]);
+    }
+}

--- a/src/User/Application/Provider/UserCollectionProvider.php
+++ b/src/User/Application/Provider/UserCollectionProvider.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace App\User\Application\Provider;
 
 use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\Pagination\ArrayPaginator;
+use ApiPlatform\State\Pagination\Pagination;
 use ApiPlatform\State\ProviderInterface;
 use App\User\Application\DTO\AuthorizationUserDto;
 use App\User\Application\Query\GetUserQueryHandlerInterface;
@@ -17,15 +19,21 @@ use Symfony\Bundle\SecurityBundle\Security;
  *
  * Without this provider the default Doctrine ODM provider returns every user
  * record, letting any authenticated user enumerate all users' PII
- * (GET /api/users). This provider returns at most the caller's own record.
+ * (GET /api/users and the GraphQL `users` query). This provider returns at most
+ * the caller's own record.
  *
- * @implements ProviderInterface<UserCollection>
+ * The result is wrapped in an {@see ArrayPaginator} so it satisfies both the
+ * REST collection normalizer and the GraphQL cursor-based collection
+ * serializer, which requires a paginator implementation.
+ *
+ * @implements ProviderInterface<\App\User\Domain\Entity\User>
  */
 final readonly class UserCollectionProvider implements ProviderInterface
 {
     public function __construct(
         private Security $security,
         private GetUserQueryHandlerInterface $getUserQueryHandler,
+        private Pagination $pagination,
     ) {
     }
 
@@ -38,7 +46,16 @@ final readonly class UserCollectionProvider implements ProviderInterface
         Operation $operation,
         array $uriVariables = [],
         array $context = []
-    ): UserCollection {
+    ): ArrayPaginator {
+        $records = $this->ownRecords();
+        $offset = $this->pagination->getOffset($operation, $context);
+        $limit = $this->pagination->getLimit($operation, $context);
+
+        return new ArrayPaginator($records->users, $offset, $limit);
+    }
+
+    private function ownRecords(): UserCollection
+    {
         $user = $this->security->getUser();
         if (!$user instanceof AuthorizationUserDto) {
             return new UserCollection();

--- a/tests/Load/scripts/graphql/graphQLGetUsers.js
+++ b/tests/Load/scripts/graphql/graphQLGetUsers.js
@@ -38,10 +38,13 @@ export default function getUsers() {
     utils.getJsonHeaderWithAuth(user.accessToken)
   );
 
+  // The users query is scoped to the authenticated caller (object-level
+  // authorization), so it returns only the caller's own record regardless of
+  // how many records are requested via `first`.
   utils.checkResponse(
     response,
-    'users returned',
-    res => JSON.parse(res.body).data.users.edges.length === usersToGetInOneRequest
+    'own user returned',
+    res => JSON.parse(res.body).data.users.edges.length === 1
   );
 }
 

--- a/tests/Memory/GraphQL/GraphQLUserOperationMemoryTest.php
+++ b/tests/Memory/GraphQL/GraphQLUserOperationMemoryTest.php
@@ -170,7 +170,7 @@ final class GraphQLUserOperationMemoryTest extends GraphQLMemoryWebTestCase
         $returnedUsers = $this->fetchReturnedUsers($client, $owner['user']);
 
         $this->assertReturnedUsersAreWellFormed($returnedUsers);
-        $this->assertReturnedFixturesArePresent($returnedUsers, $owner, $peer);
+        $this->assertReturnedCollectionIsScopedToOwner($returnedUsers, $owner, $peer);
     }
 
     private function exerciseConfirmUser(KernelBrowser $client, int $iteration): void
@@ -355,11 +355,32 @@ final class GraphQLUserOperationMemoryTest extends GraphQLMemoryWebTestCase
     }
 
     /**
+     * @param list<array{id: string, email: string}> $returnedUsers
+     */
+    private function assertReturnedUsersDoNotContain(
+        array $returnedUsers,
+        string $userId,
+        string $email,
+    ): void {
+        $expectedId = $this->buildGetUserId($userId);
+        $matchesFixture = array_filter(
+            $returnedUsers,
+            static fn (array $returnedUser): bool => $returnedUser['id'] === $expectedId
+                && $returnedUser['email'] === $email,
+        );
+
+        $this->assertSame([], $matchesFixture);
+    }
+
+    /**
+     * The secured `users` query is scoped to the authenticated caller, so the
+     * owner must see only their own record and never another user's PII.
+     *
      * @param array{user: \App\User\Domain\Entity\User, password: string} $owner
      * @param array{user: \App\User\Domain\Entity\User, password: string} $peer
      * @param list<array{id: string, email: string}> $returnedUsers
      */
-    private function assertReturnedFixturesArePresent(
+    private function assertReturnedCollectionIsScopedToOwner(
         array $returnedUsers,
         array $owner,
         array $peer,
@@ -369,7 +390,7 @@ final class GraphQLUserOperationMemoryTest extends GraphQLMemoryWebTestCase
             $owner['user']->getId(),
             $owner['user']->getEmail(),
         );
-        $this->assertReturnedUsersContain(
+        $this->assertReturnedUsersDoNotContain(
             $returnedUsers,
             $peer['user']->getId(),
             $peer['user']->getEmail(),

--- a/tests/Unit/User/Application/Provider/UserCollectionProviderTest.php
+++ b/tests/Unit/User/Application/Provider/UserCollectionProviderTest.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\User\Application\Provider;
+
+use ApiPlatform\Metadata\Operation;
+use App\Shared\Infrastructure\Factory\UuidFactory as SharedUuidFactory;
+use App\Shared\Infrastructure\Transformer\UuidTransformer;
+use App\Tests\Unit\UnitTestCase;
+use App\User\Application\DTO\AuthorizationUserDto;
+use App\User\Application\Provider\UserCollectionProvider;
+use App\User\Application\Query\GetUserQueryHandlerInterface;
+use App\User\Domain\Collection\UserCollection;
+use App\User\Domain\Entity\User;
+use App\User\Domain\Exception\UserNotFoundException;
+use PHPUnit\Framework\MockObject\MockObject;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+final class UserCollectionProviderTest extends UnitTestCase
+{
+    private Security&MockObject $security;
+    private GetUserQueryHandlerInterface&MockObject $getUserQueryHandler;
+    private UserCollectionProvider $provider;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->security = $this->createMock(Security::class);
+        $this->getUserQueryHandler = $this->createMock(
+            GetUserQueryHandlerInterface::class
+        );
+        $this->provider = new UserCollectionProvider(
+            $this->security,
+            $this->getUserQueryHandler
+        );
+    }
+
+    public function testProvideReturnsOnlyCurrentAuthenticatedUser(): void
+    {
+        $userId = $this->faker->uuid();
+        $authUser = $this->createAuthorizationUserDto($userId);
+        $ownRecord = $this->createMock(User::class);
+
+        $this->security->expects($this->once())
+            ->method('getUser')
+            ->willReturn($authUser);
+
+        $this->getUserQueryHandler->expects($this->once())
+            ->method('handle')
+            ->with($userId)
+            ->willReturn($ownRecord);
+
+        $result = $this->provider->provide($this->createMock(Operation::class));
+
+        $this->assertInstanceOf(UserCollection::class, $result);
+        $this->assertSame([$ownRecord], $result->users);
+    }
+
+    public function testProvideReturnsEmptyWhenNotAuthorizationUser(): void
+    {
+        $this->security->expects($this->once())
+            ->method('getUser')
+            ->willReturn($this->createMock(UserInterface::class));
+
+        $this->getUserQueryHandler->expects($this->never())
+            ->method('handle');
+
+        $result = $this->provider->provide($this->createMock(Operation::class));
+
+        $this->assertInstanceOf(UserCollection::class, $result);
+        $this->assertSame([], $result->users);
+    }
+
+    public function testProvideReturnsEmptyWhenNoAuthenticatedUser(): void
+    {
+        $this->security->expects($this->once())
+            ->method('getUser')
+            ->willReturn(null);
+
+        $this->getUserQueryHandler->expects($this->never())
+            ->method('handle');
+
+        $result = $this->provider->provide($this->createMock(Operation::class));
+
+        $this->assertInstanceOf(UserCollection::class, $result);
+        $this->assertSame([], $result->users);
+    }
+
+    public function testProvideReturnsEmptyWhenOwnRecordMissing(): void
+    {
+        $userId = $this->faker->uuid();
+        $authUser = $this->createAuthorizationUserDto($userId);
+
+        $this->security->expects($this->once())
+            ->method('getUser')
+            ->willReturn($authUser);
+
+        $this->getUserQueryHandler->expects($this->once())
+            ->method('handle')
+            ->with($userId)
+            ->willThrowException(new UserNotFoundException());
+
+        $result = $this->provider->provide($this->createMock(Operation::class));
+
+        $this->assertInstanceOf(UserCollection::class, $result);
+        $this->assertSame([], $result->users);
+    }
+
+    private function createAuthorizationUserDto(string $userId): AuthorizationUserDto
+    {
+        $uuidTransformer = new UuidTransformer(new SharedUuidFactory());
+
+        return new AuthorizationUserDto(
+            $this->faker->email(),
+            $this->faker->name(),
+            $this->faker->password(),
+            $uuidTransformer->transformFromString($userId),
+            true
+        );
+    }
+}

--- a/tests/Unit/User/Application/Provider/UserCollectionProviderTest.php
+++ b/tests/Unit/User/Application/Provider/UserCollectionProviderTest.php
@@ -5,13 +5,14 @@ declare(strict_types=1);
 namespace App\Tests\Unit\User\Application\Provider;
 
 use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\Pagination\ArrayPaginator;
+use ApiPlatform\State\Pagination\Pagination;
 use App\Shared\Infrastructure\Factory\UuidFactory as SharedUuidFactory;
 use App\Shared\Infrastructure\Transformer\UuidTransformer;
 use App\Tests\Unit\UnitTestCase;
 use App\User\Application\DTO\AuthorizationUserDto;
 use App\User\Application\Provider\UserCollectionProvider;
 use App\User\Application\Query\GetUserQueryHandlerInterface;
-use App\User\Domain\Collection\UserCollection;
 use App\User\Domain\Entity\User;
 use App\User\Domain\Exception\UserNotFoundException;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -35,7 +36,8 @@ final class UserCollectionProviderTest extends UnitTestCase
         );
         $this->provider = new UserCollectionProvider(
             $this->security,
-            $this->getUserQueryHandler
+            $this->getUserQueryHandler,
+            new Pagination()
         );
     }
 
@@ -56,8 +58,9 @@ final class UserCollectionProviderTest extends UnitTestCase
 
         $result = $this->provider->provide($this->createMock(Operation::class));
 
-        $this->assertInstanceOf(UserCollection::class, $result);
-        $this->assertSame([$ownRecord], $result->users);
+        $this->assertInstanceOf(ArrayPaginator::class, $result);
+        $this->assertSame([$ownRecord], iterator_to_array($result));
+        $this->assertSame(1.0, $result->getTotalItems());
     }
 
     public function testProvideReturnsEmptyWhenNotAuthorizationUser(): void
@@ -71,8 +74,9 @@ final class UserCollectionProviderTest extends UnitTestCase
 
         $result = $this->provider->provide($this->createMock(Operation::class));
 
-        $this->assertInstanceOf(UserCollection::class, $result);
-        $this->assertSame([], $result->users);
+        $this->assertInstanceOf(ArrayPaginator::class, $result);
+        $this->assertSame([], iterator_to_array($result));
+        $this->assertSame(0.0, $result->getTotalItems());
     }
 
     public function testProvideReturnsEmptyWhenNoAuthenticatedUser(): void
@@ -86,8 +90,9 @@ final class UserCollectionProviderTest extends UnitTestCase
 
         $result = $this->provider->provide($this->createMock(Operation::class));
 
-        $this->assertInstanceOf(UserCollection::class, $result);
-        $this->assertSame([], $result->users);
+        $this->assertInstanceOf(ArrayPaginator::class, $result);
+        $this->assertSame([], iterator_to_array($result));
+        $this->assertSame(0.0, $result->getTotalItems());
     }
 
     public function testProvideReturnsEmptyWhenOwnRecordMissing(): void
@@ -106,8 +111,35 @@ final class UserCollectionProviderTest extends UnitTestCase
 
         $result = $this->provider->provide($this->createMock(Operation::class));
 
-        $this->assertInstanceOf(UserCollection::class, $result);
-        $this->assertSame([], $result->users);
+        $this->assertInstanceOf(ArrayPaginator::class, $result);
+        $this->assertSame([], iterator_to_array($result));
+        $this->assertSame(0.0, $result->getTotalItems());
+    }
+
+    public function testProvideExcludesOwnRecordFromOutOfRangePage(): void
+    {
+        $userId = $this->faker->uuid();
+        $authUser = $this->createAuthorizationUserDto($userId);
+        $ownRecord = $this->createMock(User::class);
+
+        $this->security->expects($this->once())
+            ->method('getUser')
+            ->willReturn($authUser);
+
+        $this->getUserQueryHandler->expects($this->once())
+            ->method('handle')
+            ->with($userId)
+            ->willReturn($ownRecord);
+
+        $result = $this->provider->provide(
+            $this->createMock(Operation::class),
+            [],
+            ['filters' => ['page' => 2]]
+        );
+
+        $this->assertInstanceOf(ArrayPaginator::class, $result);
+        $this->assertSame([], iterator_to_array($result));
+        $this->assertSame(1.0, $result->getTotalItems());
     }
 
     private function createAuthorizationUserDto(string $userId): AuthorizationUserDto


### PR DESCRIPTION
## Security fix — Closes #320

### Vulnerability
Broken object-level authorization (CWE-639, MEDIUM). The User REST item `Get`, `GetCollection`, and the GraphQL `Query`/`QueryCollection` operations declared no object-level `security` expression. Only the firewall rule `^/api/ -> ROLE_USER` applied, so **any authenticated user could**:
- read an arbitrary user by id — `GET /api/users/{id}` and GraphQL `user(id:)`;
- page through the entire user base — `GET /api/users` (up to 100/page) and GraphQL `users`,

harvesting every user's email, initials, and confirmation status. The write operations (`Patch`/`Put`/`Delete`, GraphQL `update`/`delete`) already enforced owner-only access; the read operations did not.

### Fix
- **Item read** (`ApiPlatform\\Metadata\\Get` and GraphQL `Query`) now enforce `is_granted('ROLE_USER') and object.getId() == user.getId().__toString()`, identical to the existing write operations.
- **Collection read** (`GetCollection` and GraphQL `QueryCollection`) use a new `UserCollectionProvider` (`src/User/Application/Provider/`) that returns only the authenticated caller's own record (as a `UserCollection`), removing the enumeration primitive. It returns an empty collection when there is no `AuthorizationUserDto` caller or the caller's own record no longer exists.

No quality thresholds, Deptrac config, or serialization groups were changed.

### Local verification
One-off `secfix-312-php` container, read-only shared vendor:
- `phpunit --testsuite=Unit --filter UserCollectionProvider`: **OK (4 tests, 16 assertions)** — positive/negative/edge
- `phpunit --testsuite=Unit --filter "User"`: **OK (1090 tests, 3638 assertions)**
- `deptrac analyse`: **Violations 0**
- `psalm` (changed files): **No errors**
- `php-cs-fixer` (changed files, dry-run): **0 of 2 files**

### BMAD spec
`specs/security-320-broken-object-level-authz-pii/` (`prd.md`, `stories.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes all user read operations to the authenticated owner to fix object-level authorization and stop PII enumeration via REST and GraphQL.

- **Bug Fixes**
  - Item reads: enforce owner-only access on `ApiPlatform\Metadata\Get` and GraphQL `Query` using `is_granted('ROLE_USER') and object.getId() == user.getId().__toString()`.
  - Collection reads: use `App\User\Application\Provider\UserCollectionProvider` to return only the caller’s record; returns an `ArrayPaginator` that honors offset/limit (out-of-range pages empty); wired for REST `GetCollection` and GraphQL `QueryCollection`; returns empty when unauthenticated or the record is missing.
  - Tests/CI: added unit tests for the provider (including paginator behavior), updated the GraphQL memory test to assert owner-only scoping, fixed the K6 `graphQLGetUsers` script to expect a single record, and updated Behat scenarios to fetch the caller’s own user (including the GraphQL item query) plus a 403 case for cross-user GET.

<sup>Written for commit 49c3f7f731d337c451d01af3d0cab75bc4bfeb41. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VilnaCRM-Org/user-service/pull/333?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced object-level authorization on user read operations; users can now only access their own records via REST and GraphQL
  * Scoped user collection queries to the authenticated caller, preventing unauthorized data access and enumeration

* **Documentation**
  * Added security specification and implementation stories for user data access controls

<!-- end of auto-generated comment: release notes by coderabbit.ai -->