### PR TITLE
fix(security): stop leaking OAuth provider exception messages (#323)

### DIFF
--- a/specs/security-323-oauth-exception-message-leak/prd.md
+++ b/specs/security-323-oauth-exception-message-leak/prd.md
@@ -1,0 +1,64 @@
+# PRD — Security #323: OAuth provider exception message leak (CWE-209)
+
+## Problem
+
+`OAuthExceptionListener` (`src/OAuth/Application/EventListener/OAuthExceptionListener.php`)
+builds the client-facing `application/problem+json` error response with
+`'detail' => $exception->getMessage()`. For `OAuthProviderException`, that message is
+`sprintf('OAuth provider %s error: %s', $provider, $message)` where `$message` is the
+verbatim `getMessage()` of any `\Throwable` caught during the provider token exchange or
+profile fetch (`GitHubOAuthProvider::exchangeCode()` and `::fetchProfile()` wrap
+`$e->getMessage()` from `league/oauth2-client` / Guzzle).
+
+Guzzle and league exception messages routinely embed the outbound request URL (which may
+carry `client_id` and other query parameters), the provider's raw error body, HTTP status
+lines, and internal hostnames. The listener is not debug-gated, so the leak is emitted in
+**all** environments including production. The social-callback path (`/api/auth/social`)
+is `PUBLIC_ACCESS` in `security.yaml`, so the response is reachable by an unauthenticated
+attacker who can force the provider exchange to fail with a crafted/invalid `code`.
+
+This is an information-exposure-through-error-message weakness (CWE-209), rated MEDIUM,
+usable for reconnaissance of the OAuth integration (client_id, provider endpoints,
+internal hostnames, upstream error semantics).
+
+## Functional Requirements
+
+- **FR-1**: For every OAuth exception handled by `OAuthExceptionListener`, the client
+  response `detail` field MUST be a static, provider-agnostic, developer-controlled string.
+  It MUST NOT contain `$exception->getMessage()` or any upstream/third-party error text.
+- **FR-2**: The HTTP status, `error_code`, `type`, and `title` fields of the response
+  contract MUST remain unchanged (no breaking change to the existing client contract).
+- **FR-3**: When a handled exception occurs, the full `$exception->getMessage()` and the
+  exception object (for trace) MUST be logged server-side at `error` level, including the
+  `error_code`, so operators retain full diagnostic information.
+- **FR-4**: Exceptions not present in the listener's map MUST continue to be ignored
+  (no response set, no log written by this listener).
+
+## Non-Functional Requirements
+
+- **NFR-Security**: No untrusted, upstream, or third-party text reaches an unauthenticated
+  client through the OAuth error response. Sensitive material (client_id, secrets, provider
+  URLs, internal hostnames, HTTP status lines, raw provider error bodies) is confined to
+  server-side logs. Closes CWE-209 for the OAuth social-callback path.
+- **NFR-Compatibility**: The response shape (keys `type`, `title`, `detail`, `status`,
+  `error_code`), Content-Type (`application/problem+json`), and HTTP status codes are
+  preserved. Only the human-readable `detail` string value changes from a dynamic raw
+  message to a stable static message.
+- **NFR-Maintainability**: The static `detail` strings are colocated with each entry in the
+  existing `ERROR_CODE_MAP`, so adding a new handled exception requires defining its
+  `detail` alongside `error_code` and `status` — a single, obvious place. No new directory,
+  class type, or `*Service` suffix is introduced. Hexagonal/DDD boundaries are preserved
+  (the listener stays in the Application layer; the injected `Psr\Log\LoggerInterface` is a
+  framework-agnostic PSR-3 port, autowired via existing `_defaults` config).
+
+## Out of Scope
+
+- Changing the domain exception classes' own messages (they are developer-controlled and
+  remain useful for server-side logging).
+- Removing `$e->getMessage()` propagation inside `GitHubOAuthProvider` — the raw upstream
+  text is intentionally preserved as the exception message for server-side logging; the
+  remediation is enforced at the single client-facing boundary (the listener), which also
+  covers any future provider adapter.
+- Localization/translation of the `detail` strings (the strings are English and static;
+  i18n can be layered later without affecting this fix).
+- Any change to authentication/authorization behavior or the OAuth flow itself.

