### PR TITLE
fix(security): make account-lockout failure counter atomic (#324)

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -300,18 +300,9 @@ services:
         - '@App\User\Application\Validator\TokenExpirationValidator'
         - '@App\User\Application\Validator\TokenUsageValidator'
 
-  cache.account_lockout:
-    class: Symfony\Component\Cache\Adapter\RedisAdapter
-    arguments:
-      - '@app.account_lockout_redis_connection'
-      - 'account_lockout'
-      - 0
-    tags:
-      - { name: kernel.reset, method: reset }
-
   App\User\Infrastructure\Provider\RedisAccountLockoutProvider:
     arguments:
-      $cachePool: '@cache.account_lockout'
+      $lockoutRedis: '@app.account_lockout_redis_connection'
 
   App\User\Infrastructure\Adapter\TwoFactorSecretEncryptor:
     arguments:

--- a/config/services_test.yaml
+++ b/config/services_test.yaml
@@ -46,11 +46,10 @@ services:
     arguments:
       $cachePool: '@cache.user'
       $rateLimiterCachePool: '@cache.app'
-      $accountLockoutCachePool: '@cache.account_lockout'
 
   App\Tests\Behat\UserContext\SignInSecurityContext:
     arguments:
-      $cachePool: '@cache.account_lockout'
+      $lockoutRedis: '@app.account_lockout_redis_connection'
 
   App\OAuth\Infrastructure\Provider\GitHubOAuthProvider:
     class: App\OAuth\Infrastructure\Provider\DeterministicOAuthProvider

--- a/specs/security-324-account-lockout-counter-race/prd.md
+++ b/specs/security-324-account-lockout-counter-race/prd.md
@@ -1,0 +1,85 @@
+# PRD — Atomic Account-Lockout Failure Counter (#324)
+
+## Problem
+
+`RedisAccountLockoutProvider::recordFailure()` implemented the per-account
+failed-login counter as a non-atomic read-modify-write:
+
+1. `getItem($attemptsKey)->get()` reads the current count.
+2. `+1` is computed in PHP.
+3. `set()` / `expiresAfter()` / `save()` persists the new value.
+
+Under concurrency this is a lost-update race (CWE-362). Multiple parallel
+failed-login requests for the same email read the same starting value and each
+persist `value + 1`, so N concurrent requests advance the counter by far fewer
+than N. Because this email-keyed lockout (`MAX_ATTEMPTS = 20` within a 1h
+window) is the primary per-account brute-force control on the GraphQL `signIn`
+path — where the `signin_email` / `signin_ip` rate limiters are bypassed — the
+undercount lets an attacker fire concurrent requests and make materially more
+than 20 password guesses per window against a single account before the lock is
+ever applied.
+
+The codebase already established the correct pattern for atomic Redis security
+operations: `RedisOAuthStateRepository::validateAndConsume()` uses a
+server-side Lua script (`Redis::eval`) to GET+DEL OAuth state atomically.
+
+## Functional Requirements
+
+- **FR-1**: `recordFailure()` MUST increment the failure counter atomically on
+  the Redis server (single round trip), eliminating the PHP-side
+  read-modify-write window.
+- **FR-2**: On the first failure within a window the attempts key MUST receive
+  the 3600s expiry; subsequent increments MUST NOT reset that expiry.
+- **FR-3**: When the increment crosses `MAX_ATTEMPTS` (20), the lock key MUST be
+  set atomically with the `LOCKOUT_SECONDS` (900s) TTL, set exactly once on the
+  threshold-crossing request.
+- **FR-4**: `recordFailure()` MUST return `true` when the account is locked
+  (attempts at or above the threshold) and `false` otherwise, preserving the
+  `UserCredentialValidator` contract (locked → `LockedHttpException`, otherwise
+  → `UnauthorizedHttpException`).
+- **FR-5**: `isLocked()` and `clearFailures()` MUST operate on the same raw
+  Redis keys used by `recordFailure()` so lock detection and reset stay
+  consistent.
+
+## Non-Functional Requirements
+
+### NFR-Security
+
+- The failure counter and lock transition MUST be free of lost-update / TOCTOU
+  races (CWE-362). The increment and threshold lock MUST execute as one atomic
+  server-side operation. No PHP-side `get` then `set` for the security counter.
+- Email keys MUST remain hashed (SHA-256) before use as Redis keys (no PII in
+  key names) — unchanged from the prior behaviour.
+- The Lua script body MUST be a hardcoded constant; only bound `KEYS`/`ARGV`
+  parameters are passed (no user input interpolated into the script), matching
+  the `RedisOAuthStateRepository` precedent.
+
+### NFR-Compatibility
+
+- Public method signatures of `AccountLockoutProviderInterface` are unchanged;
+  `UserCredentialValidator` and all callers are unaffected.
+- Redis key names (`signin_lockout_<sha256>`, `signin_lock_<sha256>`) and the
+  20-attempt / 900s lock semantics are preserved.
+- The provider now binds the existing `app.account_lockout_redis_connection`
+  `\Redis` service directly instead of the `cache.account_lockout` PSR-6 pool;
+  the orphaned pool definition is removed. Behat lockout helpers operate on the
+  same raw connection / DB.
+
+### NFR-Maintainability
+
+- The fix reuses the established atomic-Lua pattern (`Redis::eval`) already
+  present in `RedisOAuthStateRepository`, keeping one idiom for atomic Redis
+  security primitives.
+- Hexagonal/DDD boundaries are respected: the provider stays in
+  `User/Infrastructure/Provider`; no Domain change; no threshold/Deptrac config
+  weakened.
+- PHPInsights complexity ≥ 94% and quality/style 100% are preserved (clean,
+  low-branch implementation).
+
+## Out of Scope
+
+- The separate finding that `signin_email` / `signin_ip` rate limiters are
+  bypassed on the GraphQL `signIn` path (tracked independently).
+- Changing the 20-attempt threshold or 900s lockout duration.
+- Distributed-lock or sliding-window redesign of the lockout policy.
+- Migrating other PSR-6 cache usages to raw Redis.

--- a/specs/security-324-account-lockout-counter-race/stories.md
+++ b/specs/security-324-account-lockout-counter-race/stories.md
@@ -1,0 +1,108 @@
+# Stories — Atomic Account-Lockout Failure Counter (#324)
+
+## Story 1 — Atomic increment + lock in `recordFailure()`
+
+**Change**: `src/User/Infrastructure/Provider/RedisAccountLockoutProvider.php`
+
+Replace the PSR-6 `CacheItemPoolInterface` read-modify-write with a raw
+`\Redis` connection and a single `Redis::eval` Lua script that `INCR`s the
+attempts key, sets the window TTL on first increment, and `SET`s the lock key
+(with lockout TTL) once the threshold is crossed. `isLocked()` uses `exists()`;
+`clearFailures()` uses `del()`.
+
+Covers FR-1, FR-2, FR-3, FR-4, FR-5, NFR-Security, NFR-Maintainability.
+
+**Test mapping** (`tests/Unit/.../RedisAccountLockoutProviderTest.php`):
+
+- Positive: `testRecordFailureReturnsFalseBeforeThreshold` — eval returns 0 →
+  `recordFailure` returns `false`.
+- Positive: `testRecordFailureReturnsTrueWhenThresholdReached` — eval returns 1
+  → `recordFailure` returns `true`.
+- Positive: `testIsLockedReturnsTrueWhenLockKeyExists` /
+  `testIsLockedReturnsFalseWhenLockKeyMissing` — `exists()` drives lock check.
+- Positive: `testClearFailuresDeletesAttemptAndLockKeys` — `del()` of both keys.
+- Negative (race regression):
+  `testRecordFailureUsesSingleAtomicEvalWithoutReadModifyWrite` — asserts the
+  Lua script contains `INCR`/`EXPIRE`, binds 2 keys (attempts + lock), and that
+  the provider NEVER calls `get`/`set`/`incr` from PHP. This FAILS against the
+  old read-modify-write implementation (which used `get`+`set`+`save` and no
+  `eval`) and PASSES with the atomic fix.
+- Edge: `testRecordFailurePassesThresholdAndTtlConfigurationToScript` — the
+  window TTL (3600), max-attempts (20) and lockout TTL (900) are forwarded to
+  the script as ARGV.
+- Edge: `testRecordFailureTreatsFalseEvalResultAsNotLocked` — a `false` eval
+  result is treated as "not locked".
+- Config guards: `testMaxAttemptsReturnsConstant`,
+  `testLockoutSecondsReturnsConstant`.
+
+**Verification commands**:
+
+```bash
+docker run --rm -v /home/kravtsov/Projects/secfix-324:/app \
+  -v /home/kravtsov/Projects/user-service/vendor:/app/vendor:ro -w /app \
+  -e APP_ENV=test --entrypoint sh secfix-312-php:latest -lc \
+  'php -d memory_limit=-1 vendor/bin/phpunit --testsuite=Unit --filter "Lockout" --no-coverage'
+```
+
+## Story 2 — Rewire DI to the raw Redis connection
+
+**Change**: `config/services.yaml`
+
+Bind `$lockoutRedis: '@app.account_lockout_redis_connection'` into the provider
+and remove the now-orphaned `cache.account_lockout` PSR-6 RedisAdapter
+definition.
+
+Covers FR-5, NFR-Compatibility.
+
+**Test mapping**: container boot is exercised by the full Unit suite and Deptrac
+(service graph compiles, no dependency violations).
+
+**Verification commands**:
+
+```bash
+docker run --rm -v /home/kravtsov/Projects/secfix-324:/app \
+  -v /home/kravtsov/Projects/user-service/vendor:/app/vendor:ro -w /app \
+  -e APP_ENV=test --entrypoint sh secfix-312-php:latest -lc \
+  'php -d memory_limit=-1 vendor/bin/deptrac analyse --config-file=deptrac.yaml --no-progress'
+```
+
+## Story 3 — Keep Behat lockout helpers consistent with raw keys
+
+**Change**: `tests/Behat/UserContext/SignInSecurityContext.php`,
+`tests/Behat/UserContext/UserContext.php`, `config/services_test.yaml`
+
+`SignInSecurityContext` now deletes lockout keys via the same raw `\Redis`
+connection (`del()`), matching the keys the provider writes. `UserContext` drops
+the obsolete `accountLockoutCachePool` dependency — `REDIS_LOCKOUT_URL` points at
+Redis DB 0 in tests, which `RedisDatabaseMirror::flushDefaultAndHttpDatabases()`
+already flushes before each scenario.
+
+Covers NFR-Compatibility.
+
+**Test mapping**:
+
+- Negative/edge: existing `signin` lockout Behat scenarios (lockout reached,
+  "minutes have passed", reset) continue to pass because the helper now clears
+  the exact raw keys the provider sets.
+
+**Verification commands**:
+
+```bash
+# Unit + static gates (run in CI; Behat exercised by the full functional suite)
+docker run --rm -v /home/kravtsov/Projects/secfix-324:/app \
+  -v /home/kravtsov/Projects/user-service/vendor:/app/vendor:ro -w /app \
+  -e APP_ENV=test --entrypoint sh secfix-312-php:latest -lc \
+  'php -d memory_limit=-1 vendor/bin/psalm --no-cache --no-progress \
+     src/User/Infrastructure/Provider/RedisAccountLockoutProvider.php \
+     tests/Unit/User/Infrastructure/Provider/RedisAccountLockoutProviderTest.php \
+     tests/Behat/UserContext/SignInSecurityContext.php \
+     tests/Behat/UserContext/UserContext.php'
+```
+
+## Aggregate verification (all gates green)
+
+- phpunit (Lockout filter): `OK (11 tests, 24 assertions)`
+- phpunit (full Unit): `OK (2261 tests, 6212 assertions)`
+- deptrac: `Errors 0`
+- psalm (changed files): `No errors found!`
+- php-cs-fixer (changed files): `Found 0 of 4 files`

--- a/src/User/Infrastructure/Provider/Exception/AccountLockoutStorageException.php
+++ b/src/User/Infrastructure/Provider/Exception/AccountLockoutStorageException.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\User\Infrastructure\Provider\Exception;
+
+use RuntimeException;
+
+final class AccountLockoutStorageException extends RuntimeException
+{
+    public function __construct()
+    {
+        parent::__construct(
+            'Account lockout storage is unavailable; sign-in attempt refused.'
+        );
+    }
+}

--- a/src/User/Infrastructure/Provider/RedisAccountLockoutProvider.php
+++ b/src/User/Infrastructure/Provider/RedisAccountLockoutProvider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\User\Infrastructure\Provider;
 
 use App\User\Application\Provider\AccountLockoutProviderInterface;
+use App\User\Infrastructure\Provider\Exception\AccountLockoutStorageException;
 use Redis;
 
 final readonly class RedisAccountLockoutProvider implements
@@ -13,10 +14,15 @@ final readonly class RedisAccountLockoutProvider implements
     private const ATTEMPT_WINDOW_SECONDS = 3600;
 
     /**
-     * Atomically increments the failure counter and, on the request that
-     * crosses the threshold, sets the lock. Keeping the read-modify-write in
-     * a single server-side script removes the lost-update race that let
-     * concurrent failed logins exceed the intended attempt cap.
+     * Atomically increments the failure counter and, on every request that is
+     * at or above the threshold, (re)applies the lock. Keeping the
+     * read-modify-write in a single server-side script removes the lost-update
+     * race that let concurrent failed logins exceed the intended attempt cap.
+     *
+     * The lock is refreshed (not just set on the exact crossing attempt) so
+     * that once the shorter lock TTL expires while the longer attempt window is
+     * still open, any further over-threshold failure re-persists the lockout
+     * instead of silently letting it lapse.
      *
      * KEYS[1] attempts counter key
      * KEYS[2] lock key
@@ -35,9 +41,7 @@ final readonly class RedisAccountLockoutProvider implements
         if attempts < maxAttempts then
             return 0
         end
-        if attempts == maxAttempts then
-            redis.call('SET', KEYS[2], '1', 'EX', ARGV[3])
-        end
+        redis.call('SET', KEYS[2], '1', 'EX', ARGV[3])
         return 1
         LUA;
 
@@ -55,7 +59,7 @@ final readonly class RedisAccountLockoutProvider implements
     #[\Override]
     public function recordFailure(string $email): bool
     {
-        /** @var int|false $locked */
+        /** @var int|string|false $locked */
         $locked = $this->lockoutRedis->eval(
             self::RECORD_FAILURE_LUA_SCRIPT,
             [
@@ -67,6 +71,10 @@ final readonly class RedisAccountLockoutProvider implements
             ],
             2,
         );
+
+        if ($locked === false) {
+            throw new AccountLockoutStorageException();
+        }
 
         return (int) $locked === 1;
     }

