### PR TITLE
feat(runtime): prepare production web and workers for AWS task roles

### DIFF
--- a/.env
+++ b/.env
@@ -187,6 +187,6 @@ OAUTH_STATE_TTL_SECONDS=600
 ###< oauth-social-signin ###
 
 ###> symfony/amazon-mailer ###
-# MAILER_DSN=ses://ACCESS_KEY:SECRET_KEY@default?region=eu-west-1
+# MAILER_DSN=ses+api://default?region=eu-west-1
 # MAILER_DSN=ses+smtp://ACCESS_KEY:SECRET_KEY@default?region=eu-west-1
 ###< symfony/amazon-mailer ###

--- a/.env
+++ b/.env
@@ -185,3 +185,8 @@ OAUTH_PROVIDER_HTTP_TIMEOUT_MS=5000
 # OAuth state TTL in seconds (default: 600 = 10 minutes)
 OAUTH_STATE_TTL_SECONDS=600
 ###< oauth-social-signin ###
+
+###> symfony/amazon-mailer ###
+# MAILER_DSN=ses://ACCESS_KEY:SECRET_KEY@default?region=eu-west-1
+# MAILER_DSN=ses+smtp://ACCESS_KEY:SECRET_KEY@default?region=eu-west-1
+###< symfony/amazon-mailer ###

--- a/.github/openapi-spec/spec.yaml
+++ b/.github/openapi-spec/spec.yaml
@@ -2765,16 +2765,16 @@ components:
                 '@type':
                   type: string
                 first:
-                  type: string
+                  type: [string, 'null']
                   format: iri-reference
                 last:
-                  type: string
+                  type: [string, 'null']
                   format: iri-reference
                 previous:
-                  type: string
+                  type: [string, 'null']
                   format: iri-reference
                 next:
-                  type: string
+                  type: [string, 'null']
                   format: iri-reference
               example:
                 '@id': string

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,10 +25,10 @@ ARG SYMFONY_VERSION=""
 ENV SYMFONY_VERSION=${SYMFONY_VERSION}
 
 ARG APCU_VERSION=v5.1.28
-ARG MONGODB_VERSION=2.3.0
+ARG MONGODB_VERSION=2.4.1
 ARG REDIS_VERSION=6.3.0
 ARG APCU_SHA256=ca9c1820810a168786f8048a4c3f8c9e3fd941407ad1553259fb2e30b5f057bf
-ARG MONGODB_SHA256=7e7c4fbdc991bad24524316096d4ac9cd805632c9ba7f9886682db843d60166c
+ARG MONGODB_SHA256=a57dc6bd18938ac2396086d9eec44bc82e7d17c399844923b04fe4cdff895ac0
 ARG REDIS_SHA256=0d5141f634bd1db6c1ddcda053d25ecf2c4fc1c395430d534fd3f8d51dd7f0b5
 
 ENV APP_ENV=prod
@@ -189,6 +189,7 @@ ENV FRANKENPHP_CONFIG="import worker.Caddyfile"
 RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
 
 COPY --link infrastructure/docker/php/conf.d/app.prod.ini $PHP_INI_DIR/conf.d/
+COPY --link infrastructure/docker/caddy/Caddyfile.prod /etc/caddy/Caddyfile
 COPY --link infrastructure/docker/php/worker.Caddyfile /etc/caddy/worker.Caddyfile
 
 COPY --link composer.* symfony.* ./
@@ -206,5 +207,8 @@ RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
 
 COPY --link infrastructure/docker/php/conf.d/app.prod.ini $PHP_INI_DIR/conf.d/
 COPY --link infrastructure/supervisor/supervisord.conf /etc/supervisor/supervisord.conf
+COPY --link --chmod=755 infrastructure/supervisor/worker-healthcheck /usr/local/bin/worker-healthcheck
+
+HEALTHCHECK --start-period=60s --interval=30s --timeout=5s --retries=3 CMD ["/usr/local/bin/worker-healthcheck"]
 
 CMD ["/usr/bin/supervisord", "-c", "/etc/supervisor/supervisord.conf"]

--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,7 @@
     "smolblog/oauth2-twitter": "^1.2",
     "spomky-labs/otphp": "^11.4",
     "symfony/amazon-sqs-messenger": "7.4.*",
+    "symfony/amazon-mailer": "8.1.*",
     "symfony/asset": "8.1.*",
     "symfony/cache": "7.4.*",
     "symfony/console": "7.4.*",
@@ -81,7 +82,7 @@
     "sort-packages": true,
     "platform": {
       "php": "8.4.4",
-      "ext-mongodb": "2.3.0"
+      "ext-mongodb": "2.4.1"
     }
   },
   "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "87fc8486fef8c71b206c878ff2c852a0",
+    "content-hash": "964193f3bfc3bed22152bdd6ad0dc3a4",
     "packages": [
         {
             "name": "api-platform/core",
-            "version": "v4.3.10",
+            "version": "v4.3.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/api-platform/core.git",
-                "reference": "77c87883e02dceeb34eb49eb8b0a888ce57e2916"
+                "reference": "1510da462dfdabdef87b53827b7dd629483518c4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/api-platform/core/zipball/77c87883e02dceeb34eb49eb8b0a888ce57e2916",
-                "reference": "77c87883e02dceeb34eb49eb8b0a888ce57e2916",
+                "url": "https://api.github.com/repos/api-platform/core/zipball/1510da462dfdabdef87b53827b7dd629483518c4",
+                "reference": "1510da462dfdabdef87b53827b7dd629483518c4",
                 "shasum": ""
             },
             "require": {
@@ -220,9 +220,9 @@
             ],
             "support": {
                 "issues": "https://github.com/api-platform/core/issues",
-                "source": "https://github.com/api-platform/core/tree/v4.3.10"
+                "source": "https://github.com/api-platform/core/tree/v4.3.12"
             },
-            "time": "2026-06-05T15:24:51+00:00"
+            "time": "2026-06-13T05:15:21+00:00"
         },
         {
             "name": "async-aws/core",
@@ -295,6 +295,68 @@
                 }
             ],
             "time": "2026-02-16T10:24:54+00:00"
+        },
+        {
+            "name": "async-aws/ses",
+            "version": "1.16.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/async-aws/ses.git",
+                "reference": "1f7e88f6afaee5e3e665341cbb59ed32b5b6c740"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/async-aws/ses/zipball/1f7e88f6afaee5e3e665341cbb59ed32b5b6c740",
+                "reference": "1f7e88f6afaee5e3e665341cbb59ed32b5b6c740",
+                "shasum": ""
+            },
+            "require": {
+                "async-aws/core": "^1.9",
+                "ext-filter": "*",
+                "php": "^8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.5.42",
+                "symfony/error-handler": "^7.3.2 || ^8.0",
+                "symfony/phpunit-bridge": "^7.3.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.16-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "AsyncAws\\Ses\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "SES client, part of the AWS SDK provided by AsyncAws.",
+            "keywords": [
+                "amazon",
+                "async-aws",
+                "aws",
+                "sdk",
+                "ses"
+            ],
+            "support": {
+                "source": "https://github.com/async-aws/ses/tree/1.16.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/jderusse",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nyholm",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-07-29T12:54:05+00:00"
         },
         {
             "name": "async-aws/sqs",
@@ -2041,26 +2103,26 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.11.0",
+            "version": "7.15.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "c987f8ce84b8434fa430795eca0f3430663da72b"
+                "reference": "744101956d78b7c1384d0cbf379db13e859167bf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/c987f8ce84b8434fa430795eca0f3430663da72b",
-                "reference": "c987f8ce84b8434fa430795eca0f3430663da72b",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/744101956d78b7c1384d0cbf379db13e859167bf",
+                "reference": "744101956d78b7c1384d0cbf379db13e859167bf",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
-                "guzzlehttp/promises": "^2.5",
-                "guzzlehttp/psr7": "^2.11",
+                "guzzlehttp/promises": "^2.5.1",
+                "guzzlehttp/psr7": "^2.13",
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-client": "^1.0",
                 "symfony/deprecation-contracts": "^2.5 || ^3.0",
-                "symfony/polyfill-php80": "^1.24"
+                "symfony/polyfill-php80": "^1.25"
             },
             "provide": {
                 "psr/http-client-implementation": "1.0"
@@ -2068,8 +2130,8 @@
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
                 "ext-curl": "*",
-                "guzzle/client-integration-tests": "3.0.2",
-                "guzzlehttp/test-server": "^0.4",
+                "guzzle/client-integration-tests": "3.0.3",
+                "guzzlehttp/test-server": "^0.7",
                 "php-http/message-factory": "^1.1",
                 "phpunit/phpunit": "^8.5.52 || ^9.6.34",
                 "psr/log": "^1.1 || ^2.0 || ^3.0"
@@ -2149,7 +2211,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.11.0"
+                "source": "https://github.com/guzzle/guzzle/tree/7.15.2"
             },
             "funding": [
                 {
@@ -2165,20 +2227,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-06-02T12:40:51+00:00"
+            "time": "2026-07-26T23:23:20+00:00"
         },
         {
             "name": "guzzlehttp/promises",
-            "version": "2.5.0",
+            "version": "2.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/promises.git",
-                "reference": "4360e982f87f5f258bf872d094647791db2f4c8e"
+                "reference": "9ad1e4fc607446a055b95870c7f668e93b5cff29"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/4360e982f87f5f258bf872d094647791db2f4c8e",
-                "reference": "4360e982f87f5f258bf872d094647791db2f4c8e",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/9ad1e4fc607446a055b95870c7f668e93b5cff29",
+                "reference": "9ad1e4fc607446a055b95870c7f668e93b5cff29",
                 "shasum": ""
             },
             "require": {
@@ -2233,7 +2295,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/promises/issues",
-                "source": "https://github.com/guzzle/promises/tree/2.5.0"
+                "source": "https://github.com/guzzle/promises/tree/2.5.1"
             },
             "funding": [
                 {
@@ -2249,20 +2311,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-06-02T12:23:43+00:00"
+            "time": "2026-07-08T15:48:39+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.11.0",
+            "version": "2.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "bbb5e61349fa5cb822b3e87842b951088b76b81f"
+                "reference": "dad89620b7a6edb60c15858442eb2e408b45d8f4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/bbb5e61349fa5cb822b3e87842b951088b76b81f",
-                "reference": "bbb5e61349fa5cb822b3e87842b951088b76b81f",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/dad89620b7a6edb60c15858442eb2e408b45d8f4",
+                "reference": "dad89620b7a6edb60c15858442eb2e408b45d8f4",
                 "shasum": ""
             },
             "require": {
@@ -2271,7 +2333,7 @@
                 "psr/http-message": "^1.1 || ^2.0",
                 "ralouphie/getallheaders": "^3.0",
                 "symfony/deprecation-contracts": "^2.5 || ^3.0",
-                "symfony/polyfill-php80": "^1.24"
+                "symfony/polyfill-php80": "^1.25"
             },
             "provide": {
                 "psr/http-factory-implementation": "1.0",
@@ -2352,7 +2414,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.11.0"
+                "source": "https://github.com/guzzle/psr7/tree/2.13.0"
             },
             "funding": [
                 {
@@ -2368,7 +2430,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-06-02T12:30:48+00:00"
+            "time": "2026-07-16T22:23:49+00:00"
         },
         {
             "name": "ircmaxell/security-lib",
@@ -3516,21 +3578,21 @@
         },
         {
             "name": "mongodb/mongodb",
-            "version": "2.3.0",
+            "version": "2.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mongodb/mongo-php-library",
-                "reference": "12e56461166d915e3dd8e4969ad0940ed5207d88"
+                "reference": "b72cc2ecf4a11d3871f78a119a8f3cc7ab6d6c29"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mongodb/mongo-php-library/zipball/12e56461166d915e3dd8e4969ad0940ed5207d88",
-                "reference": "12e56461166d915e3dd8e4969ad0940ed5207d88",
+                "url": "https://api.github.com/repos/mongodb/mongo-php-library/zipball/b72cc2ecf4a11d3871f78a119a8f3cc7ab6d6c29",
+                "reference": "b72cc2ecf4a11d3871f78a119a8f3cc7ab6d6c29",
                 "shasum": ""
             },
             "require": {
                 "composer-runtime-api": "^2.0",
-                "ext-mongodb": "^2.3",
+                "ext-mongodb": "^2.4",
                 "php": "^8.1",
                 "psr/log": "^1.1.4|^2|^3",
                 "symfony/polyfill-php85": "^1.33"
@@ -3585,7 +3647,7 @@
                 "mongodb",
                 "persistence"
             ],
-            "time": "2026-04-28T12:50:06+00:00"
+            "time": "2026-08-27T14:43:15+00:00"
         },
         {
             "name": "monolog/monolog",
@@ -3692,16 +3754,16 @@
         },
         {
             "name": "mtdowling/jmespath.php",
-            "version": "2.8.0",
+            "version": "2.9.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/jmespath/jmespath.php.git",
-                "reference": "a2a865e05d5f420b50cc2f85bb78d565db12a6bc"
+                "reference": "9c208ba27ae7d90853c288b3795d6702eb251d34"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/jmespath/jmespath.php/zipball/a2a865e05d5f420b50cc2f85bb78d565db12a6bc",
-                "reference": "a2a865e05d5f420b50cc2f85bb78d565db12a6bc",
+                "url": "https://api.github.com/repos/jmespath/jmespath.php/zipball/9c208ba27ae7d90853c288b3795d6702eb251d34",
+                "reference": "9c208ba27ae7d90853c288b3795d6702eb251d34",
                 "shasum": ""
             },
             "require": {
@@ -3710,7 +3772,7 @@
             },
             "require-dev": {
                 "composer/xdebug-handler": "^3.0.3",
-                "phpunit/phpunit": "^8.5.33"
+                "phpunit/phpunit": "^8.5.52"
             },
             "bin": [
                 "bin/jp.php"
@@ -3718,7 +3780,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.8-dev"
+                    "dev-master": "2.9-dev"
                 }
             },
             "autoload": {
@@ -3752,9 +3814,9 @@
             ],
             "support": {
                 "issues": "https://github.com/jmespath/jmespath.php/issues",
-                "source": "https://github.com/jmespath/jmespath.php/tree/2.8.0"
+                "source": "https://github.com/jmespath/jmespath.php/tree/2.9.1"
             },
-            "time": "2024-09-04T18:46:31+00:00"
+            "time": "2026-06-11T10:43:56+00:00"
         },
         {
             "name": "nelmio/cors-bundle",
@@ -4085,16 +4147,16 @@
         },
         {
             "name": "paragonie/sodium_compat",
-            "version": "v2.5.0",
+            "version": "v2.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/paragonie/sodium_compat.git",
-                "reference": "4714da6efdc782c06690bc72ce34fae7941c2d9f"
+                "reference": "e4d4933af9463a96a1a3cbaeb94327b90e3350ca"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/paragonie/sodium_compat/zipball/4714da6efdc782c06690bc72ce34fae7941c2d9f",
-                "reference": "4714da6efdc782c06690bc72ce34fae7941c2d9f",
+                "url": "https://api.github.com/repos/paragonie/sodium_compat/zipball/e4d4933af9463a96a1a3cbaeb94327b90e3350ca",
+                "reference": "e4d4933af9463a96a1a3cbaeb94327b90e3350ca",
                 "shasum": ""
             },
             "require": {
@@ -4175,9 +4237,9 @@
             ],
             "support": {
                 "issues": "https://github.com/paragonie/sodium_compat/issues",
-                "source": "https://github.com/paragonie/sodium_compat/tree/v2.5.0"
+                "source": "https://github.com/paragonie/sodium_compat/tree/v2.5.1"
             },
-            "time": "2025-12-30T16:12:18+00:00"
+            "time": "2026-08-18T15:39:41+00:00"
         },
         {
             "name": "phpmailer/phpmailer",
@@ -5217,6 +5279,76 @@
                 }
             ],
             "time": "2026-05-31T12:42:43+00:00"
+        },
+        {
+            "name": "symfony/amazon-mailer",
+            "version": "v8.1.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/amazon-mailer.git",
+                "reference": "053c95a45b71ae830cb6b482d0cc137daa32bb4f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/amazon-mailer/zipball/053c95a45b71ae830cb6b482d0cc137daa32bb4f",
+                "reference": "053c95a45b71ae830cb6b482d0cc137daa32bb4f",
+                "shasum": ""
+            },
+            "require": {
+                "async-aws/ses": "^1.8",
+                "php": ">=8.4.1",
+                "symfony/mailer": "^7.4|^8.0"
+            },
+            "require-dev": {
+                "symfony/http-client": "^7.4|^8.0"
+            },
+            "type": "symfony-mailer-bridge",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Mailer\\Bridge\\Amazon\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Amazon Mailer Bridge",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/amazon-mailer/tree/v8.1.5"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-08-21T17:47:34+00:00"
         },
         {
             "name": "symfony/amazon-sqs-messenger",
@@ -18013,16 +18145,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.13.5",
+            "version": "3.13.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "0ca86845ce43291e8f5692c7356fccf3bcf02bf4"
+                "reference": "4c378e1a528ea066890fc2397cbdd2f94eb2fc91"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/0ca86845ce43291e8f5692c7356fccf3bcf02bf4",
-                "reference": "0ca86845ce43291e8f5692c7356fccf3bcf02bf4",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/4c378e1a528ea066890fc2397cbdd2f94eb2fc91",
+                "reference": "4c378e1a528ea066890fc2397cbdd2f94eb2fc91",
                 "shasum": ""
             },
             "require": {
@@ -18088,7 +18220,7 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-11-04T16:30:35+00:00"
+            "time": "2026-08-06T00:17:32+00:00"
         },
         {
             "name": "symfony/browser-kit",
@@ -19246,7 +19378,7 @@
     "platform-dev": {},
     "platform-overrides": {
         "php": "8.4.4",
-        "ext-mongodb": "2.3.0"
+        "ext-mongodb": "2.4.1"
     },
     "plugin-api-version": "2.9.0"
 }