--- a/specs/security-323-oauth-exception-message-leak/stories.md
+++ b/specs/security-323-oauth-exception-message-leak/stories.md
@@ -1,0 +1,100 @@
+# Stories — Security #323: OAuth provider exception message leak
+
+## Story 1 — Return a static, provider-agnostic `detail` to clients
+
+**As** an unauthenticated client of `/api/auth/social/*`
+**I want** OAuth error responses to contain only a stable, generic message
+**so that** the API never discloses upstream provider error text, endpoints, client_id,
+or internal hostnames (CWE-209).
+
+**Change**: `src/OAuth/Application/EventListener/OAuthExceptionListener.php`
+- Add a static `detail` string to every entry in `ERROR_CODE_MAP`.
+- Build the JSON response `detail` from `$mapping['detail']` instead of
+  `$exception->getMessage()`.
+
+**Covers**: FR-1, FR-2, NFR-Security, NFR-Compatibility, NFR-Maintainability.
+
+**Test mapping** (`tests/Unit/OAuth/Application/EventListener/OAuthExceptionListenerTest.php`):
+- Positive: `testProviderExceptionReturns503` — status `503` + `error_code`
+  `provider_unavailable` still returned; `testResponseBodyContainsRequiredFields` and
+  `testResponseContentTypeIsProblemJson` confirm contract/Content-Type unchanged.
+- Negative: `testProviderExceptionDoesNotLeakRawUpstreamMessage` — a realistic raw Guzzle
+  message containing a `client_id`, secret, `github.com` URL, internal hostname, and `401`
+  status line is fed in; asserts NONE of those substrings appear in `detail` and that
+  `detail` equals the exact static string. FAILS before the fix (old code echoed the raw
+  message), PASSES after.
+- Edge: `testHandledExceptionsNeverLeakTheirRawMessage` — iterates every handled exception
+  type with a unique secret token embedded in its constructor message; asserts the secret
+  never appears in `detail` for any of them (defense-in-depth across all map entries).
+
+**Verification commands**:
+```
+docker run --rm -v /home/kravtsov/Projects/secfix-323:/app \
+  -v /home/kravtsov/Projects/user-service/vendor:/app/vendor:ro -w /app -e APP_ENV=test \
+  --entrypoint sh secfix-312-php:latest -lc \
+  'php -d memory_limit=-1 vendor/bin/phpunit --testsuite=Unit \
+   --filter "OAuthException|ExceptionListener" --no-coverage'
+```
+
+## Story 2 — Log the full exception server-side
+
+**As** an operator
+**I want** the full OAuth exception message and trace recorded in server logs
+**so that** removing the message from the client response does not reduce diagnosability.
+
+**Change**: `src/OAuth/Application/EventListener/OAuthExceptionListener.php`
+- Inject `Psr\Log\LoggerInterface` (autowired via existing `_defaults`).
+- On a handled exception, call `logger->error()` with the full message and a context array
+  carrying `error_code` and the `exception` object.
+
+**Covers**: FR-3, FR-4.
+
+**Test mapping** (same test file):
+- Positive: `testFullExceptionMessageIsLoggedServerSide` — asserts `logger->error()` is
+  called once with a message containing the raw upstream text and a context array holding
+  the same exception instance plus `error_code = provider_unavailable`.
+- Negative/edge: `testIgnoredExceptionIsNotLogged` — an unmapped `RuntimeException` causes
+  `logger->error()` to be called zero times and no response to be set
+  (`testNonOAuthExceptionIsIgnored`).
+- Construction edge: all existing tests now build the listener with a mocked
+  `LoggerInterface`, proving the new constructor signature is wired correctly.
+
+**Verification commands**:
+```
+# Full Unit suite (no regressions)
+docker run --rm -v /home/kravtsov/Projects/secfix-323:/app \
+  -v /home/kravtsov/Projects/user-service/vendor:/app/vendor:ro -w /app -e APP_ENV=test \
+  --entrypoint sh secfix-312-php:latest -lc \
+  'php -d memory_limit=-1 vendor/bin/phpunit --testsuite=Unit --no-coverage'
+
+# Deptrac (architecture boundaries)
+docker run --rm -v /home/kravtsov/Projects/secfix-323:/app \
+  -v /home/kravtsov/Projects/user-service/vendor:/app/vendor:ro -w /app -e APP_ENV=test \
+  --entrypoint sh secfix-312-php:latest -lc \
+  'php -d memory_limit=-1 vendor/bin/deptrac analyse --config-file=deptrac.yaml --no-progress'
+
+# Psalm (static analysis on changed files)
+docker run --rm -v /home/kravtsov/Projects/secfix-323:/app \
+  -v /home/kravtsov/Projects/user-service/vendor:/app/vendor:ro -w /app -e APP_ENV=test \
+  --entrypoint sh secfix-312-php:latest -lc \
+  'php -d memory_limit=-1 vendor/bin/psalm --no-cache --no-progress \
+   src/OAuth/Application/EventListener/OAuthExceptionListener.php \
+   tests/Unit/OAuth/Application/EventListener/OAuthExceptionListenerTest.php'
+
+# PHP CS Fixer (style on changed files)
+docker run --rm -v /home/kravtsov/Projects/secfix-323:/app \
+  -v /home/kravtsov/Projects/user-service/vendor:/app/vendor:ro -w /app -e APP_ENV=test \
+  --entrypoint sh secfix-312-php:latest -lc \
+  'PHP_CS_FIXER_IGNORE_ENV=1 vendor/bin/php-cs-fixer fix --dry-run --allow-risky=yes \
+   --config=.php-cs-fixer.dist.php --path-mode=intersection \
+   src/OAuth/Application/EventListener/OAuthExceptionListener.php \
+   tests/Unit/OAuth/Application/EventListener/OAuthExceptionListenerTest.php'
+```
+
+## Local verification results (this branch)
+
+- PHPUnit (filtered `OAuthException|ExceptionListener`): `OK (20 tests, 92 assertions)`
+- PHPUnit (full Unit suite): `OK (2262 tests, 6252 assertions)`
+- Deptrac: `Violations 0`
+- Psalm: `No errors found!`
+- PHP CS Fixer: `Found 0 of 2 files that can be fixed`