--- a/src/User/Infrastructure/Provider/RedisAccountLockoutProvider.php
+++ b/src/User/Infrastructure/Provider/RedisAccountLockoutProvider.php
@@ -5,53 +5,79 @@ declare(strict_types=1);
 namespace App\User\Infrastructure\Provider;
 
 use App\User\Application\Provider\AccountLockoutProviderInterface;
-use Psr\Cache\CacheItemPoolInterface;
+use Redis;
 
 final readonly class RedisAccountLockoutProvider implements
     AccountLockoutProviderInterface
 {
     private const ATTEMPT_WINDOW_SECONDS = 3600;
 
+    /**
+     * Atomically increments the failure counter and, on the request that
+     * crosses the threshold, sets the lock. Keeping the read-modify-write in
+     * a single server-side script removes the lost-update race that let
+     * concurrent failed logins exceed the intended attempt cap.
+     *
+     * KEYS[1] attempts counter key
+     * KEYS[2] lock key
+     * ARGV[1] attempt window TTL (seconds)
+     * ARGV[2] max attempts threshold
+     * ARGV[3] lockout TTL (seconds)
+     *
+     * Returns 1 when the account is locked, 0 otherwise.
+     */
+    private const RECORD_FAILURE_LUA_SCRIPT = <<<'LUA'
+        local attempts = redis.call('INCR', KEYS[1])
+        if attempts == 1 then
+            redis.call('EXPIRE', KEYS[1], ARGV[1])
+        end
+        local maxAttempts = tonumber(ARGV[2])
+        if attempts < maxAttempts then
+            return 0
+        end
+        if attempts == maxAttempts then
+            redis.call('SET', KEYS[2], '1', 'EX', ARGV[3])
+        end
+        return 1
+        LUA;
+
     public function __construct(
-        private CacheItemPoolInterface $cachePool
+        private Redis $lockoutRedis
     ) {
     }
 
     #[\Override]
     public function isLocked(string $email): bool
     {
-        return $this->cachePool->getItem($this->lockKey($email))->isHit();
+        return (bool) $this->lockoutRedis->exists($this->lockKey($email));
     }
 
     #[\Override]
     public function recordFailure(string $email): bool
     {
-        $attemptsItem = $this->cachePool->getItem($this->attemptsKey($email));
-        $attempts = (int) $attemptsItem->get() + 1;
+        /** @var int|false $locked */
+        $locked = $this->lockoutRedis->eval(
+            self::RECORD_FAILURE_LUA_SCRIPT,
+            [
+                $this->attemptsKey($email),
+                $this->lockKey($email),
+                (string) self::ATTEMPT_WINDOW_SECONDS,
+                (string) AccountLockoutProviderInterface::MAX_ATTEMPTS,
+                (string) AccountLockoutProviderInterface::LOCKOUT_SECONDS,
+            ],
+            2,
+        );
 
-        $attemptsItem->set($attempts);
-        $attemptsItem->expiresAfter(self::ATTEMPT_WINDOW_SECONDS);
-        $this->cachePool->save($attemptsItem);
-
-        if ($attempts < AccountLockoutProviderInterface::MAX_ATTEMPTS) {
-            return false;
-        }
-
-        $lockItem = $this->cachePool->getItem($this->lockKey($email));
-        $lockItem->set(true);
-        $lockItem->expiresAfter(AccountLockoutProviderInterface::LOCKOUT_SECONDS);
-        $this->cachePool->save($lockItem);
-
-        return true;
+        return (int) $locked === 1;
     }
 
     #[\Override]
     public function clearFailures(string $email): void
     {
-        $this->cachePool->deleteItems([
+        $this->lockoutRedis->del(
             $this->attemptsKey($email),
             $this->lockKey($email),
-        ]);
+        );
     }
 
     #[\Override]

--- a/tests/Behat/UserContext/SignInSecurityContext.php
+++ b/tests/Behat/UserContext/SignInSecurityContext.php
@@ -11,7 +11,7 @@ use App\User\Domain\Repository\RecoveryCodeRepositoryInterface;
 use Behat\Behat\Context\Context;
 use OTPHP\TOTP;
 use PHPUnit\Framework\Assert;
-use Psr\Cache\CacheItemPoolInterface;
+use Redis;
 
 final class SignInSecurityContext implements Context
 {
@@ -20,7 +20,7 @@ final class SignInSecurityContext implements Context
 
     public function __construct(
         private UserOperationsState $state,
-        private CacheItemPoolInterface $cachePool,
+        private Redis $lockoutRedis,
         private readonly UserContextUserManagementServices $userManagement,
         private readonly UserContextAuthServices $auth,
         private readonly PendingTwoFactorRepositoryInterface $pendingTwoFactorRepository,
@@ -229,7 +229,7 @@ final class SignInSecurityContext implements Context
             return;
         }
 
-        $this->cachePool->deleteItem(
+        $this->lockoutRedis->del(
             $this->lockKey($this->requireLastLockoutEmail())
         );
     }
@@ -254,10 +254,10 @@ final class SignInSecurityContext implements Context
 
         $email = $this->requireLastLockoutEmail();
 
-        $this->cachePool->deleteItems([
+        $this->lockoutRedis->del(
             $this->attemptsKey($email),
             $this->lockKey($email),
-        ]);
+        );
     }
 
     private function requireLastLockoutEmail(): string

--- a/tests/Behat/UserContext/UserContext.php
+++ b/tests/Behat/UserContext/UserContext.php
@@ -24,7 +24,6 @@ final class UserContext implements Context
     public function __construct(
         private CacheItemPoolInterface $cachePool,
         private CacheItemPoolInterface $rateLimiterCachePool,
-        private CacheItemPoolInterface $accountLockoutCachePool,
         private readonly UserContextUserManagementServices $userManagement,
         private readonly RedisDatabaseMirror $redisDatabaseMirror,
     ) {
@@ -36,9 +35,10 @@ final class UserContext implements Context
      */
     public function clearCacheBeforeScenario(BeforeScenarioScope $scope): void
     {
+        // flushDefaultAndHttpDatabases() wipes Redis DB 0, which also holds the
+        // raw account-lockout keys (REDIS_LOCKOUT_URL points at DB 0 in tests).
         $this->redisDatabaseMirror->flushDefaultAndHttpDatabases();
         $this->cachePool->clear();
-        $this->accountLockoutCachePool->clear();
         self::$lastPasswordResetToken = '';
         self::$userIdsByEmail = [];
         self::$currentTokenUserEmail = '';

--- a/tests/Unit/User/Infrastructure/Provider/Exception/AccountLockoutStorageExceptionTest.php
+++ b/tests/Unit/User/Infrastructure/Provider/Exception/AccountLockoutStorageExceptionTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\User\Infrastructure\Provider\Exception;
+
+use App\Tests\Unit\UnitTestCase;
+use App\User\Infrastructure\Provider\Exception\AccountLockoutStorageException;
+use RuntimeException;
+
+final class AccountLockoutStorageExceptionTest extends UnitTestCase
+{
+    public function testExceptionMessage(): void
+    {
+        $exception = new AccountLockoutStorageException();
+
+        $this->assertSame(
+            'Account lockout storage is unavailable; sign-in attempt refused.',
+            $exception->getMessage()
+        );
+    }
+
+    public function testExceptionCode(): void
+    {
+        $exception = new AccountLockoutStorageException();
+
+        $this->assertSame(0, $exception->getCode());
+    }
+
+    public function testExceptionIsRuntimeException(): void
+    {
+        $exception = new AccountLockoutStorageException();
+
+        $this->assertInstanceOf(RuntimeException::class, $exception);
+    }
+}

--- a/tests/Unit/User/Infrastructure/Provider/RedisAccountLockoutProviderTest.php
+++ b/tests/Unit/User/Infrastructure/Provider/RedisAccountLockoutProviderTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\User\Infrastructure\Provider;
 
 use App\Tests\Unit\UnitTestCase;
 use App\User\Application\Provider\AccountLockoutProviderInterface;
+use App\User\Infrastructure\Provider\Exception\AccountLockoutStorageException;
 use App\User\Infrastructure\Provider\RedisAccountLockoutProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use Redis;
@@ -113,11 +114,43 @@ final class RedisAccountLockoutProviderTest extends UnitTestCase
         );
     }
 
-    public function testRecordFailureTreatsFalseEvalResultAsNotLocked(): void
+    /**
+     * Regression: the lock must be (re)applied on every at-or-above-threshold
+     * failure, not only on the exact crossing attempt. With a lock TTL shorter
+     * than the attempt window, gating the SET on `attempts == maxAttempts`
+     * would let the lockout silently lapse after the lock expires while the
+     * counter is still over threshold. The script therefore SETs the lock
+     * whenever the below-threshold early return is not taken.
+     */
+    public function testRecordFailureReappliesLockOnEveryOverThresholdFailure(): void
+    {
+        $capturedArguments = $this->captureEvalArguments(1);
+
+        $this->service->recordFailure(self::EMAIL);
+
+        [$script] = $capturedArguments();
+
+        $this->assertStringContainsString('SET', $script);
+        $this->assertStringNotContainsString(
+            'attempts == maxAttempts',
+            $script,
+            'Lock SET must not be gated on the exact threshold-crossing attempt'
+        );
+    }
+
+    /**
+     * The lockout counter is a brute-force security control, so a failed Redis
+     * eval (the script returning false on a storage error) must fail closed by
+     * raising an exception rather than silently reporting "not locked", which
+     * would otherwise disable enforcement whenever the backing store errors.
+     */
+    public function testRecordFailureFailsClosedWhenEvalReturnsFalse(): void
     {
         $this->redis->method('eval')->willReturn(false);
 
-        $this->assertFalse($this->service->recordFailure(self::EMAIL));
+        $this->expectException(AccountLockoutStorageException::class);
+
+        $this->service->recordFailure(self::EMAIL);
     }
 
     /**

--- a/tests/Unit/User/Infrastructure/Provider/RedisAccountLockoutProviderTest.php
+++ b/tests/Unit/User/Infrastructure/Provider/RedisAccountLockoutProviderTest.php
@@ -5,199 +5,192 @@ declare(strict_types=1);
 namespace App\Tests\Unit\User\Infrastructure\Provider;
 
 use App\Tests\Unit\UnitTestCase;
+use App\User\Application\Provider\AccountLockoutProviderInterface;
 use App\User\Infrastructure\Provider\RedisAccountLockoutProvider;
 use PHPUnit\Framework\MockObject\MockObject;
-use Psr\Cache\CacheItemInterface;
-use Psr\Cache\CacheItemPoolInterface;
+use Redis;
 
 final class RedisAccountLockoutProviderTest extends UnitTestCase
 {
-    private CacheItemPoolInterface&MockObject $cachePool;
+    private const EMAIL = 'test@example.com';
+    private const ATTEMPT_WINDOW_SECONDS = 3600;
+
+    private Redis&MockObject $redis;
+    private RedisAccountLockoutProvider $service;
 
     #[\Override]
     protected function setUp(): void
     {
         parent::setUp();
 
-        $this->cachePool = $this->createMock(CacheItemPoolInterface::class);
+        $this->redis = $this->createMock(Redis::class);
+        $this->service = new RedisAccountLockoutProvider($this->redis);
     }
 
-    public function testIsLockedReturnsTrueWhenLockItemExists(): void
+    public function testIsLockedReturnsTrueWhenLockKeyExists(): void
     {
-        $emailHash = hash('sha256', 'test@example.com');
-
-        $lockItem = $this->createMock(CacheItemInterface::class);
-        $lockItem
+        $this->redis
             ->expects($this->once())
-            ->method('isHit')
-            ->willReturn(true);
+            ->method('exists')
+            ->with($this->lockKey())
+            ->willReturn(1);
 
-        $this->cachePool
+        $this->assertTrue($this->service->isLocked(self::EMAIL));
+    }
+
+    public function testIsLockedReturnsFalseWhenLockKeyMissing(): void
+    {
+        $this->redis
             ->expects($this->once())
-            ->method('getItem')
-            ->with(sprintf('signin_lock_%s', $emailHash))
-            ->willReturn($lockItem);
+            ->method('exists')
+            ->with($this->lockKey())
+            ->willReturn(0);
 
-        $service = new RedisAccountLockoutProvider($this->cachePool);
-
-        $this->assertTrue($service->isLocked('test@example.com'));
+        $this->assertFalse($this->service->isLocked(self::EMAIL));
     }
 
     public function testRecordFailureReturnsFalseBeforeThreshold(): void
     {
-        $emailHash = hash('sha256', 'test@example.com');
-        $attemptItem = $this->createAttemptItem(3, 4);
-        $this->expectCachePoolGetAndSave(
-            sprintf('signin_lockout_%s', $emailHash),
-            $attemptItem
-        );
-        $service = new RedisAccountLockoutProvider($this->cachePool);
+        $this->expectAtomicEval(0);
 
-        $this->assertFalse($service->recordFailure('test@example.com'));
+        $this->assertFalse($this->service->recordFailure(self::EMAIL));
     }
 
     public function testRecordFailureReturnsTrueWhenThresholdReached(): void
     {
-        $emailHash = hash('sha256', 'test@example.com');
-        $attemptItem = $this->createAttemptItem(19, 20);
-        $lockItem = $this->createLockItem();
-        $requestedKeys = [];
-        $savedItems = [];
-        $this->expectSequentialGetItems($attemptItem, $lockItem, $requestedKeys);
-        $this->expectSequentialSaves($savedItems);
-        $service = new RedisAccountLockoutProvider($this->cachePool);
-        $this->assertTrue($service->recordFailure('test@example.com'));
-        $expectedKeys = [
-            sprintf('signin_lockout_%s', $emailHash),
-            sprintf('signin_lock_%s', $emailHash),
-        ];
-        $this->assertSame($expectedKeys, $requestedKeys);
-        $this->assertSame([$attemptItem, $lockItem], $savedItems);
+        $this->expectAtomicEval(1);
+
+        $this->assertTrue($this->service->recordFailure(self::EMAIL));
+    }
+
+    /**
+     * Regression for the lost-update race (CWE-362): the failure counter must be
+     * incremented and the lock applied inside a single atomic Redis eval. The
+     * provider must NOT perform a PHP-side read-modify-write (get + set + save),
+     * which let concurrent requests read the same value and undercount attempts.
+     */
+    public function testRecordFailureUsesSingleAtomicEvalWithoutReadModifyWrite(): void
+    {
+        $capturedArguments = $this->captureEvalArguments(0);
+
+        $this->redis->expects($this->never())->method('get');
+        $this->redis->expects($this->never())->method('set');
+        $this->redis->expects($this->never())->method('incr');
+
+        $this->service->recordFailure(self::EMAIL);
+
+        [$script, $keys, $numKeys] = $capturedArguments();
+
+        $this->assertStringContainsString('INCR', $script);
+        $this->assertStringContainsString('EXPIRE', $script);
+        $this->assertSame(2, $numKeys, 'Lua must bind both attempts and lock keys');
+        $this->assertSame($this->attemptsKey(), $keys[0]);
+        $this->assertSame($this->lockKey(), $keys[1]);
+    }
+
+    public function testRecordFailurePassesThresholdAndTtlConfigurationToScript(): void
+    {
+        $capturedArguments = $this->captureEvalArguments(1);
+
+        $this->service->recordFailure(self::EMAIL);
+
+        [, $keys] = $capturedArguments();
+
+        $this->assertSame(
+            (string) self::ATTEMPT_WINDOW_SECONDS,
+            $keys[2],
+            'Attempt window TTL must be forwarded to the atomic script'
+        );
+        $this->assertSame(
+            (string) AccountLockoutProviderInterface::MAX_ATTEMPTS,
+            $keys[3],
+            'Max-attempts threshold must be forwarded to the atomic script'
+        );
+        $this->assertSame(
+            (string) AccountLockoutProviderInterface::LOCKOUT_SECONDS,
+            $keys[4],
+            'Lockout TTL must be forwarded to the atomic script'
+        );
+    }
+
+    public function testRecordFailureTreatsFalseEvalResultAsNotLocked(): void
+    {
+        $this->redis->method('eval')->willReturn(false);
+
+        $this->assertFalse($this->service->recordFailure(self::EMAIL));
     }
 
     public function testClearFailuresDeletesAttemptAndLockKeys(): void
     {
-        $emailHash = hash('sha256', 'test@example.com');
-
-        $this->cachePool
+        $this->redis
             ->expects($this->once())
-            ->method('deleteItems')
-            ->with([
-                sprintf('signin_lockout_%s', $emailHash),
-                sprintf('signin_lock_%s', $emailHash),
-            ])
-            ->willReturn(true);
+            ->method('del')
+            ->with($this->attemptsKey(), $this->lockKey())
+            ->willReturn(2);
 
-        $service = new RedisAccountLockoutProvider($this->cachePool);
-
-        $service->clearFailures('test@example.com');
+        $this->service->clearFailures(self::EMAIL);
     }
 
     public function testMaxAttemptsReturnsConstant(): void
     {
-        $service = new RedisAccountLockoutProvider($this->cachePool);
-        $this->assertSame(20, $service->maxAttempts());
+        $this->assertSame(20, $this->service->maxAttempts());
     }
 
     public function testLockoutSecondsReturnsConstant(): void
     {
-        $service = new RedisAccountLockoutProvider($this->cachePool);
-        $this->assertSame(900, $service->lockoutSeconds());
+        $this->assertSame(900, $this->service->lockoutSeconds());
     }
 
-    public function testRecordFailureTreatsEmptyAttemptCounterAsZero(): void
+    private function expectAtomicEval(int $returnValue): void
     {
-        $emailHash = hash('sha256', 'test@example.com');
-        $attemptItem = $this->createAttemptItem('', 1);
-        $this->expectCachePoolGetAndSave(
-            sprintf('signin_lockout_%s', $emailHash),
-            $attemptItem
-        );
-        $service = new RedisAccountLockoutProvider($this->cachePool);
-
-        $this->assertFalse($service->recordFailure('test@example.com'));
-    }
-
-    private function createAttemptItem(
-        mixed $currentCount,
-        int $newCount
-    ): CacheItemInterface&MockObject {
-        $item = $this->createMock(CacheItemInterface::class);
-        $item->expects($this->once())->method('get')->willReturn($currentCount);
-        $item->expects($this->once())->method('set')->with($newCount)->willReturnSelf();
-        $item->expects($this->once())->method('expiresAfter')->with(3600)->willReturnSelf();
-
-        return $item;
-    }
-
-    private function createLockItem(): CacheItemInterface&MockObject
-    {
-        $item = $this->createMock(CacheItemInterface::class);
-        $item->expects($this->once())->method('set')->with(true)->willReturnSelf();
-        $item->expects($this->once())->method('expiresAfter')->with(900)->willReturnSelf();
-
-        return $item;
-    }
-
-    private function expectCachePoolGetAndSave(
-        string $key,
-        CacheItemInterface $item
-    ): void {
-        $this->cachePool
+        $this->redis
             ->expects($this->once())
-            ->method('getItem')
-            ->with($key)
-            ->willReturn($item);
-        $this->cachePool
-            ->expects($this->once())
-            ->method('save')
-            ->with($item)
-            ->willReturn(true);
+            ->method('eval')
+            ->with(
+                $this->isType('string'),
+                $this->callback(function (array $keys): bool {
+                    return $keys[0] === $this->attemptsKey()
+                        && $keys[1] === $this->lockKey();
+                }),
+                2,
+            )
+            ->willReturn($returnValue);
     }
 
     /**
-     * @param array<string> $requestedKeys
+     * @return callable(): array{0: string, 1: list<string>, 2: int}
      */
-    private function expectSequentialGetItems(
-        CacheItemInterface $firstItem,
-        CacheItemInterface $secondItem,
-        array &$requestedKeys
-    ): void {
-        $this->cachePool
-            ->expects($this->exactly(2))
-            ->method('getItem')
+    private function captureEvalArguments(int $returnValue): callable
+    {
+        $captured = [];
+
+        $this->redis
+            ->expects($this->once())
+            ->method('eval')
             ->willReturnCallback(
                 static function (
-                    string $key
-                ) use (
-                    $firstItem,
-                    $secondItem,
-                    &$requestedKeys
-                ): MockObject&CacheItemInterface {
-                    $requestedKeys[] = $key;
+                    string $script,
+                    array $keys,
+                    int $numKeys
+                ) use (&$captured, $returnValue): int {
+                    $captured = [$script, $keys, $numKeys];
 
-                    return count($requestedKeys) === 1
-                        ? $firstItem : $secondItem;
+                    return $returnValue;
                 }
             );
+
+        return static function () use (&$captured): array {
+            return $captured;
+        };
     }
 
-    /**
-     * @param array<CacheItemInterface> $savedItems
-     */
-    private function expectSequentialSaves(array &$savedItems): void
+    private function attemptsKey(): string
     {
-        $this->cachePool
-            ->expects($this->exactly(2))
-            ->method('save')
-            ->willReturnCallback(/**
-             * @return true
-             */
-                static function (CacheItemInterface $item) use (&$savedItems): bool {
-                    $savedItems[] = $item;
+        return sprintf('signin_lockout_%s', hash('sha256', self::EMAIL));
+    }
 
-                    return true;
-                }
-            );
+    private function lockKey(): string
+    {
+        return sprintf('signin_lock_%s', hash('sha256', self::EMAIL));
     }
 }

--- a/tests/Unit/User/Infrastructure/Provider/RedisAccountLockoutProviderTest.php
+++ b/tests/Unit/User/Infrastructure/Provider/RedisAccountLockoutProviderTest.php
@@ -120,6 +120,31 @@ final class RedisAccountLockoutProviderTest extends UnitTestCase
         $this->assertFalse($this->service->recordFailure(self::EMAIL));
     }
 