--- a/config/packages/messenger.yaml
+++ b/config/packages/messenger.yaml
@@ -3,6 +3,8 @@ framework:
     transports:
       send-email:
         dsn: '%env(SEND_EMAIL_TRANSPORT_DSN)%'
+        options:
+          auto_setup: false
 
         retry_strategy:
           max_retries: 3
@@ -15,19 +17,23 @@ framework:
 
       failed-send-email:
         dsn: '%env(FAILED_EMAIL_TRANSPORT_DSN)%'
+        options:
+          auto_setup: false
 
         retry_strategy:
           service: 'App\Shared\Infrastructure\RetryStrategy\InfiniteRetryStrategy'
 
       insert-user-batch:
         dsn: '%env(INSERT_USER_BATCH_TRANSPORT_DSN)%'
+        options:
+          auto_setup: false
 
       # Main transport for async domain events (AP from CAP - resilient dispatch)
       domain-events:
         dsn: '%env(DOMAIN_EVENTS_TRANSPORT_DSN)%'
         serializer: messenger.transport.symfony_serializer
         options:
-          auto_setup: true
+          auto_setup: false
 
         retry_strategy:
           max_retries: 3
@@ -41,6 +47,8 @@ framework:
       # Infinite retry transport for failed domain events (AP theorem - eventual delivery)
       failed-domain-events:
         dsn: '%env(FAILED_DOMAIN_EVENTS_TRANSPORT_DSN)%'
+        options:
+          auto_setup: false
         retry_strategy:
           service: 'App\Shared\Infrastructure\RetryStrategy\InfiniteRetryStrategy'
 
@@ -57,6 +65,7 @@ when@test:
         send-email:
           dsn: '%env(REDIS_URL)%'
           options:
+            auto_setup: true
             consumer: '%env(MESSENGER_CONSUMER_NAME)%'
         domain-events: 'in-memory://'
         failed-domain-events: 'in-memory://'

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -5,6 +5,8 @@
 # https://symfony.com/doc/current/best_practices.html#use-parameters-for-application-configuration
 parameters:
   api_url_prefix: '%env(API_PREFIX)%'
+  social_oauth_enabled_default: true
+  social_oauth_enabled: '%env(bool:default:social_oauth_enabled_default:SOCIAL_OAUTH_ENABLED)%'
 
 services:
   # default configuration for services in *this* file
@@ -86,7 +88,16 @@ services:
     arguments:
       $providers: !tagged_iterator 'app.oauth_provider'
 
+  App\OAuth\Application\Factory\OAuthProviderCollectionFactory:
+    arguments:
+      $enabled: '%social_oauth_enabled%'
+
+  App\Shared\Application\Factory\OAuthProviderNameCollectionFactory:
+    arguments:
+      $enabled: '%social_oauth_enabled%'
+
   App\Shared\Domain\Collection\OAuthProviderNameCollection:
+    factory: ['@App\Shared\Application\Factory\OAuthProviderNameCollectionFactory', 'create']
     arguments:
       $providers: !tagged_iterator 'app.oauth_provider_name'
 
@@ -396,10 +407,6 @@ services:
     arguments:
       - version: '%env(AWS_SQS_VERSION)%'
         region: '%env(AWS_SQS_REGION)%'
-        endpoint: '%env(AWS_SQS_ENDPOINT_BASE)%:%env(LOCALSTACK_PORT)%'
-        credentials:
-          key: '%env(AWS_SQS_KEY)%'
-          secret: '%env(AWS_SQS_SECRET)%'
 
   # OAuth Social Sign-In
   oauth.redis_connection:
@@ -544,3 +551,26 @@ services:
 
   League\Bundle\OAuth2ServerBundle\Service\CredentialsRevokerInterface:
     alias: App\OAuth\Infrastructure\Adapter\CredentialsRevoker
+
+when@dev:
+  services:
+    Aws\Sqs\SqsClient: &local_sqs_client
+      arguments:
+        - version: '%env(AWS_SQS_VERSION)%'
+          region: '%env(AWS_SQS_REGION)%'
+          endpoint: '%env(AWS_SQS_ENDPOINT_BASE)%:%env(LOCALSTACK_PORT)%'
+          credentials:
+            key: '%env(AWS_SQS_KEY)%'
+            secret: '%env(AWS_SQS_SECRET)%'
+
+when@test:
+  services:
+    Aws\Sqs\SqsClient: *local_sqs_client
+
+when@load_test:
+  services:
+    Aws\Sqs\SqsClient: *local_sqs_client
+
+when@schemathesis:
+  services:
+    Aws\Sqs\SqsClient: *local_sqs_client

--- a/docker-compose.load-tests.yml
+++ b/docker-compose.load-tests.yml
@@ -24,6 +24,7 @@ services:
       - /srv/app/vendor
       - caddy_data:/data
       - caddy_config:/config
+      - ./infrastructure/docker/caddy/Caddyfile:/etc/caddy/Caddyfile:ro
       - ./infrastructure/docker/php/docker-entrypoint.sh:/usr/local/bin/docker-entrypoint:ro
       - ./infrastructure/docker/php/worker.Caddyfile:/etc/caddy/worker.Caddyfile:ro
     environment:

--- a/docs/advanced-configuration.md
+++ b/docs/advanced-configuration.md
@@ -27,9 +27,9 @@ The User Service utilizes environment variables for configuration to ensure that
 
 - `AWS_SQS_VERSION`: The AWS SQS API version.
 - `AWS_SQS_REGION`: The AWS region for SQS.
-- `AWS_SQS_ENDPOINT_BASE`: The SQS endpoint base (e.g., `localstack` for local development).
-- `AWS_SQS_KEY`: The AWS access key for SQS.
-- `AWS_SQS_SECRET`: The AWS secret key for SQS.
+- `AWS_SQS_ENDPOINT_BASE`: The LocalStack endpoint base for `dev`, `test`, `load_test`, and `schemathesis`.
+- `AWS_SQS_KEY`: The LocalStack access key for development and test environments only.
+- `AWS_SQS_SECRET`: The LocalStack secret key for development and test environments only.
 - `LOCALSTACK_PORT`: The port on which LocalStack is running.
 
 #### Messenger Transports
@@ -59,6 +59,17 @@ The User Service utilizes environment variables for configuration to ensure that
 
 In production, the application throws an explicit runtime configuration error if `OAUTH_ENCRYPTION_KEY` is empty.
 Password grant is intentionally disabled (`enable_password_grant: false`); use authorization code + PKCE or client credentials grants.
+
+#### Social sign-in
+
+`SOCIAL_OAUTH_ENABLED` defaults to `true` in every environment, including production.
+Enabled deployments support GitHub, Google, Facebook, and Twitter and require their
+configured provider credentials. Set `SOCIAL_OAUTH_ENABLED=false` explicitly for a
+deployment without social sign-in, such as the AWS PoC. The disabled factories do not
+resolve provider credentials and return empty provider and provider-name collections;
+social sign-in endpoints return `unsupported_provider`. Set the flag back to `true`
+with valid provider credentials to re-enable social sign-in without a source change.
+Local registration, password sign-in, and token flows remain unchanged.
 
 #### JWT
 
@@ -231,3 +242,45 @@ User batch endpoint testing requires additional settings, such as the size of th
 Learn more about [OAuth Server Bundle](https://oauth2.thephpleague.com/).
 
 Learn more about [Community and Support](community-and-support.md).
+
+### SQS credentials in AWS
+
+Production SQS health checks use the AWS SDK default credential provider chain
+and the regional AWS endpoint. ECS deployments must attach a task role with
+`sqs:GetQueueUrl` on the preprovisioned `health-check-queue`. Health checks only
+look up this queue; they never create it. LocalStack setup must create it before
+running application health checks. The ECS
+execution role does not provide application credentials. Do not inject static
+AWS access keys or mount shared AWS credential files into the application.
+
+Deploy this configuration in the application image before removing the legacy
+health-check IAM user and access key from an existing infrastructure stack.
+Development and test environments retain explicit LocalStack endpoint and dummy
+credentials. A non-production AWS deployment should run with `APP_ENV=prod`.
+
+See the [AWS SDK credential provider documentation](https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/defaultprovider-provider.html).
+
+### Production web and worker containers
+
+Build the web image from the `frankenphp_prod` target. Its production Caddy
+configuration serves HTTP on port 80 behind the ALB HTTPS listener and forces
+`APP_ENV=prod` and `APP_DEBUG=0`. It exposes no test listener. The development
+Caddy configuration and its arbitrary listener/configuration overrides do not
+apply to this production target.
+
+Build the worker image from the `app_workers` target. Supervisor runs ten
+production consumers for `send-email`, `insert-user-batch`, and `domain-events`.
+Failed-message transports are not consumed automatically. Worker output goes
+to standard output and standard error for collection by the container platform.
+The container health check requires all ten expected consumers to be running;
+a missing, stopped, or unexpected process makes the check fail. This process
+check does not prove message delivery or downstream service availability.
+
+### SES delivery with task credentials
+
+The application includes the Symfony Amazon Mailer SDK transport. Use
+`ses+api://default?region=eu-central-1` as the mailer DSN for the TEST PoC, with
+the approved sending identity and recipient restrictions on the ECS task role.
+Do not put AWS access keys in the DSN. SES sandbox identity and recipient
+verification still apply; installing the transport does not configure or
+verify those identities.

--- a/docs/api-endpoints.md
+++ b/docs/api-endpoints.md
@@ -31,7 +31,11 @@ The REST API also exposes two public social sign-in endpoints:
 - `GET /api/auth/social/{provider}` starts the flow, creates the OAuth state, sets the `oauth_flow_binding` cookie, and redirects the client to the selected provider.
 - `GET /api/auth/social/{provider}/callback` validates the callback and returns either access and refresh tokens or a `pending_session_id` when 2FA is enabled.
 
-Supported providers are GitHub, Google, Facebook, and Twitter.
+Social sign-in defaults to enabled in all environments and supports GitHub, Google,
+Facebook, and Twitter with configured provider credentials. A deployment can explicitly
+set `SOCIAL_OAUTH_ENABLED=false`; both endpoints then return the standard
+`unsupported_provider` 400 response without resolving provider credentials. Local
+registration, password sign-in, and token flows remain available.
 
 ## GraphQL specification
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -91,3 +91,12 @@ Multiple validators ensure token integrity:
 TBD
 
 Learn more about [Performance and Optimization](performance.md).
+
+### AWS SQS workload identity
+
+Production health checks use the ECS task role through the AWS SDK credential
+provider chain. They require only `sqs:GetQueueUrl` on the preprovisioned
+health-check queue and never create infrastructure. Static LocalStack credentials
+are restricted to development and test configurations. See
+[SQS deployment configuration](advanced-configuration.md#sqs-credentials-in-aws)
+for the coordinated migration and local setup requirements.

--- a/infrastructure/docker/caddy/Caddyfile.prod
+++ b/infrastructure/docker/caddy/Caddyfile.prod
@@ -1,0 +1,29 @@
+{
+	admin localhost:2019
+	auto_https off
+	frankenphp {
+		worker {
+			file /srv/app/public/index.php
+			env APP_RUNTIME Runtime\FrankenPhpSymfony\Runtime
+			env APP_ENV prod
+			env APP_DEBUG 0
+		}
+	}
+}
+
+:80 {
+	log {
+		output stderr
+		format json
+	}
+
+	root * /srv/app/public
+	encode zstd gzip
+	header -Server
+	vulcain
+	php_server {
+		env APP_ENV prod
+		env APP_DEBUG 0
+	}
+	file_server
+}

--- a/infrastructure/docker/php/init-aws.sh
+++ b/infrastructure/docker/php/init-aws.sh
@@ -3,3 +3,4 @@
 awslocal sqs create-queue --queue-name send-email
 awslocal sqs create-queue --queue-name failed-emails
 awslocal sqs create-queue --queue-name insert-user
+awslocal sqs create-queue --queue-name health-check-queue

--- a/infrastructure/supervisor/supervisord.conf
+++ b/infrastructure/supervisor/supervisord.conf
@@ -1,28 +1,26 @@
 [unix_http_server]
 file = /run/supervisor.sock
+chmod = 0700
 
 [supervisord]
 nodaemon=true
 
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[supervisorctl]
+serverurl = unix:///run/supervisor.sock
+
 [program:messenger-consume]
-command=php /srv/app/bin/console messenger:consume send-email insert-user-batch --time-limit=3600
+command=php /srv/app/bin/console messenger:consume send-email insert-user-batch domain-events --time-limit=3600 --env=prod --no-debug
 numprocs=10
 startsecs=0
 autostart=true
 autorestart=true
 startretries=10
-process_name=messenger-consume_%(process_num)s
-stdout_logfile=/srv/app/var/log/messenger-consume_%(process_num)s.log
-stderr_logfile=/srv/app/var/log/messenger-consume_error_%(process_num)s.log
-
-[program:messenger-consume-test]
-command=php /srv/app/bin/console messenger:consume send-email --time-limit=3600 --env=test
+process_name=messenger-consume_%(process_num)02d
 environment=MESSENGER_CONSUMER_NAME=%(program_name)s_%(process_num)02d
-numprocs=50
-startsecs=0
-autostart=true
-autorestart=true
-startretries=10
-process_name=messenger-consume-test_%(process_num)s
-stdout_logfile=/srv/app/var/log/messenger-consume-test_%(process_num)s.log
-stderr_logfile=/srv/app/var/log/messenger-consume-test_error_%(process_num)s.log
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/fd/2
+stderr_logfile_maxbytes=0

--- a/infrastructure/supervisor/worker-healthcheck
+++ b/infrastructure/supervisor/worker-healthcheck
@@ -1,0 +1,32 @@
+#!/bin/sh
+set -eu
+
+expected_processes=10
+
+status="$(supervisorctl status 'messenger-consume:*')" || exit 1
+
+printf '%s\n' "$status" | awk -v expected_processes="$expected_processes" '
+    BEGIN {
+        for (process = 0; process < expected_processes; process++) {
+            expected[sprintf("messenger-consume:messenger-consume_%02d", process)] = 1
+        }
+    }
+
+    NF == 0 {
+        next
+    }
+
+    !($1 in expected) || $1 in seen || $2 != "RUNNING" {
+        unhealthy = 1
+        next
+    }
+
+    {
+        seen[$1] = 1
+        running_processes++
+    }
+
+    END {
+        exit unhealthy || running_processes != expected_processes ? 1 : 0
+    }
+'

--- a/src/Internal/HealthCheck/Infrastructure/EventSubscriber/BrokerCheckSubscriber.php
+++ b/src/Internal/HealthCheck/Infrastructure/EventSubscriber/BrokerCheckSubscriber.php
@@ -18,11 +18,6 @@ final class BrokerCheckSubscriber extends BaseHealthCheckSubscriber
     #[\Override]
     public function onHealthCheck(HealthCheckEvent $event): void
     {
-        $this->createQueue($this->queueName);
-    }
-
-    private function createQueue(string $queueName): void
-    {
-        $this->sqsClient->createQueue(['QueueName' => $queueName]);
+        $this->sqsClient->getQueueUrl(['QueueName' => $this->queueName]);
     }
 }

--- a/src/OAuth/Application/Factory/OAuthProviderCollectionFactory.php
+++ b/src/OAuth/Application/Factory/OAuthProviderCollectionFactory.php
@@ -8,15 +8,23 @@ use App\OAuth\Application\Collection\OAuthProviderCollection;
 
 use function iterator_to_array;
 
-final class OAuthProviderCollectionFactory implements
+final readonly class OAuthProviderCollectionFactory implements
     OAuthProviderCollectionFactoryInterface
 {
+    public function __construct(private bool $enabled)
+    {
+    }
+
     /**
      * @param iterable<\App\OAuth\Application\Provider\OAuthProviderInterface> $providers
      */
     #[\Override]
     public function create(iterable $providers): OAuthProviderCollection
     {
+        if (!$this->enabled) {
+            return new OAuthProviderCollection();
+        }
+
         return new OAuthProviderCollection(...iterator_to_array($providers, false));
     }
 }

--- a/src/Shared/Application/Factory/OAuthProviderNameCollectionFactory.php
+++ b/src/Shared/Application/Factory/OAuthProviderNameCollectionFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Application\Factory;
+
+use App\OAuth\Domain\ValueObject\OAuthProvider;
+use App\Shared\Domain\Collection\OAuthProviderNameCollection;
+
+final readonly class OAuthProviderNameCollectionFactory
+{
+    public function __construct(private bool $enabled)
+    {
+    }
+
+    /**
+     * @param iterable<OAuthProvider> $providers
+     */
+    public function create(iterable $providers): OAuthProviderNameCollection
+    {
+        return new OAuthProviderNameCollection($this->enabled ? $providers : []);
+    }
+}

--- a/symfony.lock
+++ b/symfony.lock
@@ -160,6 +160,15 @@
             "phpcs.xml.dist"
         ]
     },