--- a/specs/security-323-oauth-exception-message-leak/stories.md
+++ b/specs/security-323-oauth-exception-message-leak/stories.md
@@ -8,6 +8,7 @@
 or internal hostnames (CWE-209).
 
 **Change**: `src/OAuth/Application/EventListener/OAuthExceptionListener.php`
+
 - Add a static `detail` string to every entry in `ERROR_CODE_MAP`.
 - Build the JSON response `detail` from `$mapping['detail']` instead of
   `$exception->getMessage()`.
@@ -15,6 +16,7 @@ or internal hostnames (CWE-209).
 **Covers**: FR-1, FR-2, NFR-Security, NFR-Compatibility, NFR-Maintainability.
 
 **Test mapping** (`tests/Unit/OAuth/Application/EventListener/OAuthExceptionListenerTest.php`):
+
 - Positive: `testProviderExceptionReturns503` — status `503` + `error_code`
   `provider_unavailable` still returned; `testResponseBodyContainsRequiredFields` and
   `testResponseContentTypeIsProblemJson` confirm contract/Content-Type unchanged.
@@ -28,6 +30,7 @@ or internal hostnames (CWE-209).
   never appears in `detail` for any of them (defense-in-depth across all map entries).
 
 **Verification commands**:
+
 ```
 docker run --rm -v /home/kravtsov/Projects/secfix-323:/app \
   -v /home/kravtsov/Projects/user-service/vendor:/app/vendor:ro -w /app -e APP_ENV=test \
@@ -43,6 +46,7 @@ docker run --rm -v /home/kravtsov/Projects/secfix-323:/app \
 **so that** removing the message from the client response does not reduce diagnosability.
 
 **Change**: `src/OAuth/Application/EventListener/OAuthExceptionListener.php`
+
 - Inject `Psr\Log\LoggerInterface` (autowired via existing `_defaults`).
 - On a handled exception, call `logger->error()` with the full message and a context array
   carrying `error_code` and the `exception` object.
@@ -50,6 +54,7 @@ docker run --rm -v /home/kravtsov/Projects/secfix-323:/app \
 **Covers**: FR-3, FR-4.
 
 **Test mapping** (same test file):
+
 - Positive: `testFullExceptionMessageIsLoggedServerSide` — asserts `logger->error()` is
   called once with a message containing the raw upstream text and a context array holding
   the same exception instance plus `error_code = provider_unavailable`.
@@ -60,6 +65,7 @@ docker run --rm -v /home/kravtsov/Projects/secfix-323:/app \
   `LoggerInterface`, proving the new constructor signature is wired correctly.
 
 **Verification commands**:
+
 ```
 # Full Unit suite (no regressions)
 docker run --rm -v /home/kravtsov/Projects/secfix-323:/app \