+    /**
+     * phpredis can surface the Lua integer reply as a numeric string when a
+     * serializer is configured. The provider must normalize the reply with an
+     * integer cast before the strict locked comparison, otherwise a string
+     * "1" would never be recognized as a lock and the account would stay open.
+     */
+    public function testRecordFailureCastsNumericStringEvalResultToLocked(): void
+    {
+        $this->redis->method('eval')->willReturn('1');
+
+        $this->assertTrue($this->service->recordFailure(self::EMAIL));
+    }
+
+    /**
+     * A numeric-string "0" reply must likewise be cast before comparison so a
+     * below-threshold failure is reported as not locked rather than leaking the
+     * raw Redis reply through the strict comparison.
+     */
+    public function testRecordFailureCastsNumericStringZeroEvalResultToNotLocked(): void
+    {
+        $this->redis->method('eval')->willReturn('0');
+
+        $this->assertFalse($this->service->recordFailure(self::EMAIL));
+    }
+
     public function testClearFailuresDeletesAttemptAndLockKeys(): void
     {
         $this->redis


### PR DESCRIPTION
## Security fix — Closes #324

### Vulnerability (CWE-362, race condition)
`RedisAccountLockoutProvider::recordFailure()` implemented the per-account failed-login counter as a non-atomic PSR-6 read-modify-write: `getItem()->get()`, `+1` in PHP, then `set()`/`save()`. Concurrent failed-login requests for the same email read the same starting value and each persisted `value + 1`, so N parallel requests advanced the counter by far fewer than N (lost-update race).

Because this email-keyed lockout (20 attempts / 1h) is the primary per-account brute-force control on the GraphQL `signIn` path (where the `signin_email`/`signin_ip` limiters are bypassed), the undercount let an attacker exceed the intended 20-guess cap by firing concurrent requests before the lock was ever applied.

### Fix
- Replace the read-modify-write with a single server-side Lua script via `Redis::eval` that `INCR`s the attempts key, sets the 3600s window TTL on the first increment, and atomically `SET`s the lock key (900s TTL) once the threshold is crossed — mirroring the established atomic pattern in `RedisOAuthStateRepository::validateAndConsume()`.
- Bind the existing `app.account_lockout_redis_connection` `\Redis` service directly into the provider; remove the now-orphaned `cache.account_lockout` PSR-6 RedisAdapter.
- `isLocked()` uses `EXISTS`, `clearFailures()` uses `DEL`. Behat lockout helpers now operate on the same raw connection (test DB 0 is already flushed before each scenario).
- The Lua script is a hardcoded constant; only bound `KEYS`/`ARGV` are passed (no user input in the script body). Public interface signatures, key names, and 20/900 semantics are unchanged.

### Local verification (one-off containers)
- phpunit Unit (Lockout filter): `OK (11 tests, 24 assertions)`
- phpunit full Unit: `OK (2261 tests, 6212 assertions)`
- deptrac: `Errors 0`
- psalm (changed files): `No errors found!`
- php-cs-fixer (changed files): `Found 0 of 4 files`

A new regression test (`testRecordFailureUsesSingleAtomicEvalWithoutReadModifyWrite`) asserts the script uses `INCR`/`EXPIRE`, binds both keys, and that the provider never performs a PHP-side `get`/`set`/`incr` — it fails against the old read-modify-write implementation and passes with the atomic fix.

### BMAD spec
`specs/security-324-account-lockout-counter-race/` (`prd.md`, `stories.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the race condition in account lockout by making the failure counter atomic and ensuring the lock is applied reliably under concurrency. Also refreshes the lock on every over‑threshold failure and fails closed on Redis errors. Closes #324.

- **Bug Fixes**
  - Switched to a single `Redis::eval` Lua script that `INCR`s attempts, sets the 1h TTL on first increment, and `SET`s/refreshes the 900s lock whenever attempts ≥ 20 (atomic; thresholds unchanged).
  - Normalized `eval` replies to integers and now throw `AccountLockoutStorageException` when `eval` returns `false`; added tests for numeric-string casting, the atomic path, lock reapplication, fail-closed behavior, plus a dedicated `AccountLockoutStorageException` message test.
  - Wired `App\User\Infrastructure\Provider\RedisAccountLockoutProvider` to `@app.account_lockout_redis_connection` (`\Redis`) and updated Behat helpers to use the same raw keys; removed `cache.account_lockout`.

<sup>Written for commit 4c19479682114acf15c71143e42dc577ba8f3b25. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VilnaCRM-Org/user-service/pull/337?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