+    "symfony/amazon-mailer": {
+        "version": "8.1",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "main",
+            "version": "4.4",
+            "ref": "9648db3ecae5c8a6b1a5f74715d3907124348815"
+        }
+    },
     "symfony/console": {
         "version": "6.1",
         "recipe": {

--- a/tests/Fixtures/Supervisor/worker-healthcheck.conf
+++ b/tests/Fixtures/Supervisor/worker-healthcheck.conf
@@ -1,0 +1,23 @@
+[unix_http_server]
+file = /tmp/supervisor.sock
+
+[supervisord]
+nodaemon = true
+logfile = /dev/null
+pidfile = /tmp/supervisord.pid
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[supervisorctl]
+serverurl = unix:///tmp/supervisor.sock
+
+[program:messenger-consume]
+command = /bin/sh -c 'sleep 600'
+numprocs = 10
+startsecs = 0
+process_name = messenger-consume_%(process_num)s
+stdout_logfile = /dev/fd/1
+stdout_logfile_maxbytes = 0
+stderr_logfile = /dev/fd/2
+stderr_logfile_maxbytes = 0

--- a/tests/Integration/Internal/HealthCheck/Infrastructure/EventSubscriber/BrokerCheckSubscriberTest.php
+++ b/tests/Integration/Internal/HealthCheck/Infrastructure/EventSubscriber/BrokerCheckSubscriberTest.php
@@ -12,15 +12,18 @@ use Aws\Sqs\SqsClient;
 final class BrokerCheckSubscriberTest extends InternalIntegrationTestCase
 {
     private SqsClient $sqsClient;
-    private string $testQueueName = 'test-queue';
+    private string $testQueueName;
     private BrokerCheckSubscriber $subscriber;
 
     #[\Override]
     protected function setUp(): void
     {
         parent::setUp();
-        $this->sqsClient = $this->container->get(SqsClient::class);
-        $this->subscriber = new BrokerCheckSubscriber($this->sqsClient);
+        $sqsClient = $this->container->get(SqsClient::class);
+        $this->assertInstanceOf(SqsClient::class, $sqsClient);
+        $this->sqsClient = $sqsClient;
+        $this->testQueueName = $this->faker->lexify('health-check-????????');
+        $this->subscriber = new BrokerCheckSubscriber($this->sqsClient, $this->testQueueName);
     }
 
     public function testOnHealthCheck(): void
@@ -34,6 +37,7 @@ final class BrokerCheckSubscriberTest extends InternalIntegrationTestCase
         $queueUrl = $result->get('QueueUrl');
         $this->assertIsString($queueUrl, 'Queue URL should be a string');
         $this->assertNotEmpty($queueUrl, 'Queue URL should not be empty');
+        $this->sqsClient->deleteQueue(['QueueUrl' => $queueUrl]);
     }
 
     public function testGetSubscribedEvents(): void

--- a/tests/Unit/Config/ProductionCaddyConfigTest.php
+++ b/tests/Unit/Config/ProductionCaddyConfigTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Config;
+
+use App\Tests\Unit\UnitTestCase;
+use Symfony\Component\Process\Process;
+use Symfony\Component\Serializer\Encoder\JsonDecode;
+
+final class ProductionCaddyConfigTest extends UnitTestCase
+{
+    public function testProductionIgnoresDevelopmentListenerAndEnvironmentOverrides(): void
+    {
+        $config = $this->adapt([
+            'SERVER_NAME' => $this->faker->domainName(),
+            'CADDY_GLOBAL_OPTIONS' => 'http_port 8081',
+            'CADDY_EXTRA_CONFIG' => 'respond "development"',
+            'CADDY_DEBUG' => 'debug',
+            'FRANKENPHP_CONFIG' => 'import missing-development-worker.Caddyfile',
+            'CADDY_PHP_APP_ENV' => 'test',
+            'CADDY_PHP_APP_DEBUG' => '1',
+            'APP_ENV' => 'test',
+            'APP_DEBUG' => '1',
+        ]);
+        $servers = $config['apps']['http']['servers'];
+
+        self::assertCount(1, $servers);
+        self::assertSame([':80'], $servers['srv0']['listen']);
+        self::assertTrue($servers['srv0']['automatic_https']['disable']);
+        self::assertSame('localhost:2019', $config['admin']['listen']);
+        self::assertArrayNotHasKey('tls', $config['apps']);
+        self::assertSame('prod', $config['apps']['frankenphp']['workers'][0]['env']['APP_ENV']);
+        self::assertSame('0', $config['apps']['frankenphp']['workers'][0]['env']['APP_DEBUG']);
+    }
+
+    public function testProductionWorkerKeepsProductionSettings(): void
+    {
+        $config = $this->adapt();
+        $workers = $config['apps']['frankenphp']['workers'];
+
+        self::assertCount(1, $workers);
+        self::assertSame('/srv/app/public/index.php', $workers[0]['file_name']);
+        self::assertSame([
+            'APP_DEBUG' => '0',
+            'APP_ENV' => 'prod',
+            'APP_RUNTIME' => 'Runtime\\FrankenPhpSymfony\\Runtime',
+        ], $workers[0]['env']);
+    }
+
+    public function testProductionRequestHandlerKeepsProductionSettingsAndLogging(): void
+    {
+        $config = $this->adapt();
+        $routes = $config['apps']['http']['servers']['srv0']['routes'];
+        $handlers = array_merge(...array_column($routes, 'handle'));
+        $php = array_values(array_filter(
+            $handlers,
+            static fn (array $handler): bool => $handler['handler'] === 'php'
+        ));
+        $headers = array_values(array_filter(
+            $handlers,
+            static fn (array $handler): bool => $handler['handler'] === 'headers'
+        ));
+
+        self::assertCount(1, $php);
+        self::assertSame(['APP_DEBUG' => '0', 'APP_ENV' => 'prod'], $php[0]['env']);
+        self::assertSame(['Server'], $headers[0]['response']['delete']);
+        self::assertArrayNotHasKey('request', $headers[0]);
+        self::assertSame('stderr', $config['logging']['logs']['log0']['writer']['output']);
+        self::assertSame('json', $config['logging']['logs']['log0']['encoder']['format']);
+    }
+
+    public function testOnlyProductionImageSelectsTheProductionConfig(): void
+    {
+        $dockerfile = (string) file_get_contents(dirname(__DIR__, 3) . '/Dockerfile');
+        [$development, $production] = explode(
+            'FROM frankenphp_base AS frankenphp_prod',
+            $dockerfile
+        );
+        [$production, $worker] = explode('FROM frankenphp_base AS app_workers', $production);
+        $copy = 'COPY --link infrastructure/docker/caddy/Caddyfile.prod /etc/caddy/Caddyfile';
+
+        self::assertStringContainsString($copy, $production);
+        self::assertStringNotContainsString($copy, $development);
+        self::assertStringNotContainsString($copy, $worker);
+        self::assertStringContainsString(
+            'COPY --link infrastructure/docker/caddy/Caddyfile /etc/caddy/Caddyfile',
+            $development
+        );
+    }
+
+    /**
+     * @param array<string, string> $environment
+     *
+     * @return array<string, array<string, array<array-key, array>|string>>
+     */
+    private function adapt(array $environment = []): array
+    {
+        $process = new Process([
+            'frankenphp',
+            'adapt',
+            '--adapter',
+            'caddyfile',
+            '--config',
+            dirname(__DIR__, 3) . '/infrastructure/docker/caddy/Caddyfile.prod',
+        ], null, $environment, null, 10);
+        $process->mustRun();
+
+        return (new JsonDecode())->decode(
+            $process->getOutput(),
+            'json',
+            [JsonDecode::ASSOCIATIVE => true]
+        );
+    }
+}

--- a/tests/Unit/Config/ProductionMessengerTransportConfigTest.php
+++ b/tests/Unit/Config/ProductionMessengerTransportConfigTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Config;
+
+use App\Tests\Unit\UnitTestCase;
+use Symfony\Bundle\FrameworkBundle\DependencyInjection\FrameworkExtension;
+use Symfony\Component\Config\Definition\Processor;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\Yaml\Yaml;
+
+final class ProductionMessengerTransportConfigTest extends UnitTestCase
+{
+    private const SQS_TRANSPORTS = [
+        'send-email',
+        'failed-send-email',
+        'insert-user-batch',
+        'domain-events',
+        'failed-domain-events',
+    ];
+
+    public function testProductionDisablesQueueAutoSetupForEverySqsTransport(): void
+    {
+        $transports = $this->processedConfig()['messenger']['transports'];
+
+        self::assertSame(self::SQS_TRANSPORTS, array_keys($transports));
+
+        foreach (self::SQS_TRANSPORTS as $transport) {
+            self::assertFalse($transports[$transport]['options']['auto_setup']);
+        }
+    }
+
+    public function testTestRedisTransportRetainsAutomaticSetupAndConsumerOverride(): void
+    {
+        $config = $this->sourceConfig();
+        $testConfig = $this->processedConfig($config['when@test']['framework']);
+        $transports = $testConfig['messenger']['transports'];
+        $sendEmail = $transports['send-email'];
+
+        self::assertSame('%env(REDIS_URL)%', $sendEmail['dsn']);
+        self::assertTrue($sendEmail['options']['auto_setup']);
+        self::assertSame(
+            '%env(MESSENGER_CONSUMER_NAME)%',
+            $sendEmail['options']['consumer']
+        );
+        self::assertSame('in-memory://', $transports['domain-events']['dsn']);
+        self::assertSame('in-memory://', $transports['failed-domain-events']['dsn']);
+    }
+
+    /**
+     * @param array<string, array<string, array<string, array<string, bool|string>|string>>>|null $environmentOverride
+     *
+     * @return array<string, array<string, array<string, array<string, array<string, bool|string>|string>>>>
+     */
+    private function processedConfig(?array $environmentOverride = null): array
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('kernel.debug', false);
+
+        $extension = new FrameworkExtension();
+        $configuration = $extension->getConfiguration([], $container);
+        self::assertNotNull($configuration);
+
+        $config = $this->sourceConfig();
+        $configs = [$config['framework']];
+        if ($environmentOverride !== null) {
+            $configs[] = $environmentOverride;
+        }
+
+        return (new Processor())->processConfiguration($configuration, $configs);
+    }
+
+    /**
+     * @return array<string, array<string, array<string, array<string, array<string, bool|string>|string>>>>
+     */
+    private function sourceConfig(): array
+    {
+        return Yaml::parseFile(dirname(__DIR__, 3) . '/config/packages/messenger.yaml');
+    }
+}

--- a/tests/Unit/Config/ProductionSocialOAuthConfigTest.php
+++ b/tests/Unit/Config/ProductionSocialOAuthConfigTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Config;
+
+use App\Tests\Unit\UnitTestCase;
+
+final class ProductionSocialOAuthConfigTest extends UnitTestCase
+{
+    public function testFlagPreservesEnabledDefaultsAndAllowsExplicitOptOut(): void
+    {
+        $config = $this->servicesConfig();
+
+        self::assertStringContainsString('social_oauth_enabled_default: true', $config);
+        self::assertStringContainsString(
+            '%env(bool:default:social_oauth_enabled_default:SOCIAL_OAUTH_ENABLED)%',
+            $config
+        );
+    }
+
+    public function testBothCollectionFactoriesReceiveTheSameFlag(): void
+    {
+        $binding = "\$enabled: '%social_oauth_enabled%'";
+
+        self::assertSame(2, substr_count($this->servicesConfig(), $binding));
+    }
+
+    public function testProductionRetainsConfiguredProviderRegistrations(): void
+    {
+        $config = $this->servicesConfig();
+
+        foreach (['GITHUB', 'GOOGLE', 'FACEBOOK', 'TWITTER'] as $provider) {
+            self::assertStringContainsString('%env(OAUTH_' . $provider . '_CLIENT_ID)%', $config);
+            self::assertStringContainsString(
+                '%env(OAUTH_' . $provider . '_CLIENT_SECRET)%',
+                $config
+            );
+        }
+    }
+
+    private function servicesConfig(): string
+    {
+        $contents = file_get_contents(dirname(__DIR__, 3) . '/config/services.yaml');
+        self::assertIsString($contents);
+
+        return $contents;
+    }
+}

--- a/tests/Unit/Config/SesApiTransportDsnTest.php
+++ b/tests/Unit/Config/SesApiTransportDsnTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Config;
+
+use App\Tests\Unit\UnitTestCase;
+use Symfony\Component\Mailer\Bridge\Amazon\Transport\SesApiAsyncAwsTransport;
+use Symfony\Component\Mailer\Transport;
+use Symfony\Component\Mailer\Transport\Dsn;
+
+final class SesApiTransportDsnTest extends UnitTestCase
+{
+    private const DSN = 'ses+api://default?region=eu-central-1';
+
+    public function testCredentialFreeSesApiDsnBuildsTheAsyncAwsTransport(): void
+    {
+        $dsn = Dsn::fromString(self::DSN);
+
+        self::assertNull($dsn->getUser());
+        self::assertNull($dsn->getPassword());
+
+        $transport = Transport::fromDsn(self::DSN);
+
+        self::assertInstanceOf(SesApiAsyncAwsTransport::class, $transport);
+    }
+}

--- a/tests/Unit/Config/SqsClientConfigTest.php
+++ b/tests/Unit/Config/SqsClientConfigTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Config;
+
+use App\Tests\Unit\UnitTestCase;
+use Aws\Sqs\SqsClient;
+use Symfony\Component\Yaml\Yaml;
+
+final class SqsClientConfigTest extends UnitTestCase
+{
+    public function testProductionUsesDefaultCredentialsAndRegionalEndpoint(): void
+    {
+        $config = Yaml::parseFile(
+            dirname(__DIR__, 3) . '/config/services.yaml',
+            Yaml::PARSE_CUSTOM_TAGS
+        );
+        $options = $config['services'][SqsClient::class]['arguments'][0];
+
+        $this->assertSame('%env(AWS_SQS_VERSION)%', $options['version']);
+        $this->assertSame('%env(AWS_SQS_REGION)%', $options['region']);
+        $this->assertArrayNotHasKey('credentials', $options);
+        $this->assertArrayNotHasKey('endpoint', $options);
+        $this->assertArrayNotHasKey('when@prod', $config);
+    }
+
+    public function testLocalEnvironmentsKeepExplicitLocalStackConfiguration(): void
+    {
+        $config = Yaml::parseFile(
+            dirname(__DIR__, 3) . '/config/services.yaml',
+            Yaml::PARSE_CUSTOM_TAGS
+        );
+
+        foreach (['dev', 'test', 'load_test', 'schemathesis'] as $environment) {
+            $environmentConfig = $config['when@' . $environment];
+            $options = $environmentConfig['services'][SqsClient::class]['arguments'][0];
+
+            $this->assertSame('%env(AWS_SQS_VERSION)%', $options['version']);
+            $this->assertSame('%env(AWS_SQS_REGION)%', $options['region']);
+            $this->assertSame(
+                '%env(AWS_SQS_ENDPOINT_BASE)%:%env(LOCALSTACK_PORT)%',
+                $options['endpoint']
+            );
+            $this->assertSame('%env(AWS_SQS_KEY)%', $options['credentials']['key']);
+            $this->assertSame('%env(AWS_SQS_SECRET)%', $options['credentials']['secret']);
+        }
+    }
+}

--- a/tests/Unit/Config/WorkerRuntimeContractTest.php
+++ b/tests/Unit/Config/WorkerRuntimeContractTest.php
@@ -1,0 +1,236 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Config;
+
+use App\Tests\Unit\UnitTestCase;
+
+final class WorkerRuntimeContractTest extends UnitTestCase
+{
+    private const SUPERVISOR_PATH = 'infrastructure/supervisor/supervisord.conf';
+
+    private const PROCESS_NAME = 'process_name=messenger-consume_%(process_num)02d';
+
+    private const SUPERVISOR_RPC_FACTORY = <<<'SUPERVISOR'
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+SUPERVISOR;
+
+    private const SYSTEM_PATH = '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin';
+
+    private const WORKER_COMMAND = <<<'COMMAND'
+messenger:consume send-email insert-user-batch domain-events --time-limit=3600 --env=prod --no-debug
+COMMAND;
+
+    private const WORKER_HEALTHCHECK_PATH = 'infrastructure/supervisor/worker-healthcheck';
+
+    private const SUPERVISORCTL_SCRIPT = <<<'SH'
+#!/bin/sh
+printf '%s\n' "$SUPERVISOR_STATUS"
+exit "${SUPERVISORCTL_EXIT_CODE:-0}"
+SH;
+
+    public function testWorkerSupervisorStartsOnlyConfiguredProductionConsumers(): void
+    {
+        $config = $this->supervisorConfig();
+
+        self::assertStringContainsString('[rpcinterface:supervisor]', $config);
+        self::assertStringContainsString(self::SUPERVISOR_RPC_FACTORY, $config);
+        self::assertStringContainsString('serverurl = unix:///run/supervisor.sock', $config);
+        self::assertStringContainsString(
+            self::WORKER_COMMAND,
+            $config
+        );
+        self::assertStringNotContainsString('--env=test', $config);
+        self::assertStringNotContainsString('messenger-consume-test', $config);
+        self::assertStringNotContainsString('failed-send-email', $config);
+        self::assertStringNotContainsString('failed-domain-events', $config);
+        self::assertStringContainsString('numprocs=10', $config);
+        self::assertStringContainsString(self::PROCESS_NAME, $config);
+        self::assertStringContainsString('stdout_logfile=/dev/fd/1', $config);
+        self::assertStringContainsString('stderr_logfile=/dev/fd/2', $config);
+    }
+
+    public function testWorkerImageUsesSupervisorProcessHealthcheck(): void
+    {
+        $workerStage = $this->workerDockerStage();
+
+        self::assertStringContainsString(
+            $this->workerHealthcheckCopy(),
+            $workerStage
+        );
+        self::assertStringContainsString(
+            $this->workerHealthcheckDirective(),
+            $workerStage
+        );
+        self::assertStringNotContainsString('curl -f http://localhost:2019/metrics', $workerStage);
+    }
+
+    public function testWorkerHealthcheckPassesOnlyWhenEveryConsumerIsRunning(): void
+    {
+        self::assertSame(0, $this->runHealthcheck($this->supervisorStatus('RUNNING')));
+    }
+
+    /**
+     * @dataProvider unhealthySupervisorStatusProvider
+     */
+    public function testWorkerHealthcheckRejectsUnhealthySupervisorStatus(string $status): void
+    {
+        self::assertSame(1, $this->runHealthcheck($status));
+    }
+
+    public function testWorkerHealthcheckFailsWhenSupervisorCannotBeReached(): void
+    {
+        self::assertSame(1, $this->runHealthcheck('', 1));
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function unhealthySupervisorStatusProvider(): iterable
+    {
+        $runningStatus = self::buildSupervisorStatus('RUNNING');
+
+        yield 'stopped consumer' => [self::replaceFirstState($runningStatus, 'STOPPED')];
+        yield 'starting consumer' => [self::replaceFirstState($runningStatus, 'STARTING')];
+        yield 'fatal consumer' => [self::replaceFirstState($runningStatus, 'FATAL')];
+        yield 'missing consumer' => [self::withoutLastConsumer($runningStatus)];
+        yield 'duplicate consumer' => [
+            $runningStatus . "\n" . strtok($runningStatus, "\n"),
+        ];
+        yield 'extra consumer' => [$runningStatus . "\n" . self::extraConsumerStatus()];
+    }
+
+    private function supervisorConfig(): string
+    {
+        return (string) file_get_contents($this->projectPath(self::SUPERVISOR_PATH));
+    }
+
+    private function workerDockerStage(): string
+    {
+        $dockerfile = (string) file_get_contents($this->projectPath('Dockerfile'));
+        $workerStage = strstr($dockerfile, 'FROM frankenphp_base AS app_workers');
+
+        self::assertIsString($workerStage);
+
+        return $workerStage;
+    }
+
+    private function runHealthcheck(string $status, int $supervisorctlExitCode = 0): int
+    {
+        $directory = sys_get_temp_dir() . '/worker-healthcheck-' . bin2hex(random_bytes(8));
+        self::assertTrue(mkdir($directory));
+
+        $supervisorctl = $this->createSupervisorctl($directory);
+
+        try {
+            return $this->executeHealthcheck($directory, $status, $supervisorctlExitCode);
+        } finally {
+            unlink($supervisorctl);
+            rmdir($directory);
+        }
+    }
+
+    private function createSupervisorctl(string $directory): string
+    {
+        $supervisorctl = $directory . '/supervisorctl';
+        file_put_contents(
+            $supervisorctl,
+            self::SUPERVISORCTL_SCRIPT
+        );
+        chmod($supervisorctl, 0755);
+
+        return $supervisorctl;
+    }
+
+    private function executeHealthcheck(
+        string $directory,
+        string $status,
+        int $supervisorctlExitCode
+    ): int {
+        $process = proc_open(
+            ['/bin/sh', $this->projectPath(self::WORKER_HEALTHCHECK_PATH)],
+            [1 => ['pipe', 'w'], 2 => ['pipe', 'w']],
+            $pipes,
+            null,
+            [
+                'PATH' => $directory . ':' . self::SYSTEM_PATH,
+                'SUPERVISOR_STATUS' => $status,
+                'SUPERVISORCTL_EXIT_CODE' => (string) $supervisorctlExitCode,
+            ]
+        );
+
+        self::assertIsResource($process);
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+
+        return proc_close($process);
+    }
+
+    private function supervisorStatus(string $state): string
+    {
+        return self::buildSupervisorStatus($state);
+    }
+
+    private static function buildSupervisorStatus(string $state): string
+    {
+        $status = [];
+
+        for ($process = 0; $process < 10; $process++) {
+            $status[] = sprintf(
+                'messenger-consume:messenger-consume_%02d %s pid 1, uptime 0:00:01',
+                $process,
+                $state
+            );
+        }
+
+        return implode("\n", $status);
+    }
+
+    private static function replaceFirstState(string $status, string $state): string
+    {
+        return preg_replace('/ RUNNING /', ' ' . $state . ' ', $status, 1) ?? $status;
+    }
+
+    private static function withoutLastConsumer(string $status): string
+    {
+        $consumers = explode("\n", $status);
+        array_pop($consumers);
+
+        return implode("\n", $consumers);
+    }
+
+    private static function extraConsumerStatus(): string
+    {
+        return 'messenger-consume:messenger-consume_10 RUNNING pid 1, uptime 0:00:01';
+    }
+
+    private function workerHealthcheckCopy(): string
+    {
+        return implode(' ', [
+            'COPY',
+            '--link',
+            '--chmod=755',
+            'infrastructure/supervisor/worker-healthcheck',
+            '/usr/local/bin/worker-healthcheck',
+        ]);
+    }
+
+    private function workerHealthcheckDirective(): string
+    {
+        return implode(' ', [
+            'HEALTHCHECK',
+            '--start-period=60s',
+            '--interval=30s',
+            '--timeout=5s',
+            '--retries=3',
+            'CMD',
+            '["/usr/local/bin/worker-healthcheck"]',
+        ]);
+    }
+
+    private function projectPath(string $path): string
+    {
+        return dirname(__DIR__, 3) . '/' . $path;
+    }
+}

--- a/tests/Unit/Internal/HealthCheck/Infrastructure/EventSubscriber/BrokerCheckSubscriberTest.php
+++ b/tests/Unit/Internal/HealthCheck/Infrastructure/EventSubscriber/BrokerCheckSubscriberTest.php
@@ -15,8 +15,9 @@ use PHPUnit\Framework\MockObject\MockObject;
 
 final class BrokerCheckSubscriberTest extends UnitTestCase
 {
-    private SqsClient|MockObject $sqsClient;
+    private SqsClient&MockObject $sqsClient;
     private BrokerCheckSubscriber $subscriber;
+    private string $queueName;
 
     #[\Override]
     protected function setUp(): void
@@ -24,50 +25,48 @@ final class BrokerCheckSubscriberTest extends UnitTestCase
         parent::setUp();
 
         $this->sqsClient = $this->createMock(SqsClient::class);
-        $this->subscriber = new BrokerCheckSubscriber($this->sqsClient);
+        $this->queueName = $this->faker->lexify('health-check-????????');
+        $this->subscriber = new BrokerCheckSubscriber($this->sqsClient, $this->queueName);
     }
 
-    public function testOnHealthCheckCreatesQueue(): void
+    public function testOnHealthCheckReadsExistingQueue(): void
     {
         $result = new Result(
-            ['QueueUrl' => 'http://example.com/queue/health-check-queue']
+            ['QueueUrl' => $this->faker->url()]
         );
 
         $this->sqsClient->expects($this->once())
             ->method('__call')
             ->with($this->equalTo(
-                'createQueue'
-            ), $this->equalTo([['QueueName' => 'health-check-queue']]))
+                'getQueueUrl'
+            ), $this->equalTo([['QueueName' => $this->queueName]]))
             ->willReturn($result);
 
         $event = new HealthCheckEvent();
         $this->subscriber->onHealthCheck($event);
     }
 
