### PR TITLE
chore: ignore .claude/worktrees subagent dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,4 @@ _bmad-output/
 /config/jwt/*.pem
 /config/reference.php
 ###< league/oauth2-server-bundle ###
+.claude/worktrees/


### PR DESCRIPTION
https://claude.ai/code/session_0194oTs2mpoGNa5yM2rj4JxV

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ignore `.claude/worktrees/` in `.gitignore` to prevent local subagent worktree files from being tracked.
This keeps the repo clean and avoids noise in PRs.

<sup>Written for commit 871442e404baed9be8598086e7057349fc99841c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VilnaCRM-Org/user-service/pull/339?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