--- a/specs/security-323-oauth-exception-message-leak/stories.md
+++ b/specs/security-323-oauth-exception-message-leak/stories.md
@@ -29,14 +29,15 @@ or internal hostnames (CWE-209).
   type with a unique secret token embedded in its constructor message; asserts the secret
   never appears in `detail` for any of them (defense-in-depth across all map entries).
 
-**Verification commands**:
+**Verification commands** (run from the repository root):
 
 ```
-docker run --rm -v /home/kravtsov/Projects/secfix-323:/app \
-  -v /home/kravtsov/Projects/user-service/vendor:/app/vendor:ro -w /app -e APP_ENV=test \
-  --entrypoint sh secfix-312-php:latest -lc \
-  'php -d memory_limit=-1 vendor/bin/phpunit --testsuite=Unit \
-   --filter "OAuthException|ExceptionListener" --no-coverage'
+# Full unit suite (repository-standard entry point)
+make unit-tests
+
+# Scoped to this story's tests only
+docker compose exec php php -d memory_limit=-1 vendor/bin/phpunit \
+  --testsuite=Unit --filter "OAuthException|ExceptionListener" --no-coverage
 ```
 
 ## Story 2 — Log the full exception server-side

--- a/src/OAuth/Application/EventListener/OAuthExceptionListener.php
+++ b/src/OAuth/Application/EventListener/OAuthExceptionListener.php
@@ -70,9 +70,11 @@ final class OAuthExceptionListener
         OAuthProviderException::class => [
             'error_code' => 'provider_unavailable',
             'status' => Response::HTTP_SERVICE_UNAVAILABLE,
-            'detail' => 'The authentication provider is currently unavailable. Please try again later.',
+            'detail' => 'The authentication provider is currently unavailable. Try again later.',
         ],
     ];
+
+    private const LOG_MESSAGE_PREFIX = 'OAuth flow failed: ';
 
     public function __construct(
         private readonly LoggerInterface $logger,
@@ -88,14 +90,25 @@ final class OAuthExceptionListener
             return;
         }
 
-        $this->logger->error('OAuth flow failed: ' . $exception->getMessage(), [
-            'error_code' => $mapping['error_code'],
-            'exception' => $exception,
-        ]);
+        $this->logger->error(
+            self::LOG_MESSAGE_PREFIX . $exception->getMessage(),
+            [
+                'error_code' => $mapping['error_code'],
+                'exception' => $exception,
+            ]
+        );
 
+        $event->setResponse($this->buildProblemResponse($mapping));
+    }
+
+    /**
+     * @param array{error_code: string, status: int, detail: string} $mapping
+     */
+    private function buildProblemResponse(array $mapping): JsonResponse
+    {
         $status = $mapping['status'];
 
-        $event->setResponse(new JsonResponse(
+        return new JsonResponse(
             [
                 'type' => "/errors/{$status}",
                 'title' => 'An error occurred',
@@ -105,6 +118,6 @@ final class OAuthExceptionListener
             ],
             $status,
             ['Content-Type' => 'application/problem+json']
-        ));
+        );
     }
 }