-    public function testOnHealthCheckHandlesQueueAlreadyExistsException(): void
+    public function testOnHealthCheckPropagatesMissingQueueException(): void
     {
         $command = $this->createMock(CommandInterface::class);
 
         $this->sqsClient->expects($this->once())
             ->method('__call')
             ->with($this->equalTo(
-                'createQueue'
-            ), $this->equalTo([['QueueName' => 'health-check-queue']]))
+                'getQueueUrl'
+            ), $this->equalTo([['QueueName' => $this->queueName]]))
             ->willThrowException(new AwsException(
-                'Queue already exists',
+                'Queue does not exist',
                 $command,
                 [
-                    'code' => 'QueueAlreadyExists',
+                    'code' => 'AWS.SimpleQueueService.NonExistentQueue',
                 ]
             ));
 
-        try {
-            $event = new HealthCheckEvent();
-            $this->subscriber->onHealthCheck($event);
-        } catch (AwsException $e) {
-            $this->assertEquals('Queue already exists', $e->getMessage());
-            $this->assertEquals('QueueAlreadyExists', $e->getAwsErrorCode());
-        }
+        $this->expectException(AwsException::class);
+        $this->expectExceptionMessage('Queue does not exist');
+
+        $this->subscriber->onHealthCheck(new HealthCheckEvent());
     }
 
     public function testGetSubscribedEvents(): void

--- a/tests/Unit/OAuth/Application/Factory/OAuthProviderCollectionFactoryTest.php
+++ b/tests/Unit/OAuth/Application/Factory/OAuthProviderCollectionFactoryTest.php
@@ -19,7 +19,7 @@ final class OAuthProviderCollectionFactoryTest extends UnitTestCase
     {
         parent::setUp();
 
-        $this->factory = new OAuthProviderCollectionFactory();
+        $this->factory = new OAuthProviderCollectionFactory(true);
     }
 
     public function testCreateBuildsCollectionFromIterable(): void
@@ -49,6 +49,25 @@ final class OAuthProviderCollectionFactoryTest extends UnitTestCase
         $this->assertCount(2, $collection);
         $this->assertSame($github, $collection->get('github'));
         $this->assertSame($google, $collection->get('google'));
+    }
+
+    public function testDisabledFactoryDoesNotInstantiateTaggedProviders(): void
+    {
+        $providers = (static function (): \Generator {
+            yield throw new \LogicException('Disabled providers must not be resolved');
+        })();
+
+        $collection = (new OAuthProviderCollectionFactory(false))->create($providers);
+
+        self::assertCount(0, $collection);
+    }
+
+    public function testExplicitOptInPreservesEnabledProviders(): void
+    {
+        $provider = $this->createProviderMock('github');
+        $collection = (new OAuthProviderCollectionFactory(true))->create([$provider]);
+
+        self::assertSame($provider, $collection->get('github'));
     }
 
     private function createProviderMock(string $name): OAuthProviderInterface

--- a/tests/Unit/OAuth/Application/Provider/OAuthProviderRegistryTest.php
+++ b/tests/Unit/OAuth/Application/Provider/OAuthProviderRegistryTest.php
@@ -70,6 +70,15 @@ final class OAuthProviderRegistryTest extends UnitTestCase
         $this->registry->get('unsupported_provider');
     }
 
+    public function testDisabledProvidersAreUnsupported(): void
+    {
+        $registry = new OAuthProviderRegistry(new OAuthProviderCollection());
+
+        $this->expectException(UnsupportedProviderException::class);
+
+        $registry->get('github');
+    }
+
     public function testSupportedProvidersReturnsAllProviderNames(): void
     {
         $supported = $this->registry->supportedProviders();

--- a/tests/Unit/Shared/Application/Factory/OAuthProviderNameCollectionFactoryTest.php
+++ b/tests/Unit/Shared/Application/Factory/OAuthProviderNameCollectionFactoryTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Shared\Application\Factory;
+
+use App\OAuth\Domain\ValueObject\OAuthProvider;
+use App\Shared\Application\Factory\OAuthProviderNameCollectionFactory;
+use App\Tests\Unit\UnitTestCase;
+
+final class OAuthProviderNameCollectionFactoryTest extends UnitTestCase
+{
+    public function testEnabledFactoryPreservesProviderNames(): void
+    {
+        $providers = [OAuthProvider::fromString('github'), OAuthProvider::fromString('google')];
+        $collection = (new OAuthProviderNameCollectionFactory(true))->create($providers);
+
+        self::assertSame(['github', 'google'], $collection->names());
+    }
+
+    public function testDisabledFactoryDoesNotIterateProviderNames(): void
+    {
+        $providers = (static function (): \Generator {
+            yield throw new \LogicException('Disabled provider names must not be resolved');
+        })();
+        $collection = (new OAuthProviderNameCollectionFactory(false))->create($providers);
+
+        self::assertSame([], $collection->names());
+    }
+
+    public function testExplicitOptInRetainsProviderNames(): void
+    {
+        $collection = (new OAuthProviderNameCollectionFactory(true))->create([
+            OAuthProvider::fromString('github'),
+        ]);
+
+        self::assertSame(['github'], $collection->names());
+    }
+}

--- a/tests/Unit/Shared/Application/Validator/EmailUniquenessValidatorTest.php
+++ b/tests/Unit/Shared/Application/Validator/EmailUniquenessValidatorTest.php
@@ -11,15 +11,12 @@ use App\Tests\Unit\UnitTestCase;
 use App\User\Domain\Collection\UserCollection;
 use App\User\Domain\Entity\UserInterface;
 use App\User\Domain\Repository\UserRepositoryInterface;
-
 use function mb_strtolower;
 use function sprintf;
 use function strtolower;
 use function strtoupper;
-
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
-
 use function trim;
 use function ucfirst;
 

--- a/tests/Unit/User/Application/CommandHandler/RegisterUserBatchCommandHandlerTest.php
+++ b/tests/Unit/User/Application/CommandHandler/RegisterUserBatchCommandHandlerTest.php
@@ -23,10 +23,8 @@ use App\User\Domain\Exception\DuplicateEmailException;
 use App\User\Domain\Factory\Event\UserRegisteredEventFactoryInterface;
 use App\User\Domain\Factory\UserFactory;
 use App\User\Domain\Repository\UserRepositoryInterface;
-
 use function mb_strtolower;
 use function mb_strtoupper;
-
 use Symfony\Component\PasswordHasher\Hasher\PasswordHasherFactoryInterface;
 use Symfony\Component\PasswordHasher\PasswordHasherInterface;
 use Symfony\Component\Uid\Factory\UuidFactory;

--- a/tests/Unit/User/Application/EventListener/UserResolveListenerTest.php
+++ b/tests/Unit/User/Application/EventListener/UserResolveListenerTest.php
@@ -19,9 +19,7 @@ use App\User\Domain\Factory\UserFactoryInterface;
 use League\Bundle\OAuth2ServerBundle\Event\UserResolveEvent;
 use League\Bundle\OAuth2ServerBundle\Model\AbstractClient;
 use League\Bundle\OAuth2ServerBundle\ValueObject\Grant;
-
 use function mb_strtoupper;
-
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\PasswordHasher\Hasher\PasswordHasherFactoryInterface;
 use Symfony\Component\PasswordHasher\PasswordHasherInterface;

--- a/tests/Unit/User/Infrastructure/Command/BackfillUserNormalizedEmailsCommandMutationTest.php
+++ b/tests/Unit/User/Infrastructure/Command/BackfillUserNormalizedEmailsCommandMutationTest.php
@@ -21,15 +21,11 @@ namespace App\Tests\Unit\User\Infrastructure\Command;
  */
 
 use App\Shared\Application\Normalizer\EmailNormalizer;
-
 use function mb_strtoupper;
-
 use MongoDB\BulkWriteResult;
 use MongoDB\Collection;
-
 use function sprintf;
 use function substr_count;
-
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Tester\CommandTester;
 

--- a/tests/Unit/User/Infrastructure/Command/BackfillUserNormalizedEmailsCommandReportTest.php
+++ b/tests/Unit/User/Infrastructure/Command/BackfillUserNormalizedEmailsCommandReportTest.php
@@ -10,9 +10,7 @@ namespace App\Tests\Unit\User\Infrastructure\Command;
  */
 
 use App\Shared\Application\Normalizer\EmailNormalizer;
-
 use function mb_strtoupper;
-
 use MongoDB\Collection;
 use Symfony\Component\Console\Command\Command;
 

--- a/tests/Unit/User/Infrastructure/Command/BackfillUserNormalizedEmailsCommandTest.php
+++ b/tests/Unit/User/Infrastructure/Command/BackfillUserNormalizedEmailsCommandTest.php
@@ -12,9 +12,7 @@ namespace App\Tests\Unit\User\Infrastructure\Command;
 
 use App\Shared\Application\Normalizer\EmailNormalizer;
 use ArrayObject;
-
 use function mb_strtoupper;
-
 use MongoDB\BulkWriteResult;
 use MongoDB\Collection;
 use Symfony\Component\Console\Command\Command;

--- a/tests/Unit/User/Infrastructure/Repository/MongoDBUserRepositoryBatchTest.php
+++ b/tests/Unit/User/Infrastructure/Repository/MongoDBUserRepositoryBatchTest.php
@@ -13,20 +13,15 @@ use App\User\Domain\Exception\DuplicateEmailException;
 use App\User\Domain\Factory\UserFactory;
 use App\User\Domain\Factory\UserFactoryInterface;
 use App\User\Infrastructure\Repository\MongoDBUserRepository;
-
 use function count;
-
 use Doctrine\Bundle\MongoDBBundle\ManagerRegistry;
 use Doctrine\ODM\MongoDB\DocumentManager;
-
 use function implode;
 use function intdiv;
 use function mb_strtolower;
 use function min;
-
 use PHPUnit\Framework\MockObject\MockObject;
 use RuntimeException;
-
 use function sprintf;
 
 final class MongoDBUserRepositoryBatchTest extends UnitTestCase

--- a/tests/Unit/User/Infrastructure/Repository/MongoDBUserRepositoryLegacyFallbackTest.php
+++ b/tests/Unit/User/Infrastructure/Repository/MongoDBUserRepositoryLegacyFallbackTest.php
@@ -15,10 +15,8 @@ use Doctrine\Bundle\MongoDBBundle\ManagerRegistry;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Query\Builder;
 use Doctrine\ODM\MongoDB\Query\Query;
-
 use function mb_strtolower;
 use function mb_strtoupper;
-
 use PHPUnit\Framework\MockObject\MockObject;
 
 /**

--- a/tests/Unit/User/Infrastructure/Repository/MongoDBUserRepositoryTest.php
+++ b/tests/Unit/User/Infrastructure/Repository/MongoDBUserRepositoryTest.php
@@ -12,16 +12,11 @@ use Doctrine\Bundle\MongoDBBundle\ManagerRegistry;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Query\Builder;
 use Doctrine\ODM\MongoDB\Query\Query;
-
 use function implode;
-
 use InvalidArgumentException;
-
 use function mb_strtolower;
 use function mb_strtoupper;
-
 use RuntimeException;
-
 use function sprintf;
 use function trim;
 

--- a/workspace.dsl
+++ b/workspace.dsl
@@ -96,6 +96,10 @@ workspace {
                     tags "MessageBroker"
                 }
 
+                ses = component "Amazon SES" "Optional configured email delivery via task credentials" "SES API" {
+                    tags "Item"
+                }
+
                 registerUserProcessor -> registerUserCommandHandler "dispatches RegisterUserCommand"
                 registerUserResolver -> registerUserCommandHandler "dispatches RegisterUserCommand"
                 confirmUserProcessor -> confirmUserCommandHandler "dispatches ConfirmUserCommand"
@@ -110,7 +114,7 @@ workspace {
                 sendConfirmationEmailCommandHandler -> confirmationEmailSentEventSubscriber "publishes ConfirmationEmailSentEvent"
                 passwordChangedEventSubscriber -> messenger "adds email to queue"
                 confirmationEmailSentEventSubscriber -> messenger "adds email to queue"
-                mailer -> messenger "consumes emails"
+                messenger -> mailer "delivers queued emails via transport"
                 userPatchProcessor -> updateUserCommandHandler "dispatches UpdateUserCommand"
                 userPutProcessor -> updateUserCommandHandler "dispatches UpdateUserCommand"
                 updateUserResolver -> updateUserCommandHandler "dispatches UpdateUserCommand"
@@ -120,7 +124,8 @@ workspace {
                 tokenRepository -> token "save and load"
                 userRepository -> database "accesses data"
                 tokenRepository -> cache "accesses data"
-                mailer -> sqs "publish message"
+                messenger -> sqs "publishes and consumes queued messages"
+                mailer -> ses "sends email when SES API transport is configured" "HTTPS API"
             }
         }
     }

--- a/workspace.json
+++ b/workspace.json
@@ -3,7 +3,8 @@
   "description" : "Description",
   "documentation" : { },
   "id" : 1,
-  "lastModifiedDate" : "2026-01-12T18:37:23Z",
+  "lastModifiedAgent" : "structurizr-javascript",
+  "lastModifiedDate" : "2026-09-09T00:20:41Z",
   "model" : {
     "properties" : {
       "structurizr.groupSeparator" : "/"
@@ -22,7 +23,10 @@
           "relationships" : [ {
             "description" : "dispatches RegisterUserCommand",
             "destinationId" : "12",
-            "id" : "28",
+            "id" : "29",
+            "properties" : {
+              "structurizr.dsl.identifier" : "f84873ce-5752-4368-a49e-12b8871672ff"
+            },
             "sourceId" : "3",
             "tags" : "Relationship"
           } ],
@@ -40,7 +44,10 @@
           "relationships" : [ {
             "description" : "dispatches ConfirmUserCommand",
             "destinationId" : "11",
-            "id" : "30",
+            "id" : "31",
+            "properties" : {
+              "structurizr.dsl.identifier" : "90a7a2a7-3c57-417b-a71b-5e33742d0f61"
+            },
             "sourceId" : "4",
             "tags" : "Relationship"
           } ],
@@ -58,7 +65,10 @@
           "relationships" : [ {
             "description" : "dispatches UpdateUserCommand",
             "destinationId" : "10",
-            "id" : "43",
+            "id" : "44",
+            "properties" : {
+              "structurizr.dsl.identifier" : "56f380a6-36fb-43b8-a11b-fd24c15affe8"
+            },
             "sourceId" : "5",
             "tags" : "Relationship"
           } ],
@@ -76,7 +86,10 @@
           "relationships" : [ {
             "description" : "dispatches UpdateUserCommand",
             "destinationId" : "10",
-            "id" : "44",
+            "id" : "45",
+            "properties" : {
+              "structurizr.dsl.identifier" : "b1fa02a0-fd0e-4f9e-b303-efdde128f571"
+            },
             "sourceId" : "6",
             "tags" : "Relationship"
           } ],
@@ -94,7 +107,10 @@
           "relationships" : [ {
             "description" : "dispatches UpdateUserCommand",
             "destinationId" : "10",
-            "id" : "45",
+            "id" : "46",
+            "properties" : {
+              "structurizr.dsl.identifier" : "7669ae53-6352-4244-869b-7ded4d6fd798"
+            },
             "sourceId" : "7",
             "tags" : "Relationship"
           } ],
@@ -112,7 +128,10 @@
           "relationships" : [ {
             "description" : "dispatches RegisterUserCommand",
             "destinationId" : "12",
-            "id" : "29",
+            "id" : "30",
+            "properties" : {
+              "structurizr.dsl.identifier" : "675c7aba-7474-4838-950e-a4939b7063d8"
+            },
             "sourceId" : "8",
             "tags" : "Relationship"
           } ],
@@ -130,7 +149,10 @@
           "relationships" : [ {
             "description" : "dispatches ConfirmUserCommand",
             "destinationId" : "11",
-            "id" : "31",
+            "id" : "32",
+            "properties" : {
+              "structurizr.dsl.identifier" : "be838319-a198-4d87-945f-19c1e733652b"
+            },
             "sourceId" : "9",
             "tags" : "Relationship"
           } ],
@@ -148,13 +170,19 @@
           "relationships" : [ {
             "description" : "publishes EmailChangedEvent",
             "destinationId" : "17",
-            "id" : "35",
+            "id" : "36",
+            "properties" : {
+              "structurizr.dsl.identifier" : "ccbf7dbe-e376-4b32-846c-19229a11078c"
+            },
             "sourceId" : "10",
             "tags" : "Relationship"
           }, {
             "description" : "publishes PasswordChangedEvent",
             "destinationId" : "18",
-            "id" : "36",
+            "id" : "37",
+            "properties" : {
+              "structurizr.dsl.identifier" : "f71eaa04-0f06-4280-bdea-054f69b0f22e"
+            },
             "sourceId" : "10",
             "tags" : "Relationship"
           } ],
@@ -172,7 +200,10 @@
           "relationships" : [ {
             "description" : "publishes UserConfirmedEvent",
             "destinationId" : "15",
-            "id" : "32",
+            "id" : "33",
+            "properties" : {
+              "structurizr.dsl.identifier" : "4330c6d1-b79d-456a-97d5-8f1c45c5aea6"
+            },
             "sourceId" : "11",
             "tags" : "Relationship"
           } ],
@@ -190,13 +221,19 @@
           "relationships" : [ {
             "description" : "publishes UserRegisteredEvent",
             "destinationId" : "14",
-            "id" : "33",
+            "id" : "34",
+            "properties" : {
+              "structurizr.dsl.identifier" : "f077823d-0817-4ea6-81f4-4c5ab07d7d17"
+            },
             "sourceId" : "12",
             "tags" : "Relationship"
           }, {
             "description" : "creates",
             "destinationId" : "19",
-            "id" : "34",
+            "id" : "35",
+            "properties" : {
+              "structurizr.dsl.identifier" : "4dcd8253-1422-44eb-891e-44baa6180758"
+            },
             "sourceId" : "12",
             "tags" : "Relationship"
           } ],
@@ -214,7 +251,10 @@
           "relationships" : [ {
             "description" : "publishes ConfirmationEmailSentEvent",
             "destinationId" : "16",
-            "id" : "39",
+            "id" : "40",
+            "properties" : {
+              "structurizr.dsl.identifier" : "0077f175-9618-4402-9b01-6c5c9dd187c5"
+            },
             "sourceId" : "13",
             "tags" : "Relationship"
           } ],
@@ -232,7 +272,10 @@
           "relationships" : [ {
             "description" : "dispatches SendConfirmationEmailCommand",
             "destinationId" : "13",
-            "id" : "38",
+            "id" : "39",
+            "properties" : {
+              "structurizr.dsl.identifier" : "6baf94fb-4ead-4b19-8350-66ccdf9b7c17"
+            },
             "sourceId" : "14",
             "tags" : "Relationship"
           } ],
@@ -250,7 +293,10 @@
           "relationships" : [ {
             "description" : "deletes",
             "destinationId" : "20",
-            "id" : "47",
+            "id" : "48",
+            "properties" : {
+              "structurizr.dsl.identifier" : "b5d4276c-75d5-41fc-8923-4f5e1392c57c"
+            },
             "sourceId" : "15",
             "tags" : "Relationship"
           } ],
@@ -268,13 +314,19 @@
           "relationships" : [ {
             "description" : "adds email to queue",
             "destinationId" : "24",
-            "id" : "41",
+            "id" : "42",
+            "properties" : {
+              "structurizr.dsl.identifier" : "ff2bbf8a-2c92-4a6c-ad3d-ea26b002a9b1"
+            },
             "sourceId" : "16",
             "tags" : "Relationship"
           }, {
             "description" : "creates",
             "destinationId" : "20",
-            "id" : "46",
+            "id" : "47",
+            "properties" : {
+              "structurizr.dsl.identifier" : "e48a469f-2846-4f46-b45c-9551251a9de3"
+            },
             "sourceId" : "16",
             "tags" : "Relationship"
           } ],
@@ -292,7 +344,10 @@
           "relationships" : [ {
             "description" : "dispatches SendConfirmationEmailCommand",
             "destinationId" : "13",
-            "id" : "37",
+            "id" : "38",
+            "properties" : {
+              "structurizr.dsl.identifier" : "6c1b2f79-796c-400c-9ea9-778b3448b708"
+            },
             "sourceId" : "17",
             "tags" : "Relationship"
           } ],
@@ -310,7 +365,10 @@
           "relationships" : [ {
             "description" : "adds email to queue",
             "destinationId" : "24",
-            "id" : "40",
+            "id" : "41",
+            "properties" : {
+              "structurizr.dsl.identifier" : "27adef4b-2b4a-4097-b6f3-393b2e069db2"
+            },
             "sourceId" : "18",
             "tags" : "Relationship"
           } ],
@@ -350,13 +408,19 @@
           "relationships" : [ {
             "description" : "save and load",
             "destinationId" : "19",
-            "id" : "48",
+            "id" : "49",
+            "properties" : {
+              "structurizr.dsl.identifier" : "4e1988fa-bf66-4c77-b9f8-cba98dfb32fc"
+            },
             "sourceId" : "21",
             "tags" : "Relationship"
           }, {
             "description" : "accesses data",
             "destinationId" : "25",
-            "id" : "50",
+            "id" : "51",
+            "properties" : {
+              "structurizr.dsl.identifier" : "4f350397-2e94-48a3-8544-9728c290c491"
+            },
             "sourceId" : "21",
             "tags" : "Relationship"
           } ],
@@ -374,13 +438,19 @@
           "relationships" : [ {
             "description" : "save and load",
             "destinationId" : "20",
-            "id" : "49",
+            "id" : "50",
+            "properties" : {
+              "structurizr.dsl.identifier" : "12d6b0a7-57ee-4f3e-9b99-dbbc73090f25"
+            },
             "sourceId" : "22",
             "tags" : "Relationship"
           }, {
             "description" : "accesses data",
             "destinationId" : "26",
-            "id" : "51",
+            "id" : "52",
+            "properties" : {
+              "structurizr.dsl.identifier" : "7736ca75-9753-4eea-8ee2-a1a99cc16365"
+            },
             "sourceId" : "22",
             "tags" : "Relationship"
           } ],
@@ -396,17 +466,15 @@
             "structurizr.dsl.identifier" : "softwaresystem.userservice.mailer"
           },
           "relationships" : [ {
-            "description" : "consumes emails",
-            "destinationId" : "24",
-            "id" : "42",
+            "description" : "sends email when SES API transport is configured",
+            "destinationId" : "28",
+            "id" : "54",
+            "properties" : {
+              "structurizr.dsl.identifier" : "49dc0e87-df2d-465b-80b5-c0f4e3866eb6"
+            },
             "sourceId" : "23",
-            "tags" : "Relationship"
-          }, {
-            "description" : "publish message",
-            "destinationId" : "27",
-            "id" : "52",
-            "sourceId" : "23",
-            "tags" : "Relationship"
+            "tags" : "Relationship",
+            "technology" : "HTTPS API"
           } ],
           "tags" : "Element,Component,Item"
         }, {
@@ -418,6 +486,25 @@
           "properties" : {
             "structurizr.dsl.identifier" : "softwaresystem.userservice.messenger"
           },
+          "relationships" : [ {
+            "description" : "delivers queued emails via transport",
+            "destinationId" : "23",
+            "id" : "43",
+            "properties" : {
+              "structurizr.dsl.identifier" : "713586ab-720c-4ceb-9751-db1076b362fa"
+            },
+            "sourceId" : "24",
+            "tags" : "Relationship"
+          }, {
+            "description" : "publishes and consumes queued messages",
+            "destinationId" : "27",
+            "id" : "53",
+            "properties" : {
+              "structurizr.dsl.identifier" : "e7557be3-83ef-4f5a-a58f-5256200096de"
+            },
+            "sourceId" : "24",
+            "tags" : "Relationship"
+          } ],
           "tags" : "Element,Component,Item"
         }, {
           "description" : "Stores user, information, hashed authentication credentials, access rights, oauth credentials, etc.",
@@ -449,6 +536,16 @@
           },
           "tags" : "Element,Component,MessageBroker",
           "technology" : "AWS SQS"
+        }, {
+          "description" : "Optional configured email delivery via task credentials",
+          "documentation" : { },
+          "id" : "28",
+          "name" : "Amazon SES",
+          "properties" : {
+            "structurizr.dsl.identifier" : "softwaresystem.userservice.ses"
+          },
+          "tags" : "Element,Component,Item",
+          "technology" : "SES API"
         } ],
         "documentation" : { },
         "id" : "2",
@@ -470,7 +567,7 @@
   },
   "name" : "Name",
   "properties" : {
-    "structurizr.dsl" : "d29ya3NwYWNlIHsKCiAgICAhaWRlbnRpZmllcnMgaGllcmFyY2hpY2FsCgogICAgbW9kZWwgewogICAgICAgIHByb3BlcnRpZXMgewogICAgICAgICAgICAic3RydWN0dXJpenIuZ3JvdXBTZXBhcmF0b3IiICIvIgogICAgICAgIH0KCiAgICAgICAgc29mdHdhcmVTeXN0ZW0gPSBzb2Z0d2FyZVN5c3RlbSAiVmlsbmFDUk0iIHsKICAgICAgICAgICAgdXNlclNlcnZpY2UgPSBjb250YWluZXIgIlVzZXIgU2VydmljZSIgewoKICAgICAgICAgICAgICAgIGdyb3VwICJBcHBsaWNhdGlvbiIgewogICAgICAgICAgICAgICAgICAgIHJlZ2lzdGVyVXNlclByb2Nlc3NvciA9IGNvbXBvbmVudCAiUmVnaXN0ZXJVc2VyUHJvY2Vzc29yIiAiUHJvY2Vzc2VzIEhUVFAgcmVxdWVzdHMgZm9yIHVzZXIgcmVnaXN0cmF0aW9uIiAiUmVxdWVzdFByb2Nlc3NvciIgewogICAgICAgICAgICAgICAgICAgICAgICB0YWdzICJJdGVtIgogICAgICAgICAgICAgICAgICAgIH0KICAgICAgICAgICAgICAgICAgICBjb25maXJtVXNlclByb2Nlc3NvciA9IGNvbXBvbmVudCAiQ29uZmlybVVzZXJQcm9jZXNzb3IiICJQcm9jZXNzZXMgSFRUUCByZXF1ZXN0cyBmb3IgdXNlciBjb25maXJtYXRpb24iICJSZXF1ZXN0UHJvY2Vzc29yIiB7CiAgICAgICAgICAgICAgICAgICAgICAgIHRhZ3MgIkl0ZW0iCiAgICAgICAgICAgICAgICAgICAgfQogICAgICAgICAgICAgICAgICAgIHVzZXJQYXRjaFByb2Nlc3NvciA9IGNvbXBvbmVudCAiVXNlclBhdGNoUHJvY2Vzc29yIiAiUHJvY2Vzc2VzIEhUVFAgcmVxdWVzdHMgZm9yIHVwZGF0aW5nIHVzZXIiICJSZXF1ZXN0UHJvY2Vzc29yIiB7CiAgICAgICAgICAgICAgICAgICAgICAgIHRhZ3MgIkl0ZW0iCiAgICAgICAgICAgICAgICAgICAgfQogICAgICAgICAgICAgICAgICAgIHVzZXJQdXRQcm9jZXNzb3IgPSBjb21wb25lbnQgIlVzZXJQdXRQcm9jZXNzb3IiICJQcm9jZXNzZXMgSFRUUCByZXF1ZXN0cyBmb3IgcmVwbGFjaW5nIHVzZXIiICJSZXF1ZXN0UHJvY2Vzc29yIiB7CiAgICAgICAgICAgICAgICAgICAgICAgIHRhZ3MgIkl0ZW0iCiAgICAgICAgICAgICAgICAgICAgfQogICAgICAgICAgICAgICAgICAgIHVwZGF0ZVVzZXJSZXNvbHZlciA9IGNvbXBvbmVudCAiVXBkYXRlVXNlclJlc29sdmVyIiAiUHJvY2Vzc2VzIEdyYXBoUUwgcmVxdWVzdHMgZm9yIHVwZGF0aW5nIHVzZXIiICJNdXRhdGlvblJlc29sdmVyIiB7CiAgICAgICAgICAgICAgICAgICAgICAgIHRhZ3MgIkl0ZW0iCiAgICAgICAgICAgICAgICAgICAgfQogICAgICAgICAgICAgICAgICAgIHJlZ2lzdGVyVXNlclJlc29sdmVyID0gY29tcG9uZW50ICJSZWdpc3RlclVzZXJSZXNvbHZlciIgIlByb2Nlc3NlcyBHcmFwaFFMIHJlcXVlc3RzIGZvciB1c2VyIHJlZ2lzdHJhdGlvbiIgIk11dGF0aW9uUmVzb2x2ZXIiIHsKICAgICAgICAgICAgICAgICAgICAgICAgdGFncyAiSXRlbSIKICAgICAgICAgICAgICAgICAgICB9CiAgICAgICAgICAgICAgICAgICAgY29uZmlybVVzZXJSZXNvbHZlciA9IGNvbXBvbmVudCAiQ29uZmlybVVzZXJSZXNvbHZlciIgIlByb2Nlc3NlcyBHcmFwaFFMIHJlcXVlc3RzIGZvciB1c2VyIGNvbmZpcm1hdGlvbiIgIk11dGF0aW9uUmVzb2x2ZXIiIHsKICAgICAgICAgICAgICAgICAgICAgICAgdGFncyAiSXRlbSIKICAgICAgICAgICAgICAgICAgICB9CiAgICAgICAgICAgICAgICAgICAgdXBkYXRlVXNlckNvbW1hbmRIYW5kbGVyID0gY29tcG9uZW50ICJVcGRhdGVVc2VyQ29tbWFuZEhhbmRsZXIiICJIYW5kbGVzIFVwZGF0ZVVzZXJDb21tYW5kIiAiQ29tbWFuZEhhbmRsZXIiIHsKICAgICAgICAgICAgICAgICAgICAgICAgdGFncyAiSXRlbSIKICAgICAgICAgICAgICAgICAgICB9CiAgICAgICAgICAgICAgICAgICAgY29uZmlybVVzZXJDb21tYW5kSGFuZGxlciA9IGNvbXBvbmVudCAiQ29uZmlybVVzZXJDb21tYW5kSGFuZGxlciIgIkhhbmRsZXMgQ29uZmlybVVzZXJDb21tYW5kIiAiQ29tbWFuZEhhbmRsZXIiIHsKICAgICAgICAgICAgICAgICAgICAgICAgdGFncyAiSXRlbSIKICAgICAgICAgICAgICAgICAgICB9CiAgICAgICAgICAgICAgICAgICAgcmVnaXN0ZXJVc2VyQ29tbWFuZEhhbmRsZXIgPSBjb21wb25lbnQgIlJlZ2lzdGVyVXNlckNvbW1hbmRIYW5kbGVyIiAiSGFuZGxlcyBSZWdpc3RlclVzZXJDb21tYW5kIiAiQ29tbWFuZEhhbmRsZXIiIHsKICAgICAgICAgICAgICAgICAgICAgICAgdGFncyAiSXRlbSIKICAgICAgICAgICAgICAgICAgICB9CiAgICAgICAgICAgICAgICAgICAgc2VuZENvbmZpcm1hdGlvbkVtYWlsQ29tbWFuZEhhbmRsZXIgPSBjb21wb25lbnQgIlNlbmRDb25maXJtYXRpb25FbWFpbENvbW1hbmRIYW5kbGVyIiAiSGFuZGxlcyAiICJDb21tYW5kSGFuZGxlciIgewogICAgICAgICAgICAgICAgICAgICAgICB0YWdzICJJdGVtIgogICAgICAgICAgICAgICAgICAgIH0KICAgICAgICAgICAgICAgICAgICB1c2VyUmVnaXN0ZXJlZEV2ZW50U3Vic2NyaWJlciA9IGNvbXBvbmVudCAiVXNlclJlZ2lzdGVyZWRFdmVudFN1YnNjcmliZXIiICJIYW5kbGVzIFVzZXJSZWdpc3RlcmVkRXZlbnQiICJFdmVudFN1YnNjcmliZXIiIHsKICAgICAgICAgICAgICAgICAgICAgICAgdGFncyAiSXRlbSIKICAgICAgICAgICAgICAgICAgICB9CiAgICAgICAgICAgICAgICAgICAgdXNlckNvbmZpcm1lZEV2ZW50U3Vic2NyaWJlciA9IGNvbXBvbmVudCAiVXNlckNvbmZpcm1lZEV2ZW50U3Vic2NyaWJlciIgIkhhbmRsZXMgVXNlckNvbmZpcm1lZEV2ZW50IiAiRXZlbnRTdWJzY3JpYmVyIiB7CiAgICAgICAgICAgICAgICAgICAgICAgIHRhZ3MgIkl0ZW0iCiAgICAgICAgICAgICAgICAgICAgfQogICAgICAgICAgICAgICAgICAgIGNvbmZpcm1hdGlvbkVtYWlsU2VudEV2ZW50U3Vic2NyaWJlciA9IGNvbXBvbmVudCAiQ29uZmlybWF0aW9uRW1haWxTZW50RXZlbnRTdWJzY3JpYmVyIiAiSGFuZGxlcyBDb25maXJtYXRpb25FbWFpbFNlbnRFdmVudCIgIkV2ZW50U3Vic2NyaWJlciIgewogICAgICAgICAgICAgICAgICAgICAgICB0YWdzICJJdGVtIgoKICAgICAgICAgICAgICAgICAgICB9CiAgICAgICAgICAgICAgICAgICAgZW1haWxDaGFuZ2VkRXZlbnRTdWJzY3JpYmVyID0gY29tcG9uZW50ICJFbWFpbENoYW5nZWRFdmVudFN1YnNjcmliZXIiICJIYW5kbGVzIEVtYWlsQ2hhbmdlZEV2ZW50IiAiRXZlbnRTdWJzY3JpYmVyIiB7CiAgICAgICAgICAgICAgICAgICAgICAgIHRhZ3MgIkl0ZW0iCiAgICAgICAgICAgICAgICAgICAgfQogICAgICAgICAgICAgICAgICAgIHBhc3N3b3JkQ2hhbmdlZEV2ZW50U3Vic2NyaWJlciA9IGNvbXBvbmVudCAiUGFzc3dvcmRDaGFuZ2VkRXZlbnRTdWJzY3JpYmVyIiAiSGFuZGxlcyBQYXNzd29yZENoYW5nZWRFdmVudCIgIkV2ZW50U3Vic2NyaWJlciIgewogICAgICAgICAgICAgICAgICAgICAgICB0YWdzICJJdGVtIgogICAgICAgICAgICAgICAgICAgIH0KICAgICAgICAgICAgICAgIH0KCiAgICAgICAgICAgICAgICBncm91cCAiRG9tYWluIiB7CiAgICAgICAgICAgICAgICAgICAgdXNlciA9IGNvbXBvbmVudCAiVXNlciIgIlJlcHJlc2VudHMgdXNlciIgIkVudGl0eSIgewogICAgICAgICAgICAgICAgICAgICAgICB0YWdzICJJdGVtIgogICAgICAgICAgICAgICAgICAgIH0KICAgICAgICAgICAgICAgICAgICB0b2tlbiA9IGNvbXBvbmVudCAiQ29uZmlybWF0aW9uVG9rZW4iICJSZXByZXNlbnRzIGNvbmZpcm1hdGlvbiB0b2tlbiIgIkVudGl0eSIgewogICAgICAgICAgICAgICAgICAgICAgICB0YWdzICJJdGVtIgogICAgICAgICAgICAgICAgICAgIH0KICAgICAgICAgICAgICAgIH0KCiAgICAgICAgICAgICAgICBncm91cCAiSW5mcmFzdHJ1Y3R1cmUiIHsKICAgICAgICAgICAgICAgICAgICB1c2VyUmVwb3NpdG9yeSA9IGNvbXBvbmVudCAiTWFyaWFEQlVzZXJSZXBvc2l0b3J5IiAiTWFuYWdlcyBhY2Nlc3MgdG8gdXNlcnMiICJSZXBvc2l0b3J5IiB7CiAgICAgICAgICAgICAgICAgICAgICAgIHRhZ3MgIkl0ZW0iCiAgICAgICAgICAgICAgICAgICAgfQogICAgICAgICAgICAgICAgICAgIHRva2VuUmVwb3NpdG9yeSA9IGNvbXBvbmVudCAiUmVkaXNUb2tlblJlcG9zaXRvcnkiICJNYW5hZ2VzIGFjY2VzcyB0byBjb25maXJtYXRpb24gdG9rZW5zIiAiUmVwb3NpdG9yeSIgewogICAgICAgICAgICAgICAgICAgICAgICB0YWdzICJJdGVtIgogICAgICAgICAgICAgICAgICAgIH0KICAgICAgICAgICAgICAgICAgICBtYWlsZXIgPSBjb21wb25lbnQgIlN5bWZvbnkgTWFpbGVyIiAiTWFuYWdlcyBzZW5kaW5nIG9mIGVtYWlscyIgewogICAgICAgICAgICAgICAgICAgICAgICB0YWdzICJJdGVtIgogICAgICAgICAgICAgICAgICAgIH0KICAgICAgICAgICAgICAgICAgICBtZXNzZW5nZXIgPSBjb21wb25lbnQgIlN5bWZvbnkgTWVzc2VuZ2VyIiAiTWFuYWdlcyBiYWNrZ3JvdW5kIHRhc2tzIiB7CiAgICAgICAgICAgICAgICAgICAgICAgIHRhZ3MgIkl0ZW0iCiAgICAgICAgICAgICAgICAgICAgfQogICAgICAgICAgICAgICAgfQoKICAgICAgICAgICAgICAgIGRhdGFiYXNlID0gY29tcG9uZW50ICJEYXRhYmFzZSIgIlN0b3JlcyB1c2VyLCBpbmZvcm1hdGlvbiwgaGFzaGVkIGF1dGhlbnRpY2F0aW9uIGNyZWRlbnRpYWxzLCBhY2Nlc3MgcmlnaHRzLCBvYXV0aCBjcmVkZW50aWFscywgZXRjLiIgIk1hcmlhREIiIHsKICAgICAgICAgICAgICAgICAgICB0YWdzICJEYXRhYmFzZSIKICAgICAgICAgICAgICAgIH0KICAgICAgICAgICAgICAgIGNhY2hlID0gY29tcG9uZW50ICJDYWNoZSIgIlN0b3JlcyBjb25maXJtYXRpb24gdG9rZW4sIGRvY3RyaW5lIHF1ZXJ5IGNhY2hlIiAiRWxhc3RpY2FjaGUiIHsKICAgICAgICAgICAgICAgICAgICB0YWdzICJDYWNoZSIKICAgICAgICAgICAgICAgIH0KICAgICAgICAgICAgICAgIHNxcyA9IGNvbXBvbmVudCAiQVdTIFNRUyIgIk1lc3NhZ2UgYnJva2VyIGZvciBzZW5kaW5nIGVtYWlscyIgIkFXUyBTUVMiIHsKICAgICAgICAgICAgICAgICAgICB0YWdzICJNZXNzYWdlQnJva2VyIgogICAgICAgICAgICAgICAgfQoKICAgICAgICAgICAgICAgIHJlZ2lzdGVyVXNlclByb2Nlc3NvciAtPiByZWdpc3RlclVzZXJDb21tYW5kSGFuZGxlciAiZGlzcGF0Y2hlcyBSZWdpc3RlclVzZXJDb21tYW5kIgogICAgICAgICAgICAgICAgcmVnaXN0ZXJVc2VyUmVzb2x2ZXIgLT4gcmVnaXN0ZXJVc2VyQ29tbWFuZEhhbmRsZXIgImRpc3BhdGNoZXMgUmVnaXN0ZXJVc2VyQ29tbWFuZCIKICAgICAgICAgICAgICAgIGNvbmZpcm1Vc2VyUHJvY2Vzc29yIC0+IGNvbmZpcm1Vc2VyQ29tbWFuZEhhbmRsZXIgImRpc3BhdGNoZXMgQ29uZmlybVVzZXJDb21tYW5kIgogICAgICAgICAgICAgICAgY29uZmlybVVzZXJSZXNvbHZlciAtPiBjb25maXJtVXNlckNvbW1hbmRIYW5kbGVyICJkaXNwYXRjaGVzIENvbmZpcm1Vc2VyQ29tbWFuZCIKICAgICAgICAgICAgICAgIGNvbmZpcm1Vc2VyQ29tbWFuZEhhbmRsZXIgLT4gdXNlckNvbmZpcm1lZEV2ZW50U3Vic2NyaWJlciAicHVibGlzaGVzIFVzZXJDb25maXJtZWRFdmVudCIKICAgICAgICAgICAgICAgIHJlZ2lzdGVyVXNlckNvbW1hbmRIYW5kbGVyIC0+IHVzZXJSZWdpc3RlcmVkRXZlbnRTdWJzY3JpYmVyICJwdWJsaXNoZXMgVXNlclJlZ2lzdGVyZWRFdmVudCIKICAgICAgICAgICAgICAgIHJlZ2lzdGVyVXNlckNvbW1hbmRIYW5kbGVyIC0+IHVzZXIgImNyZWF0ZXMiCiAgICAgICAgICAgICAgICB1cGRhdGVVc2VyQ29tbWFuZEhhbmRsZXIgLT4gZW1haWxDaGFuZ2VkRXZlbnRTdWJzY3JpYmVyICJwdWJsaXNoZXMgRW1haWxDaGFuZ2VkRXZlbnQiCiAgICAgICAgICAgICAgICB1cGRhdGVVc2VyQ29tbWFuZEhhbmRsZXIgLT4gcGFzc3dvcmRDaGFuZ2VkRXZlbnRTdWJzY3JpYmVyICJwdWJsaXNoZXMgUGFzc3dvcmRDaGFuZ2VkRXZlbnQiCiAgICAgICAgICAgICAgICBlbWFpbENoYW5nZWRFdmVudFN1YnNjcmliZXIgLT4gc2VuZENvbmZpcm1hdGlvbkVtYWlsQ29tbWFuZEhhbmRsZXIgImRpc3BhdGNoZXMgU2VuZENvbmZpcm1hdGlvbkVtYWlsQ29tbWFuZCIKICAgICAgICAgICAgICAgIHVzZXJSZWdpc3RlcmVkRXZlbnRTdWJzY3JpYmVyIC0+IHNlbmRDb25maXJtYXRpb25FbWFpbENvbW1hbmRIYW5kbGVyICJkaXNwYXRjaGVzIFNlbmRDb25maXJtYXRpb25FbWFpbENvbW1hbmQiCiAgICAgICAgICAgICAgICBzZW5kQ29uZmlybWF0aW9uRW1haWxDb21tYW5kSGFuZGxlciAtPiBjb25maXJtYXRpb25FbWFpbFNlbnRFdmVudFN1YnNjcmliZXIgInB1Ymxpc2hlcyBDb25maXJtYXRpb25FbWFpbFNlbnRFdmVudCIKICAgICAgICAgICAgICAgIHBhc3N3b3JkQ2hhbmdlZEV2ZW50U3Vic2NyaWJlciAtPiBtZXNzZW5nZXIgImFkZHMgZW1haWwgdG8gcXVldWUiCiAgICAgICAgICAgICAgICBjb25maXJtYXRpb25FbWFpbFNlbnRFdmVudFN1YnNjcmliZXIgLT4gbWVzc2VuZ2VyICJhZGRzIGVtYWlsIHRvIHF1ZXVlIgogICAgICAgICAgICAgICAgbWFpbGVyIC0+IG1lc3NlbmdlciAiY29uc3VtZXMgZW1haWxzIgogICAgICAgICAgICAgICAgdXNlclBhdGNoUHJvY2Vzc29yIC0+IHVwZGF0ZVVzZXJDb21tYW5kSGFuZGxlciAiZGlzcGF0Y2hlcyBVcGRhdGVVc2VyQ29tbWFuZCIKICAgICAgICAgICAgICAgIHVzZXJQdXRQcm9jZXNzb3IgLT4gdXBkYXRlVXNlckNvbW1hbmRIYW5kbGVyICJkaXNwYXRjaGVzIFVwZGF0ZVVzZXJDb21tYW5kIgogICAgICAgICAgICAgICAgdXBkYXRlVXNlclJlc29sdmVyIC0+IHVwZGF0ZVVzZXJDb21tYW5kSGFuZGxlciAiZGlzcGF0Y2hlcyBVcGRhdGVVc2VyQ29tbWFuZCIKICAgICAgICAgICAgICAgIGNvbmZpcm1hdGlvbkVtYWlsU2VudEV2ZW50U3Vic2NyaWJlciAtPiB0b2tlbiAiY3JlYXRlcyIKICAgICAgICAgICAgICAgIHVzZXJDb25maXJtZWRFdmVudFN1YnNjcmliZXIgLT4gdG9rZW4gImRlbGV0ZXMiCiAgICAgICAgICAgICAgICB1c2VyUmVwb3NpdG9yeSAtPiB1c2VyICJzYXZlIGFuZCBsb2FkIgogICAgICAgICAgICAgICAgdG9rZW5SZXBvc2l0b3J5IC0+IHRva2VuICJzYXZlIGFuZCBsb2FkIgogICAgICAgICAgICAgICAgdXNlclJlcG9zaXRvcnkgLT4gZGF0YWJhc2UgImFjY2Vzc2VzIGRhdGEiCiAgICAgICAgICAgICAgICB0b2tlblJlcG9zaXRvcnkgLT4gY2FjaGUgImFjY2Vzc2VzIGRhdGEiCiAgICAgICAgICAgICAgICBtYWlsZXIgLT4gc3FzICJwdWJsaXNoIG1lc3NhZ2UiCiAgICAgICAgICAgIH0KICAgICAgICB9CiAgICB9CgogICAgdmlld3MgewogICAgICAgIGNvbXBvbmVudCBzb2Z0d2FyZVN5c3RlbS51c2VyU2VydmljZSAiQ29tcG9uZW50c19BbGwiIHsKICAgICAgICAgICAgaW5jbHVkZSAqCiAgICAgICAgfQoKICAgICAgICBzdHlsZXMgewogICAgICAgICAgICBlbGVtZW50ICJJdGVtIiB7CiAgICAgICAgICAgICAgICBjb2xvciB3aGl0ZQogICAgICAgICAgICAgICAgYmFja2dyb3VuZCAjMzRhYmViCiAgICAgICAgICAgIH0KICAgICAgICAgICAgZWxlbWVudCAiRGF0YWJhc2UiIHsKICAgICAgICAgICAgICAgIGNvbG9yIHdoaXRlCiAgICAgICAgICAgICAgICBzaGFwZSBjeWxpbmRlcgogICAgICAgICAgICAgICAgYmFja2dyb3VuZCAjMzRhYmViCiAgICAgICAgICAgIH0KICAgICAgICAgICAgZWxlbWVudCAiQ2FjaGUiIHsKICAgICAgICAgICAgICAgIGNvbG9yIHdoaXRlCiAgICAgICAgICAgICAgICBzaGFwZSBjeWxpbmRlcgogICAgICAgICAgICAgICAgYmFja2dyb3VuZCAjMzRhYmViCiAgICAgICAgICAgIH0KICAgICAgICAgICAgZWxlbWVudCAiTWVzc2FnZUJyb2tlciIgewogICAgICAgICAgICAgICAgY29sb3Igd2hpdGUKICAgICAgICAgICAgICAgIHNoYXBlIHBpcGUKICAgICAgICAgICAgICAgIGJhY2tncm91bmQgIzM0YWJlYgogICAgICAgICAgICB9CiAgICAgICAgfQogICAgfQp9"
+    "structurizr.dsl" : "d29ya3NwYWNlIHsKCiAgICAhaWRlbnRpZmllcnMgaGllcmFyY2hpY2FsCgogICAgbW9kZWwgewogICAgICAgIHByb3BlcnRpZXMgewogICAgICAgICAgICAic3RydWN0dXJpenIuZ3JvdXBTZXBhcmF0b3IiICIvIgogICAgICAgIH0KCiAgICAgICAgc29mdHdhcmVTeXN0ZW0gPSBzb2Z0d2FyZVN5c3RlbSAiVmlsbmFDUk0iIHsKICAgICAgICAgICAgdXNlclNlcnZpY2UgPSBjb250YWluZXIgIlVzZXIgU2VydmljZSIgewoKICAgICAgICAgICAgICAgIGdyb3VwICJBcHBsaWNhdGlvbiIgewogICAgICAgICAgICAgICAgICAgIHJlZ2lzdGVyVXNlclByb2Nlc3NvciA9IGNvbXBvbmVudCAiUmVnaXN0ZXJVc2VyUHJvY2Vzc29yIiAiUHJvY2Vzc2VzIEhUVFAgcmVxdWVzdHMgZm9yIHVzZXIgcmVnaXN0cmF0aW9uIiAiUmVxdWVzdFByb2Nlc3NvciIgewogICAgICAgICAgICAgICAgICAgICAgICB0YWdzICJJdGVtIgogICAgICAgICAgICAgICAgICAgIH0KICAgICAgICAgICAgICAgICAgICBjb25maXJtVXNlclByb2Nlc3NvciA9IGNvbXBvbmVudCAiQ29uZmlybVVzZXJQcm9jZXNzb3IiICJQcm9jZXNzZXMgSFRUUCByZXF1ZXN0cyBmb3IgdXNlciBjb25maXJtYXRpb24iICJSZXF1ZXN0UHJvY2Vzc29yIiB7CiAgICAgICAgICAgICAgICAgICAgICAgIHRhZ3MgIkl0ZW0iCiAgICAgICAgICAgICAgICAgICAgfQogICAgICAgICAgICAgICAgICAgIHVzZXJQYXRjaFByb2Nlc3NvciA9IGNvbXBvbmVudCAiVXNlclBhdGNoUHJvY2Vzc29yIiAiUHJvY2Vzc2VzIEhUVFAgcmVxdWVzdHMgZm9yIHVwZGF0aW5nIHVzZXIiICJSZXF1ZXN0UHJvY2Vzc29yIiB7CiAgICAgICAgICAgICAgICAgICAgICAgIHRhZ3MgIkl0ZW0iCiAgICAgICAgICAgICAgICAgICAgfQogICAgICAgICAgICAgICAgICAgIHVzZXJQdXRQcm9jZXNzb3IgPSBjb21wb25lbnQgIlVzZXJQdXRQcm9jZXNzb3IiICJQcm9jZXNzZXMgSFRUUCByZXF1ZXN0cyBmb3IgcmVwbGFjaW5nIHVzZXIiICJSZXF1ZXN0UHJvY2Vzc29yIiB7CiAgICAgICAgICAgICAgICAgICAgICAgIHRhZ3MgIkl0ZW0iCiAgICAgICAgICAgICAgICAgICAgfQogICAgICAgICAgICAgICAgICAgIHVwZGF0ZVVzZXJSZXNvbHZlciA9IGNvbXBvbmVudCAiVXBkYXRlVXNlclJlc29sdmVyIiAiUHJvY2Vzc2VzIEdyYXBoUUwgcmVxdWVzdHMgZm9yIHVwZGF0aW5nIHVzZXIiICJNdXRhdGlvblJlc29sdmVyIiB7CiAgICAgICAgICAgICAgICAgICAgICAgIHRhZ3MgIkl0ZW0iCiAgICAgICAgICAgICAgICAgICAgfQogICAgICAgICAgICAgICAgICAgIHJlZ2lzdGVyVXNlclJlc29sdmVyID0gY29tcG9uZW50ICJSZWdpc3RlclVzZXJSZXNvbHZlciIgIlByb2Nlc3NlcyBHcmFwaFFMIHJlcXVlc3RzIGZvciB1c2VyIHJlZ2lzdHJhdGlvbiIgIk11dGF0aW9uUmVzb2x2ZXIiIHsKICAgICAgICAgICAgICAgICAgICAgICAgdGFncyAiSXRlbSIKICAgICAgICAgICAgICAgICAgICB9CiAgICAgICAgICAgICAgICAgICAgY29uZmlybVVzZXJSZXNvbHZlciA9IGNvbXBvbmVudCAiQ29uZmlybVVzZXJSZXNvbHZlciIgIlByb2Nlc3NlcyBHcmFwaFFMIHJlcXVlc3RzIGZvciB1c2VyIGNvbmZpcm1hdGlvbiIgIk11dGF0aW9uUmVzb2x2ZXIiIHsKICAgICAgICAgICAgICAgICAgICAgICAgdGFncyAiSXRlbSIKICAgICAgICAgICAgICAgICAgICB9CiAgICAgICAgICAgICAgICAgICAgdXBkYXRlVXNlckNvbW1hbmRIYW5kbGVyID0gY29tcG9uZW50ICJVcGRhdGVVc2VyQ29tbWFuZEhhbmRsZXIiICJIYW5kbGVzIFVwZGF0ZVVzZXJDb21tYW5kIiAiQ29tbWFuZEhhbmRsZXIiIHsKICAgICAgICAgICAgICAgICAgICAgICAgdGFncyAiSXRlbSIKICAgICAgICAgICAgICAgICAgICB9CiAgICAgICAgICAgICAgICAgICAgY29uZmlybVVzZXJDb21tYW5kSGFuZGxlciA9IGNvbXBvbmVudCAiQ29uZmlybVVzZXJDb21tYW5kSGFuZGxlciIgIkhhbmRsZXMgQ29uZmlybVVzZXJDb21tYW5kIiAiQ29tbWFuZEhhbmRsZXIiIHsKICAgICAgICAgICAgICAgICAgICAgICAgdGFncyAiSXRlbSIKICAgICAgICAgICAgICAgICAgICB9CiAgICAgICAgICAgICAgICAgICAgcmVnaXN0ZXJVc2VyQ29tbWFuZEhhbmRsZXIgPSBjb21wb25lbnQgIlJlZ2lzdGVyVXNlckNvbW1hbmRIYW5kbGVyIiAiSGFuZGxlcyBSZWdpc3RlclVzZXJDb21tYW5kIiAiQ29tbWFuZEhhbmRsZXIiIHsKICAgICAgICAgICAgICAgICAgICAgICAgdGFncyAiSXRlbSIKICAgICAgICAgICAgICAgICAgICB9CiAgICAgICAgICAgICAgICAgICAgc2VuZENvbmZpcm1hdGlvbkVtYWlsQ29tbWFuZEhhbmRsZXIgPSBjb21wb25lbnQgIlNlbmRDb25maXJtYXRpb25FbWFpbENvbW1hbmRIYW5kbGVyIiAiSGFuZGxlcyAiICJDb21tYW5kSGFuZGxlciIgewogICAgICAgICAgICAgICAgICAgICAgICB0YWdzICJJdGVtIgogICAgICAgICAgICAgICAgICAgIH0KICAgICAgICAgICAgICAgICAgICB1c2VyUmVnaXN0ZXJlZEV2ZW50U3Vic2NyaWJlciA9IGNvbXBvbmVudCAiVXNlclJlZ2lzdGVyZWRFdmVudFN1YnNjcmliZXIiICJIYW5kbGVzIFVzZXJSZWdpc3RlcmVkRXZlbnQiICJFdmVudFN1YnNjcmliZXIiIHsKICAgICAgICAgICAgICAgICAgICAgICAgdGFncyAiSXRlbSIKICAgICAgICAgICAgICAgICAgICB9CiAgICAgICAgICAgICAgICAgICAgdXNlckNvbmZpcm1lZEV2ZW50U3Vic2NyaWJlciA9IGNvbXBvbmVudCAiVXNlckNvbmZpcm1lZEV2ZW50U3Vic2NyaWJlciIgIkhhbmRsZXMgVXNlckNvbmZpcm1lZEV2ZW50IiAiRXZlbnRTdWJzY3JpYmVyIiB7CiAgICAgICAgICAgICAgICAgICAgICAgIHRhZ3MgIkl0ZW0iCiAgICAgICAgICAgICAgICAgICAgfQogICAgICAgICAgICAgICAgICAgIGNvbmZpcm1hdGlvbkVtYWlsU2VudEV2ZW50U3Vic2NyaWJlciA9IGNvbXBvbmVudCAiQ29uZmlybWF0aW9uRW1haWxTZW50RXZlbnRTdWJzY3JpYmVyIiAiSGFuZGxlcyBDb25maXJtYXRpb25FbWFpbFNlbnRFdmVudCIgIkV2ZW50U3Vic2NyaWJlciIgewogICAgICAgICAgICAgICAgICAgICAgICB0YWdzICJJdGVtIgoKICAgICAgICAgICAgICAgICAgICB9CiAgICAgICAgICAgICAgICAgICAgZW1haWxDaGFuZ2VkRXZlbnRTdWJzY3JpYmVyID0gY29tcG9uZW50ICJFbWFpbENoYW5nZWRFdmVudFN1YnNjcmliZXIiICJIYW5kbGVzIEVtYWlsQ2hhbmdlZEV2ZW50IiAiRXZlbnRTdWJzY3JpYmVyIiB7CiAgICAgICAgICAgICAgICAgICAgICAgIHRhZ3MgIkl0ZW0iCiAgICAgICAgICAgICAgICAgICAgfQogICAgICAgICAgICAgICAgICAgIHBhc3N3b3JkQ2hhbmdlZEV2ZW50U3Vic2NyaWJlciA9IGNvbXBvbmVudCAiUGFzc3dvcmRDaGFuZ2VkRXZlbnRTdWJzY3JpYmVyIiAiSGFuZGxlcyBQYXNzd29yZENoYW5nZWRFdmVudCIgIkV2ZW50U3Vic2NyaWJlciIgewogICAgICAgICAgICAgICAgICAgICAgICB0YWdzICJJdGVtIgogICAgICAgICAgICAgICAgICAgIH0KICAgICAgICAgICAgICAgIH0KCiAgICAgICAgICAgICAgICBncm91cCAiRG9tYWluIiB7CiAgICAgICAgICAgICAgICAgICAgdXNlciA9IGNvbXBvbmVudCAiVXNlciIgIlJlcHJlc2VudHMgdXNlciIgIkVudGl0eSIgewogICAgICAgICAgICAgICAgICAgICAgICB0YWdzICJJdGVtIgogICAgICAgICAgICAgICAgICAgIH0KICAgICAgICAgICAgICAgICAgICB0b2tlbiA9IGNvbXBvbmVudCAiQ29uZmlybWF0aW9uVG9rZW4iICJSZXByZXNlbnRzIGNvbmZpcm1hdGlvbiB0b2tlbiIgIkVudGl0eSIgewogICAgICAgICAgICAgICAgICAgICAgICB0YWdzICJJdGVtIgogICAgICAgICAgICAgICAgICAgIH0KICAgICAgICAgICAgICAgIH0KCiAgICAgICAgICAgICAgICBncm91cCAiSW5mcmFzdHJ1Y3R1cmUiIHsKICAgICAgICAgICAgICAgICAgICB1c2VyUmVwb3NpdG9yeSA9IGNvbXBvbmVudCAiTWFyaWFEQlVzZXJSZXBvc2l0b3J5IiAiTWFuYWdlcyBhY2Nlc3MgdG8gdXNlcnMiICJSZXBvc2l0b3J5IiB7CiAgICAgICAgICAgICAgICAgICAgICAgIHRhZ3MgIkl0ZW0iCiAgICAgICAgICAgICAgICAgICAgfQogICAgICAgICAgICAgICAgICAgIHRva2VuUmVwb3NpdG9yeSA9IGNvbXBvbmVudCAiUmVkaXNUb2tlblJlcG9zaXRvcnkiICJNYW5hZ2VzIGFjY2VzcyB0byBjb25maXJtYXRpb24gdG9rZW5zIiAiUmVwb3NpdG9yeSIgewogICAgICAgICAgICAgICAgICAgICAgICB0YWdzICJJdGVtIgogICAgICAgICAgICAgICAgICAgIH0KICAgICAgICAgICAgICAgICAgICBtYWlsZXIgPSBjb21wb25lbnQgIlN5bWZvbnkgTWFpbGVyIiAiTWFuYWdlcyBzZW5kaW5nIG9mIGVtYWlscyIgewogICAgICAgICAgICAgICAgICAgICAgICB0YWdzICJJdGVtIgogICAgICAgICAgICAgICAgICAgIH0KICAgICAgICAgICAgICAgICAgICBtZXNzZW5nZXIgPSBjb21wb25lbnQgIlN5bWZvbnkgTWVzc2VuZ2VyIiAiTWFuYWdlcyBiYWNrZ3JvdW5kIHRhc2tzIiB7CiAgICAgICAgICAgICAgICAgICAgICAgIHRhZ3MgIkl0ZW0iCiAgICAgICAgICAgICAgICAgICAgfQogICAgICAgICAgICAgICAgfQoKICAgICAgICAgICAgICAgIGRhdGFiYXNlID0gY29tcG9uZW50ICJEYXRhYmFzZSIgIlN0b3JlcyB1c2VyLCBpbmZvcm1hdGlvbiwgaGFzaGVkIGF1dGhlbnRpY2F0aW9uIGNyZWRlbnRpYWxzLCBhY2Nlc3MgcmlnaHRzLCBvYXV0aCBjcmVkZW50aWFscywgZXRjLiIgIk1hcmlhREIiIHsKICAgICAgICAgICAgICAgICAgICB0YWdzICJEYXRhYmFzZSIKICAgICAgICAgICAgICAgIH0KICAgICAgICAgICAgICAgIGNhY2hlID0gY29tcG9uZW50ICJDYWNoZSIgIlN0b3JlcyBjb25maXJtYXRpb24gdG9rZW4sIGRvY3RyaW5lIHF1ZXJ5IGNhY2hlIiAiRWxhc3RpY2FjaGUiIHsKICAgICAgICAgICAgICAgICAgICB0YWdzICJDYWNoZSIKICAgICAgICAgICAgICAgIH0KICAgICAgICAgICAgICAgIHNxcyA9IGNvbXBvbmVudCAiQVdTIFNRUyIgIk1lc3NhZ2UgYnJva2VyIGZvciBzZW5kaW5nIGVtYWlscyIgIkFXUyBTUVMiIHsKICAgICAgICAgICAgICAgICAgICB0YWdzICJNZXNzYWdlQnJva2VyIgogICAgICAgICAgICAgICAgfQoKICAgICAgICAgICAgICAgIHNlcyA9IGNvbXBvbmVudCAiQW1hem9uIFNFUyIgIk9wdGlvbmFsIGNvbmZpZ3VyZWQgZW1haWwgZGVsaXZlcnkgdmlhIHRhc2sgY3JlZGVudGlhbHMiICJTRVMgQVBJIiB7CiAgICAgICAgICAgICAgICAgICAgdGFncyAiSXRlbSIKICAgICAgICAgICAgICAgIH0KCiAgICAgICAgICAgICAgICByZWdpc3RlclVzZXJQcm9jZXNzb3IgLT4gcmVnaXN0ZXJVc2VyQ29tbWFuZEhhbmRsZXIgImRpc3BhdGNoZXMgUmVnaXN0ZXJVc2VyQ29tbWFuZCIKICAgICAgICAgICAgICAgIHJlZ2lzdGVyVXNlclJlc29sdmVyIC0+IHJlZ2lzdGVyVXNlckNvbW1hbmRIYW5kbGVyICJkaXNwYXRjaGVzIFJlZ2lzdGVyVXNlckNvbW1hbmQiCiAgICAgICAgICAgICAgICBjb25maXJtVXNlclByb2Nlc3NvciAtPiBjb25maXJtVXNlckNvbW1hbmRIYW5kbGVyICJkaXNwYXRjaGVzIENvbmZpcm1Vc2VyQ29tbWFuZCIKICAgICAgICAgICAgICAgIGNvbmZpcm1Vc2VyUmVzb2x2ZXIgLT4gY29uZmlybVVzZXJDb21tYW5kSGFuZGxlciAiZGlzcGF0Y2hlcyBDb25maXJtVXNlckNvbW1hbmQiCiAgICAgICAgICAgICAgICBjb25maXJtVXNlckNvbW1hbmRIYW5kbGVyIC0+IHVzZXJDb25maXJtZWRFdmVudFN1YnNjcmliZXIgInB1Ymxpc2hlcyBVc2VyQ29uZmlybWVkRXZlbnQiCiAgICAgICAgICAgICAgICByZWdpc3RlclVzZXJDb21tYW5kSGFuZGxlciAtPiB1c2VyUmVnaXN0ZXJlZEV2ZW50U3Vic2NyaWJlciAicHVibGlzaGVzIFVzZXJSZWdpc3RlcmVkRXZlbnQiCiAgICAgICAgICAgICAgICByZWdpc3RlclVzZXJDb21tYW5kSGFuZGxlciAtPiB1c2VyICJjcmVhdGVzIgogICAgICAgICAgICAgICAgdXBkYXRlVXNlckNvbW1hbmRIYW5kbGVyIC0+IGVtYWlsQ2hhbmdlZEV2ZW50U3Vic2NyaWJlciAicHVibGlzaGVzIEVtYWlsQ2hhbmdlZEV2ZW50IgogICAgICAgICAgICAgICAgdXBkYXRlVXNlckNvbW1hbmRIYW5kbGVyIC0+IHBhc3N3b3JkQ2hhbmdlZEV2ZW50U3Vic2NyaWJlciAicHVibGlzaGVzIFBhc3N3b3JkQ2hhbmdlZEV2ZW50IgogICAgICAgICAgICAgICAgZW1haWxDaGFuZ2VkRXZlbnRTdWJzY3JpYmVyIC0+IHNlbmRDb25maXJtYXRpb25FbWFpbENvbW1hbmRIYW5kbGVyICJkaXNwYXRjaGVzIFNlbmRDb25maXJtYXRpb25FbWFpbENvbW1hbmQiCiAgICAgICAgICAgICAgICB1c2VyUmVnaXN0ZXJlZEV2ZW50U3Vic2NyaWJlciAtPiBzZW5kQ29uZmlybWF0aW9uRW1haWxDb21tYW5kSGFuZGxlciAiZGlzcGF0Y2hlcyBTZW5kQ29uZmlybWF0aW9uRW1haWxDb21tYW5kIgogICAgICAgICAgICAgICAgc2VuZENvbmZpcm1hdGlvbkVtYWlsQ29tbWFuZEhhbmRsZXIgLT4gY29uZmlybWF0aW9uRW1haWxTZW50RXZlbnRTdWJzY3JpYmVyICJwdWJsaXNoZXMgQ29uZmlybWF0aW9uRW1haWxTZW50RXZlbnQiCiAgICAgICAgICAgICAgICBwYXNzd29yZENoYW5nZWRFdmVudFN1YnNjcmliZXIgLT4gbWVzc2VuZ2VyICJhZGRzIGVtYWlsIHRvIHF1ZXVlIgogICAgICAgICAgICAgICAgY29uZmlybWF0aW9uRW1haWxTZW50RXZlbnRTdWJzY3JpYmVyIC0+IG1lc3NlbmdlciAiYWRkcyBlbWFpbCB0byBxdWV1ZSIKICAgICAgICAgICAgICAgIG1lc3NlbmdlciAtPiBtYWlsZXIgImRlbGl2ZXJzIHF1ZXVlZCBlbWFpbHMgdmlhIHRyYW5zcG9ydCIKICAgICAgICAgICAgICAgIHVzZXJQYXRjaFByb2Nlc3NvciAtPiB1cGRhdGVVc2VyQ29tbWFuZEhhbmRsZXIgImRpc3BhdGNoZXMgVXBkYXRlVXNlckNvbW1hbmQiCiAgICAgICAgICAgICAgICB1c2VyUHV0UHJvY2Vzc29yIC0+IHVwZGF0ZVVzZXJDb21tYW5kSGFuZGxlciAiZGlzcGF0Y2hlcyBVcGRhdGVVc2VyQ29tbWFuZCIKICAgICAgICAgICAgICAgIHVwZGF0ZVVzZXJSZXNvbHZlciAtPiB1cGRhdGVVc2VyQ29tbWFuZEhhbmRsZXIgImRpc3BhdGNoZXMgVXBkYXRlVXNlckNvbW1hbmQiCiAgICAgICAgICAgICAgICBjb25maXJtYXRpb25FbWFpbFNlbnRFdmVudFN1YnNjcmliZXIgLT4gdG9rZW4gImNyZWF0ZXMiCiAgICAgICAgICAgICAgICB1c2VyQ29uZmlybWVkRXZlbnRTdWJzY3JpYmVyIC0+IHRva2VuICJkZWxldGVzIgogICAgICAgICAgICAgICAgdXNlclJlcG9zaXRvcnkgLT4gdXNlciAic2F2ZSBhbmQgbG9hZCIKICAgICAgICAgICAgICAgIHRva2VuUmVwb3NpdG9yeSAtPiB0b2tlbiAic2F2ZSBhbmQgbG9hZCIKICAgICAgICAgICAgICAgIHVzZXJSZXBvc2l0b3J5IC0+IGRhdGFiYXNlICJhY2Nlc3NlcyBkYXRhIgogICAgICAgICAgICAgICAgdG9rZW5SZXBvc2l0b3J5IC0+IGNhY2hlICJhY2Nlc3NlcyBkYXRhIgogICAgICAgICAgICAgICAgbWVzc2VuZ2VyIC0+IHNxcyAicHVibGlzaGVzIGFuZCBjb25zdW1lcyBxdWV1ZWQgbWVzc2FnZXMiCiAgICAgICAgICAgICAgICBtYWlsZXIgLT4gc2VzICJzZW5kcyBlbWFpbCB3aGVuIFNFUyBBUEkgdHJhbnNwb3J0IGlzIGNvbmZpZ3VyZWQiICJIVFRQUyBBUEkiCiAgICAgICAgICAgIH0KICAgICAgICB9CiAgICB9CgogICAgdmlld3MgewogICAgICAgIGNvbXBvbmVudCBzb2Z0d2FyZVN5c3RlbS51c2VyU2VydmljZSAiQ29tcG9uZW50c19BbGwiIHsKICAgICAgICAgICAgaW5jbHVkZSAqCiAgICAgICAgfQoKICAgICAgICBzdHlsZXMgewogICAgICAgICAgICBlbGVtZW50ICJJdGVtIiB7CiAgICAgICAgICAgICAgICBjb2xvciB3aGl0ZQogICAgICAgICAgICAgICAgYmFja2dyb3VuZCAjMzRhYmViCiAgICAgICAgICAgIH0KICAgICAgICAgICAgZWxlbWVudCAiRGF0YWJhc2UiIHsKICAgICAgICAgICAgICAgIGNvbG9yIHdoaXRlCiAgICAgICAgICAgICAgICBzaGFwZSBjeWxpbmRlcgogICAgICAgICAgICAgICAgYmFja2dyb3VuZCAjMzRhYmViCiAgICAgICAgICAgIH0KICAgICAgICAgICAgZWxlbWVudCAiQ2FjaGUiIHsKICAgICAgICAgICAgICAgIGNvbG9yIHdoaXRlCiAgICAgICAgICAgICAgICBzaGFwZSBjeWxpbmRlcgogICAgICAgICAgICAgICAgYmFja2dyb3VuZCAjMzRhYmViCiAgICAgICAgICAgIH0KICAgICAgICAgICAgZWxlbWVudCAiTWVzc2FnZUJyb2tlciIgewogICAgICAgICAgICAgICAgY29sb3Igd2hpdGUKICAgICAgICAgICAgICAgIHNoYXBlIHBpcGUKICAgICAgICAgICAgICAgIGJhY2tncm91bmQgIzM0YWJlYgogICAgICAgICAgICB9CiAgICAgICAgfQogICAgfQp9Cg=="
   },
   "views" : {
     "componentViews" : [ {
@@ -579,13 +676,15 @@
         "id" : "27",
         "x" : 1050,
         "y" : 3495
+      }, {
+        "id" : "28",
+        "x" : 335,
+        "y" : 3530
       } ],
       "externalContainerBoundariesVisible" : false,
       "key" : "Components_All",
       "order" : 1,
       "relationships" : [ {
-        "id" : "28"
-      }, {
         "id" : "29"
       }, {
         "id" : "30"
@@ -633,11 +732,16 @@
         "id" : "51"
       }, {
         "id" : "52"
+      }, {
+        "id" : "53"
+      }, {
+        "id" : "54"
       } ]
     } ],
     "configuration" : {
       "branding" : { },
       "lastSavedView" : "Components_All",
+      "metadataSymbols" : "SquareBrackets",
       "styles" : {
         "elements" : [ {
           "background" : "#34abeb",


### PR DESCRIPTION
## Description

Prepare the real production web and worker images for the AWS user-service PoC. Production SQS uses task-role credentials and existing queues; health checks resolve the health queue without mutating it. Add SES API transport support, production Caddy behind the HTTPS load balancer, and supervised workers with process health checks and container logging.

Optional external OAuth providers can be disabled explicitly with SOCIAL_OAUTH_ENABLED=false; existing behavior remains enabled by default. Update required runtime dependencies and matching MongoDB test doubles, and synchronize runtime documentation and the SES/Messenger architecture diagram.

## Related Issue

Part of #116 and [user-service-infrastructure #18](https://github.com/VilnaCRM-Org/user-service-infrastructure/issues/18#issuecomment-5575434850). This runtime prerequisite does not close image publishing or live PoC acceptance.

## Motivation and Context

The planned ECS task identities must supply AWS credentials automatically. The production images also need runnable web/worker targets and an explicit way to omit optional third-party OAuth credentials. OIDC image publishing, release manifests and workload deployment remain subsequent work under the existing plan.

## How Has This Been Tested?

- Full make ci passed in an isolated supported-kernel Docker guest: 2,486 unit tests, 130 integration tests, 645 Behat scenarios, schema/API checks, and 4,972/4,972 killed mutations (100% MSI).
- Actual make ai-review-loop with Codex passed after CI; the reviewed source stayed unchanged. Documentation-only diagram synchronization was independently rendered and saved in Structurizr.
- Compiled production OAuth container checks covered explicit false, true and default behavior; production runtime/queue/worker configuration tests passed.
- PR-range Gitleaks scan passed.
- All 153 Bats cases have passing per-case evidence across the original run and targeted recovery after fixing guest-only gh/Node dependencies. The original interrupted run is not claimed to have exited successfully.
- make smoke-load-tests passed all 50 scenarios; frozen guest runtime source remained unchanged.
- Hosted GraphQL comparison is blocked by an existing action/runtime and base-ref defect addressed in #493. Other hosted checks and external review must complete before merge; live AWS acceptance remains pending.

## Types of changes

- [x] Bug fix
- [x] New feature
- [ ] Breaking change

## Checklist

- [x] Project code style and self-review completed.
- [x] Runtime documentation and Structurizr diagram updated.
- [x] Tests added for the changed behavior.
- [x] One focused commit.
- [ ] All remaining local and hosted acceptance checks complete.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Amazon SES support for email delivery, including API and SMTP configuration examples.
  * Added a `SOCIAL_OAUTH_ENABLED` setting to enable or disable social sign-in.
  * Added production worker health checks and improved container/runtime configuration.
  * Health checks now verify existing queues without creating infrastructure.

* **Bug Fixes**
  * Updated API documentation so pagination links may be unavailable (`null`).

* **Documentation**
  * Expanded guidance for social sign-in, SES email delivery, AWS credentials, SQS, and production deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->