--- a/src/OAuth/Application/EventListener/OAuthExceptionListener.php
+++ b/src/OAuth/Application/EventListener/OAuthExceptionListener.php
@@ -12,6 +12,7 @@ use App\OAuth\Domain\Exception\ProviderMismatchException;
 use App\OAuth\Domain\Exception\StateExpiredException;
 use App\OAuth\Domain\Exception\UnsupportedProviderException;
 use App\OAuth\Domain\Exception\UnverifiedProviderEmailException;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\ExceptionEvent;
@@ -21,40 +22,62 @@ use Symfony\Component\HttpKernel\Event\ExceptionEvent;
  */
 final class OAuthExceptionListener
 {
+    /**
+     * Maps each handled OAuth exception to a stable client contract.
+     *
+     * The `detail` values are static, provider-agnostic, and safe to expose to
+     * unauthenticated clients. Raw exception messages are never returned because
+     * they may embed upstream provider error bodies, request URLs (with
+     * client_id query parameters), internal hostnames, or HTTP status lines
+     * (CWE-209). The full exception message and trace are logged server-side.
+     */
     private const ERROR_CODE_MAP = [
         UnsupportedProviderException::class => [
             'error_code' => 'unsupported_provider',
             'status' => Response::HTTP_BAD_REQUEST,
+            'detail' => 'The requested authentication provider is not supported.',
         ],
         MissingOAuthParametersException::class => [
             'error_code' => 'missing_oauth_parameters',
             'status' => Response::HTTP_BAD_REQUEST,
+            'detail' => 'The authentication request is missing required parameters.',
         ],
         ProviderMismatchException::class => [
             'error_code' => 'provider_mismatch',
             'status' => Response::HTTP_BAD_REQUEST,
+            'detail' => 'The authentication provider does not match the original request.',
         ],
         InvalidStateException::class => [
             'error_code' => 'invalid_state',
             'status' => Response::HTTP_UNPROCESSABLE_ENTITY,
+            'detail' => 'The authentication request could not be verified.',
         ],
         StateExpiredException::class => [
             'error_code' => 'state_expired',
             'status' => Response::HTTP_UNPROCESSABLE_ENTITY,
+            'detail' => 'The authentication request has expired. Please try again.',
         ],
         OAuthEmailUnavailableException::class => [
             'error_code' => 'provider_email_unavailable',
             'status' => Response::HTTP_UNPROCESSABLE_ENTITY,
+            'detail' => 'The authentication provider did not return an email address.',
         ],
         UnverifiedProviderEmailException::class => [
             'error_code' => 'unverified_provider_email',
             'status' => Response::HTTP_UNPROCESSABLE_ENTITY,
+            'detail' => 'The authentication provider did not return a verified email address.',
         ],
         OAuthProviderException::class => [
             'error_code' => 'provider_unavailable',
             'status' => Response::HTTP_SERVICE_UNAVAILABLE,
+            'detail' => 'The authentication provider is currently unavailable. Please try again later.',
         ],
     ];
+
+    public function __construct(
+        private readonly LoggerInterface $logger,
+    ) {
+    }
 
     public function __invoke(ExceptionEvent $event): void
     {
@@ -65,13 +88,18 @@ final class OAuthExceptionListener
             return;
         }
 
+        $this->logger->error('OAuth flow failed: ' . $exception->getMessage(), [
+            'error_code' => $mapping['error_code'],
+            'exception' => $exception,
+        ]);
+
         $status = $mapping['status'];
 
         $event->setResponse(new JsonResponse(
             [
                 'type' => "/errors/{$status}",
                 'title' => 'An error occurred',
-                'detail' => $exception->getMessage(),
+                'detail' => $mapping['detail'],
                 'status' => $status,
                 'error_code' => $mapping['error_code'],
             ],

--- a/tests/Unit/OAuth/Application/EventListener/OAuthExceptionListenerTest.php
+++ b/tests/Unit/OAuth/Application/EventListener/OAuthExceptionListenerTest.php
@@ -179,13 +179,7 @@ final class OAuthExceptionListenerTest extends UnitTestCase
     {
         $clientId = 'Iv1.' . $this->faker->bothify('????????????????');
         $secret = $this->faker->sha256();
-        $rawUpstreamMessage = sprintf(
-            'Client error: `POST https://github.com/login/oauth/access_token'
-            . '?client_id=%s&client_secret=%s` resulted in a 401 Unauthorized'
-            . ' {"error":"bad_verification_code"} at internal-host-12.local',
-            $clientId,
-            $secret,
-        );
+        $rawUpstreamMessage = $this->buildLeakyUpstreamMessage($clientId, $secret);
 
         $event = $this->createExceptionEvent(
             new OAuthProviderException('github', $rawUpstreamMessage)
@@ -202,8 +196,7 @@ final class OAuthExceptionListenerTest extends UnitTestCase
         $this->assertStringNotContainsString('internal-host-12.local', $detail);
         $this->assertStringNotContainsString('401', $detail);
         $this->assertSame(
-            'The authentication provider is currently unavailable.'
-            . ' Please try again later.',
+            'The authentication provider is currently unavailable. Try again later.',
             $detail,
         );
     }
@@ -234,10 +227,30 @@ final class OAuthExceptionListenerTest extends UnitTestCase
             ->with(
                 $this->stringContains($rawUpstreamMessage),
                 $this->callback(
-                    static fn (array $context): bool =>
-                        ($context['exception'] ?? null) === $exception
-                        && $context['error_code'] === 'provider_unavailable'
+                    static function (array $context) use ($exception): bool {
+                        return ($context['exception'] ?? null) === $exception
+                            && $context['error_code'] === 'provider_unavailable';
+                    }
                 )
+            );
+
+        $listener = new OAuthExceptionListener($logger);
+        $listener($this->createExceptionEvent($exception));
+    }
+
+    public function testLoggedMessagePrefixesTheRawExceptionMessage(): void
+    {
+        $rawUpstreamMessage = 'sensitive upstream detail ' . $this->faker->uuid();
+        $exception = new OAuthProviderException('github', $rawUpstreamMessage);
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())
+            ->method('error')
+            ->with(
+                $this->identicalTo(
+                    'OAuth flow failed: ' . $exception->getMessage()
+                ),
+                $this->anything()
             );
 
         $listener = new OAuthExceptionListener($logger);
@@ -295,6 +308,22 @@ final class OAuthExceptionListenerTest extends UnitTestCase
         $this->assertArrayHasKey('detail', $body);
         $this->assertArrayHasKey('status', $body);
         $this->assertArrayHasKey('error_code', $body);
+    }
+
+    private function buildLeakyUpstreamMessage(string $clientId, string $secret): string
+    {
+        $url = sprintf(
+            'https://github.com/login/oauth/access_token?client_id=%s&client_secret=%s',
+            $clientId,
+            $secret,
+        );
+
+        return sprintf(
+            'Client error: `POST %s` resulted in a 401 Unauthorized %s at %s',
+            $url,
+            '{"error":"bad_verification_code"}',
+            'internal-host-12.local',
+        );
     }
 
     private function extractDetail(ExceptionEvent $event): string

--- a/tests/Unit/OAuth/Application/EventListener/OAuthExceptionListenerTest.php
+++ b/tests/Unit/OAuth/Application/EventListener/OAuthExceptionListenerTest.php
@@ -14,6 +14,7 @@ use App\OAuth\Domain\Exception\StateExpiredException;
 use App\OAuth\Domain\Exception\UnsupportedProviderException;
 use App\OAuth\Domain\Exception\UnverifiedProviderEmailException;
 use App\Tests\Unit\UnitTestCase;
+use Psr\Log\LoggerInterface;
 use RuntimeException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -24,13 +25,15 @@ final class OAuthExceptionListenerTest extends UnitTestCase
 {
     private OAuthExceptionListener $listener;
     private HttpKernelInterface $kernel;
+    private LoggerInterface $logger;
 
     #[\Override]
     protected function setUp(): void
     {
         parent::setUp();
 
-        $this->listener = new OAuthExceptionListener();
+        $this->logger = $this->createMock(LoggerInterface::class);
+        $this->listener = new OAuthExceptionListener($this->logger);
         $this->kernel = $this->createMock(HttpKernelInterface::class);
     }
 
@@ -172,6 +175,86 @@ final class OAuthExceptionListenerTest extends UnitTestCase
         $this->assertNull($event->getResponse());
     }
 
+    public function testProviderExceptionDoesNotLeakRawUpstreamMessage(): void
+    {
+        $clientId = 'Iv1.' . $this->faker->bothify('????????????????');
+        $secret = $this->faker->sha256();
+        $rawUpstreamMessage = sprintf(
+            'Client error: `POST https://github.com/login/oauth/access_token'
+            . '?client_id=%s&client_secret=%s` resulted in a 401 Unauthorized'
+            . ' {"error":"bad_verification_code"} at internal-host-12.local',
+            $clientId,
+            $secret,
+        );
+
+        $event = $this->createExceptionEvent(
+            new OAuthProviderException('github', $rawUpstreamMessage)
+        );
+
+        ($this->listener)($event);
+
+        $detail = $this->extractDetail($event);
+
+        $this->assertStringNotContainsString($rawUpstreamMessage, $detail);
+        $this->assertStringNotContainsString($clientId, $detail);
+        $this->assertStringNotContainsString($secret, $detail);
+        $this->assertStringNotContainsString('github.com', $detail);
+        $this->assertStringNotContainsString('internal-host-12.local', $detail);
+        $this->assertStringNotContainsString('401', $detail);
+        $this->assertSame(
+            'The authentication provider is currently unavailable.'
+            . ' Please try again later.',
+            $detail,
+        );
+    }
+
+    public function testHandledExceptionsNeverLeakTheirRawMessage(): void
+    {
+        $secretToken = 'leak-token-' . $this->faker->uuid();
+
+        foreach ($this->handledExceptionFactories($secretToken) as $factory) {
+            $event = $this->createExceptionEvent($factory());
+
+            ($this->listener)($event);
+
+            $detail = $this->extractDetail($event);
+
+            $this->assertStringNotContainsString($secretToken, $detail);
+        }
+    }
+
+    public function testFullExceptionMessageIsLoggedServerSide(): void
+    {
+        $rawUpstreamMessage = 'sensitive upstream detail ' . $this->faker->uuid();
+        $exception = new OAuthProviderException('github', $rawUpstreamMessage);
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())
+            ->method('error')
+            ->with(
+                $this->stringContains($rawUpstreamMessage),
+                $this->callback(
+                    static fn (array $context): bool =>
+                        ($context['exception'] ?? null) === $exception
+                        && $context['error_code'] === 'provider_unavailable'
+                )
+            );
+
+        $listener = new OAuthExceptionListener($logger);
+        $listener($this->createExceptionEvent($exception));
+    }
+
+    public function testIgnoredExceptionIsNotLogged(): void
+    {
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->never())->method('error');
+
+        $listener = new OAuthExceptionListener($logger);
+        $listener($this->createExceptionEvent(
+            new RuntimeException($this->faker->sentence())
+        ));
+    }
+
     public function testResponseContentTypeIsProblemJson(): void
     {
         $event = $this->createExceptionEvent(
@@ -212,6 +295,41 @@ final class OAuthExceptionListenerTest extends UnitTestCase
         $this->assertArrayHasKey('detail', $body);
         $this->assertArrayHasKey('status', $body);
         $this->assertArrayHasKey('error_code', $body);
+    }
+
+    private function extractDetail(ExceptionEvent $event): string
+    {
+        $response = $event->getResponse();
+        $this->assertNotNull($response);
+
+        $body = json_decode(
+            (string) $response->getContent(),
+            true,
+            512,
+            JSON_THROW_ON_ERROR
+        );
+
+        $this->assertArrayHasKey('detail', $body);
+        $this->assertIsString($body['detail']);
+
+        return $body['detail'];
+    }
+
+    /**
+     * @return list<callable(): \Throwable>
+     */
+    private function handledExceptionFactories(string $secret): array
+    {
+        return [
+            static fn (): \Throwable => new UnsupportedProviderException($secret),
+            static fn (): \Throwable => new MissingOAuthParametersException(),
+            static fn (): \Throwable => new ProviderMismatchException($secret, $secret),
+            static fn (): \Throwable => new InvalidStateException($secret),
+            static fn (): \Throwable => new StateExpiredException(),
+            static fn (): \Throwable => new OAuthEmailUnavailableException($secret),
+            static fn (): \Throwable => new UnverifiedProviderEmailException($secret),
+            static fn (): \Throwable => new OAuthProviderException($secret, $secret),
+        ];
     }
 
     private function createExceptionEvent(\Throwable $exception): ExceptionEvent


### PR DESCRIPTION
## Security fix — Closes #323

### Vulnerability (CWE-209, MEDIUM)
`OAuthExceptionListener` returned the client-facing `application/problem+json` response with `detail => $exception->getMessage()`. For `OAuthProviderException` that message is `OAuth provider <p> error: <raw>`, where `<raw>` is the verbatim `getMessage()` of the Guzzle/league exception caught in `GitHubOAuthProvider` during token exchange / profile fetch. Those upstream messages routinely embed the outbound request URL (carrying `client_id`), the provider's raw error body, HTTP status lines, and internal hostnames.

The listener is not debug-gated, and `/api/auth/social` is `PUBLIC_ACCESS` in `security.yaml`. An unauthenticated attacker who forces the provider exchange to fail (crafted/invalid `code`) receives a `503` whose `detail` discloses the configured `client_id`, the exact provider endpoints, internal error semantics, and internal hostnames — useful for reconnaissance.

### Fix
- Add a static, provider-agnostic `detail` string to every entry in `ERROR_CODE_MAP` and emit that instead of the raw exception message. Response shape, HTTP status codes, `error_code`, `type`, `title`, and `Content-Type` are unchanged (no client-contract break).
- Inject `Psr\Log\LoggerInterface` (autowired via existing `_defaults`) and log the full exception message + object at `error` level with the `error_code`, preserving server-side diagnosability.
- Remediation is enforced at the single client-facing boundary (the listener), so it also covers any future provider adapter. Hexagonal/DDD boundaries preserved; no new directories/threshold changes.

### Tests
`tests/Unit/OAuth/Application/EventListener/OAuthExceptionListenerTest.php`
- Negative: a realistic raw Guzzle message (with `client_id`, secret, provider URL, internal hostname, `401`) is asserted absent from the response `detail` — fails before the fix, passes after.
- Edge: every handled exception type is verified to never echo its raw message; ignored exceptions are neither logged nor responded to.
- Positive: full message is logged with `error_code` + exception context; existing status/contract assertions still pass.

### Local verification (one-off containers)
- phpunit (filtered `OAuthException|ExceptionListener`): **OK (20 tests, 92 assertions)**
- phpunit (full Unit suite): **OK (2262 tests, 6252 assertions)**
- deptrac: **Violations 0**
- psalm: **No errors found**
- php-cs-fixer: **0 of 2 files** need fixing

### BMAD spec
`specs/security-323-oauth-exception-message-leak/` (`prd.md`, `stories.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop leaking raw OAuth provider error messages to clients by returning static, safe `detail` strings in the problem+json response. The response shape and status codes stay the same; full errors are logged server-side for diagnosis.

- **Bug Fixes**
  - Use static, provider-agnostic `detail` strings from `OAuthExceptionListener::ERROR_CODE_MAP` instead of `$exception->getMessage()`.
  - Inject `Psr\Log\LoggerInterface` and log the full exception (with `error_code` and context) at error level, prefixed with `OAuth flow failed: `.
  - Keep unmapped exceptions ignored by this listener.
  - Add unit tests to confirm no message leak, verify logging (including exact log prefix), and preserve the client contract.

- **Refactors**
  - Extract `buildProblemResponse()` for clearer response construction and shorter listener method; introduce `LOG_MESSAGE_PREFIX` constant.
  - Tidy tests to satisfy PHP Insights and Infection, restoring MSI to 100% (no functional changes).
  - Update security story verification commands to portable `make unit-tests` and `docker compose exec` variants.

<sup>Written for commit 9ab8c28e028e482889cebccc4a21c003cc90d7b1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VilnaCRM-Org/user-service/pull/335?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

